### PR TITLE
Fix ResultsAll for BitBucket

### DIFF
--- a/ResultsAll.go
+++ b/ResultsAll.go
@@ -334,7 +334,8 @@ func getFirstPartForFilename(platform, orgName, repoName string) string {
 		_, analysisFile, err := detectPlatformAndReadAnalysis()
 		if err == nil {
 			var analysisResult AnalysisResult
-			if err := json.Unmarshal(analysisFile, &analysisResult); err == nil {
+			err = json.Unmarshal(analysisFile, &analysisResult)
+			if err == nil {
 				// Find the repository and get its ProjectKey
 				for _, branch := range analysisResult.ProjectBranches {
 					if branch.RepoSlug == repoName {


### PR DESCRIPTION
This pull request fixes the issue #27 
It updates the logic for determining the correct identifier (either `ProjectKey` or `Org`) used in file naming and branch data handling for different repository platforms, with special attention to Bitbucket and Bitbucket Data Center. The changes ensure that Bitbucket uses `ProjectKey` where appropriate, improving consistency and correctness across functions that generate or parse filenames and branch data.

Platform-specific filename and identifier logic:

* Updated `getFirstPartForPlatform` to use `ProjectKey` for Bitbucket and Bitbucket Data Center, falling back to `Org` if `ProjectKey` is not available; GitHub, GitLab, and file platforms continue to use `Org`.
* Modified `getFirstPartForFilename` to look up and use `ProjectKey` for Bitbucket and Bitbucket Data Center by reading from analysis results, with a fallback to `orgName` if the lookup fails; other platforms are unchanged.

Filename and branch data handling improvements:

* Changed `getOtherBranchesData` to use the correct `firstPart` (now `ProjectKey` for Bitbucket, `Org` for others) when parsing filenames, ensuring more robust and accurate branch name extraction.
* In `getRepositoryDetailData`, stored a reference to the found branch for later use, enabling more precise platform-specific logic.
* Updated `getRepositoryDetailData` to use `getFirstPartForPlatform` with the branch object for Bitbucket, ensuring the correct identifier is used in report filenames; falls back to the original method if the branch is not found.