### PR TITLE
Excluding JSON from totals of reports (ResultsAll and .pdfs)

### DIFF
--- a/golc.go
+++ b/golc.go
@@ -1298,7 +1298,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Initialize the sum of TotalCodeLines
+	// Initialize the sum of TotalCodeLines (excluding JSON to match SonarQube behavior)
 	totalCodeLinesSum := 0
 
 	// Analyse All file
@@ -1321,11 +1321,21 @@ func main() {
 				continue
 			}
 
-			totalCodeLinesSum += result.TotalCodeLines
+			// Exclude JSON LOC from total to match SonarQube standard behavior
+			jsonLOC := 0
+			for _, r := range result.Results {
+				if strings.TrimSpace(r.Language) == utils.LanguageExcludedFromTotalLOC {
+					jsonLOC += r.CodeLines
+					break
+				}
+			}
+			codeLinesForTotal := result.TotalCodeLines - jsonLOC
 
-			// Check if this repo has a higher TotalCodeLines than the current maximum
-			if result.TotalCodeLines > maxTotalCodeLines {
-				maxTotalCodeLines = result.TotalCodeLines
+			totalCodeLinesSum += codeLinesForTotal
+
+			// Check if this repo has a higher TotalCodeLines (excl. JSON) than the current maximum
+			if codeLinesForTotal > maxTotalCodeLines {
+				maxTotalCodeLines = codeLinesForTotal
 				// Extract project and repo name from file name
 				parts := strings.Split(strings.TrimSuffix(file.Name(), ".json"), "_")
 				if platformConfig["DevOps"].(string) != "file" {

--- a/pkg/reporter/pdf/pdf_reporter.go
+++ b/pkg/reporter/pdf/pdf_reporter.go
@@ -154,6 +154,18 @@ func (p PdfReporter) writePdf(pdfReport *report) error {
 	pdf.Cell(0, 10, Title2)
 	pdf.Ln(10)
 
+	// Total Code Lines excluding JSON (SonarQube standard behavior)
+	totalCodeLinesForReport := pdfReport.TotalCodeLines
+	if fileResults, ok := pdfReport.Results.([]fileResult); ok {
+		jsonCodeLines := 0
+		for _, r := range fileResults {
+			if strings.HasSuffix(strings.ToLower(r.File), ".json") {
+				jsonCodeLines += r.CodeLines
+			}
+		}
+		totalCodeLinesForReport = pdfReport.TotalCodeLines - jsonCodeLines
+	}
+
 	//Global statistics
 	pdf.SetFont("Times", "", 10)
 	pdf.Cell(0, 10, "Total Lines: "+strconv.Itoa(pdfReport.TotalLines))
@@ -162,7 +174,10 @@ func (p PdfReporter) writePdf(pdfReport *report) error {
 	pdf.Ln(5)
 	pdf.Cell(0, 10, "Total Comments: "+strconv.Itoa(pdfReport.TotalComments))
 	pdf.Ln(5)
-	pdf.Cell(0, 10, "Total Code Lines: "+strconv.Itoa(pdfReport.TotalCodeLines))
+	pdf.Cell(0, 10, "Total Code Lines: "+strconv.Itoa(totalCodeLinesForReport))
+	pdf.Ln(5)
+	pdf.SetFont("Times", "", 8)
+	pdf.Cell(0, 8, "Note: "+utils.NoteExcludedFromTotal)
 	pdf.Ln(10)
 
 	// Table Headers

--- a/pkg/utils/loc_exclusion.go
+++ b/pkg/utils/loc_exclusion.go
@@ -1,0 +1,8 @@
+package utils
+
+// LanguageExcludedFromTotalLOC is the language name whose lines of code are
+// excluded from report totals to match SonarQube standard behavior.
+const LanguageExcludedFromTotalLOC = "JSON"
+
+// NoteExcludedFromTotal is the note shown in reports when JSON is excluded from total LOC.
+const NoteExcludedFromTotal = "JSON is excluded from the total to reproduce standard SonarQube behavior."


### PR DESCRIPTION
This pull request implements a consistent approach across the codebase to exclude JSON lines of code (LOC) from total code line counts and percentage calculations, aligning the reports with standard SonarQube behavior (Issue #36) . It introduces a central utility for this logic, updates data structures and report generation, and improves both HTML and PDF outputs to clearly communicate this exclusion to users.

**Key changes include:**

### Core logic and utilities

* Added `LanguageExcludedFromTotalLOC` and `NoteExcludedFromTotal` constants in `pkg/utils/loc_exclusion.go` to centralize the logic and messaging for excluding JSON LOC from totals.
* Introduced `getTotalCodeLinesExcludingJSON` in `pkg/utils/globalreport.go` to sum code lines for all languages except JSON, used for totals and percentage calculations.

### Data processing and calculations

* Modified repository and global data aggregation functions (`ResultsAll.go`, `pkg/utils/repository_summary.go`, `golc.go`) to exclude JSON LOC from totals and percentages, including in per-repo and global summaries. [[1]](diffhunk://#diff-50d6dde346fbf0711a5df7ea2f3afd75a33e03f084db887d9966ad655a4cf794L249-R287) [[2]](diffhunk://#diff-50d6dde346fbf0711a5df7ea2f3afd75a33e03f084db887d9966ad655a4cf794R619-R627) [[3]](diffhunk://#diff-50d6dde346fbf0711a5df7ea2f3afd75a33e03f084db887d9966ad655a4cf794L603-R649) [[4]](diffhunk://#diff-50d6dde346fbf0711a5df7ea2f3afd75a33e03f084db887d9966ad655a4cf794R753-R774) [[5]](diffhunk://#diff-50d6dde346fbf0711a5df7ea2f3afd75a33e03f084db887d9966ad655a4cf794R798) [[6]](diffhunk://#diff-03147ed6af67b06aec6d2475fd19c0bc3d4b265c1e792aeadc71d4a468f1f489L1301-R1301) [[7]](diffhunk://#diff-03147ed6af67b06aec6d2475fd19c0bc3d4b265c1e792aeadc71d4a468f1f489L1324-R1338) [[8]](diffhunk://#diff-6b9f854c5fca8ea66e634d08d52cda8adfe70f1d30da4681d9c789da6dba04e6L171-R205) [[9]](diffhunk://#diff-9826ec0832b395d07d6d6cd0cfe56fc743a6ac332763e0ac0543d22b1207a165L235-R262)

### Report and template updates

* Updated HTML templates to display a note about JSON exclusion and to mark JSON entries as excluded in language lists. [[1]](diffhunk://#diff-50d6dde346fbf0711a5df7ea2f3afd75a33e03f084db887d9966ad655a4cf794R1125) [[2]](diffhunk://#diff-50d6dde346fbf0711a5df7ea2f3afd75a33e03f084db887d9966ad655a4cf794R1138-R1143) [[3]](diffhunk://#diff-50d6dde346fbf0711a5df7ea2f3afd75a33e03f084db887d9966ad655a4cf794R1613)
* Updated PDF generation (both global and per-repository) to show totals excluding JSON, mark JSON as excluded, and add an explanatory note. [[1]](diffhunk://#diff-edf4e78d78cbccf5dc999b403a74fb6a153fc16e75c7f974990e3661b98a88eaR157-R168) [[2]](diffhunk://#diff-edf4e78d78cbccf5dc999b403a74fb6a153fc16e75c7f974990e3661b98a88eaL165-R180) [[3]](diffhunk://#diff-9826ec0832b395d07d6d6cd0cfe56fc743a6ac332763e0ac0543d22b1207a165R222-R223) [[4]](diffhunk://#diff-6b9f854c5fca8ea66e634d08d52cda8adfe70f1d30da4681d9c789da6dba04e6R386)

### Data structure enhancements

* Added `NoteLOCExcluded` fields to `RepositoryDetailData` and `PageData` structs to propagate the explanatory note to report outputs. [[1]](diffhunk://#diff-50d6dde346fbf0711a5df7ea2f3afd75a33e03f084db887d9966ad655a4cf794R153-R160) [[2]](diffhunk://#diff-50d6dde346fbf0711a5df7ea2f3afd75a33e03f084db887d9966ad655a4cf794R798) [[3]](diffhunk://#diff-50d6dde346fbf0711a5df7ea2f3afd75a33e03f084db887d9966ad655a4cf794L603-R649)

These updates ensure all reports and summaries accurately reflect the intended LOC calculation, provide user-facing transparency, and maintain alignment with SonarQube standards.