### PR TITLE
Bump sonarqube-scan-action from v5 to v7 and improving GH Action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,7 +3,7 @@ name: Go Build, SonarQube Analysis
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch: # Allows manual triggers


### PR DESCRIPTION
#### Improvements on `go.yml` to:
- [x] Remove ⚠️ Warning:
> Warning: This version of the SonarQube Scanner GitHub Action is no longer supported and contains a security vulnerability. Please update your workflow to use sonarsource/sonarqube-scan-action@v6 for the latest security patches and features. For more information visit https://community.sonarsource.com/gha-v6-update
from [here](https://github.com/SonarSource-Demos/sonar-golc/actions/runs/20748382064/job/59592610884?pr=26).
- [x] Added `-trimpath` to make action's build paths relative
- [x] Changed scope of Action from ``**`` to `main`, to avoid duplicated analysis of the same code and improve performance
