### PR TITLE
Allow scanning to be done on on-prem GitLab

### DIFF
--- a/golc.go
+++ b/golc.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -353,12 +354,17 @@ func analyseGithubRepo(project interface{}, DestinationResult string, platformCo
 // Analysis functions for GitLab
 func analyseGitlabRepo(project interface{}, DestinationResult string, platformConfig map[string]interface{}, spin *spinner.Spinner, results chan int, count *int) {
 	p := project.(getgitlab.ProjectBranch)
+	var baseUrl = "gitlab.com"
+	platformUrl, err := url.Parse(platformConfig["Url"].(string))
+	if err == nil {
+		baseUrl = platformUrl.Host
+	}
 	params := RepoParams{
 		ProjectKey: p.Org,
 		Namespace:  p.Namespace,
 		RepoSlug:   p.RepoSlug,
 		MainBranch: p.MainBranch,
-		PathToScan: fmt.Sprintf("%s://gitlab-ci-token:%s@%s/%s.git", platformConfig["Protocol"].(string), platformConfig["AccessToken"].(string), "gitlab.com", p.Namespace),
+		PathToScan: fmt.Sprintf("%s://gitlab-ci-token:%s@%s/%s.git", platformConfig["Protocol"].(string), platformConfig["AccessToken"].(string), baseUrl, p.Namespace),
 	}
 	performRepoAnalysis(params, DestinationResult, spin, results, count)
 }


### PR DESCRIPTION
Make some slight adjustments to allow on Prem GitLab scanning by just detecting the URL in the config.json file.

My Test setup:
- Gitlab - 17.1-ce, arm64

Before the update:
![Screenshot 2024-07-17 at 3 57 25 PM](https://github.com/user-attachments/assets/98dadda1-31f6-4625-a0bd-5fc2a1d44889)

After the update:
![Screenshot 2024-07-17 at 4 00 27 PM](https://github.com/user-attachments/assets/bc88b1e1-2a72-4bd8-8fba-2834d7bb788b)
