### PR TITLE
Investigation: Windows local mode path handling fixes

### DIFF
--- a/docs/WINDOWS_INVESTIGATION.md
+++ b/docs/WINDOWS_INVESTIGATION.md
@@ -1,0 +1,69 @@
+# Investigation: Windows local mode path handling failure
+
+## Symptom
+
+On Windows, local mode analysis was reported as "not willing to follow either relative or absolute path". The same configuration worked on Linux/macOS.
+
+## Root causes
+
+### 1. Case-sensitive path comparison
+
+In `buildGitignoreFunc` (pkg/goloc) and in the analyzer's `canAdd` (pkg/analyzer), paths were compared with `strings.HasPrefix` and `strings.TrimPrefix`. On Windows the filesystem is case-insensitive (`C:\Repo` and `c:\repo` are the same), but Go string comparison is case-sensitive. So:
+
+- `findGitRoot` could return `C:\repo` (from `filepath.Abs`),
+- while `filepath.Walk` could pass `c:\repo\src\file.go`,
+- and `strings.HasPrefix("c:\repo\...", "C:\repo")` is **false**, so the path was treated as outside the repo and .gitignore / exclusion logic broke.
+
+### 2. Relative vs absolute in the ignore callback
+
+The callback passed to the analyzer receives the same path style as the walk root. If the root was relative (e.g. `.\myproject`), paths in the callback could be relative while `repoRoot` from `findGitRoot` was absolute (it uses `filepath.Abs`). Comparing relative and absolute strings then failed.
+
+### 3. Exclude-path prefix check in the analyzer
+
+In `canAdd`, `strings.HasPrefix(path, pathToExclude)` was used. Again, case and slash differences on Windows could make exclusions not apply even when the file was under the excluded directory.
+
+### 4. Local path not resolved before the getter
+
+Relative paths (e.g. from config) were passed to the getter as-is. On Windows, resolving them to absolute form first makes behaviour consistent and avoids "path not followed" issues.
+
+### 5. Getter and Windows drive paths
+
+For a path like `C:\repo`, the hashicorp go-getter might not always treat it as a local path. Converting such paths to a `file:///` URL on Windows makes the getter reliably accept them.
+
+## Fixes applied
+
+### pkg/goloc/goloc.go
+
+- **`pathUnderRoot`**  
+  New helper that resolves both paths to absolute, normalizes with `filepath.Clean` and `filepath.ToSlash`, and on Windows compares case-insensitively (lowercasing normalized paths). Used by `buildGitignoreFunc` so .gitignore matching works for any path casing and relative/absolute mix on Windows.
+
+- **`buildGitignoreFunc`**  
+  Now uses `pathUnderRoot` instead of raw `HasPrefix`/`TrimPrefix`.
+
+- **`getRepoPath`**  
+  For local mode (no branch), resolves `params.Path` with `filepath.Abs` before calling the getter so the getter and downstream code see a single, absolute path form.
+
+### pkg/analyzer/analyzer.go
+
+- **`pathHasPrefix`**  
+  New helper that normalizes both sides with `filepath.Clean` and `filepath.ToSlash`, and on Windows uses case-insensitive comparison before checking the prefix and the trailing `/`.
+
+- **`canAdd`**  
+  Uses `pathHasPrefix(path, pathToExclude)` instead of `strings.HasPrefix(path, pathToExclude)` so excluded directories are detected correctly on Windows regardless of case or slash style.
+
+### pkg/getter/getter.go
+
+- **`toFileURL`**  
+  On Windows, converts an absolute path like `C:\repo` to `file:///C:/repo`.
+
+- **`Getter`**  
+  On Windows, when `src` looks like a local drive path (e.g. `X:\...`) and is not already a `file://` URL, it is converted with `toFileURL` before calling the getter client so the getter consistently accepts local paths.
+
+## Testing
+
+- All existing tests in `pkg/goloc` (including `TestBuildGitignoreFunc_*` and `TestFindGitRoot*`) pass.
+- Project builds successfully with `go build ./...`.
+
+## Result
+
+Local analysis should now correctly follow both relative and absolute paths on Windows and respect .gitignore and exclusions regardless of path casing.

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"io/fs"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -94,9 +95,28 @@ func (a *Analyzer) getFileExtension(path string) string {
 	return extension
 }
 
+// pathHasPrefix reports whether path is under prefix (path equals prefix or is a descendant).
+// On Windows, comparison is case-insensitive. Paths are normalized so that relative/absolute
+// and different separators do not break exclusion (e.g. config with forward slashes on Windows).
+func pathHasPrefix(path, prefix string) bool {
+	normPath := filepath.ToSlash(filepath.Clean(path))
+	normPrefix := filepath.ToSlash(filepath.Clean(prefix))
+	if runtime.GOOS == "windows" {
+		normPath = strings.ToLower(normPath)
+		normPrefix = strings.ToLower(normPrefix)
+	}
+	if !strings.HasPrefix(normPath, normPrefix) {
+		return false
+	}
+	if len(normPath) == len(normPrefix) {
+		return true
+	}
+	return normPath[len(normPrefix)] == '/'
+}
+
 func (a *Analyzer) canAdd(path string, extension string) bool {
 	for _, pathToExclude := range a.excludePaths {
-		if strings.HasPrefix(path, pathToExclude) {
+		if pathHasPrefix(path, pathToExclude) {
 			return false
 		}
 	}

--- a/pkg/getter/getter.go
+++ b/pkg/getter/getter.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -19,7 +21,26 @@ func extractLastString(url string) string {
 	return filepath.Base(url)
 }
 
+// toFileURL converts an absolute local path to a file:// URL so that go-getter
+// reliably recognizes it on all platforms. On Windows, paths like C:\repo are
+// converted to file:///C:/repo.
+func toFileURL(absPath string) string {
+	if runtime.GOOS != "windows" {
+		return absPath
+	}
+	// Windows: file:///C:/path or file:///C:/ (drive root)
+	slash := filepath.ToSlash(absPath)
+	if len(slash) >= 2 && slash[1] == ':' {
+		return "file:///" + slash
+	}
+	return absPath
+}
+
 func Getter(src string) (string, error) {
+	// On Windows, pass local absolute paths as file:// URLs so the getter accepts them.
+	if runtime.GOOS == "windows" && len(src) >= 2 && src[1] == ':' && !strings.HasPrefix(src, "file://") {
+		src = toFileURL(src)
+	}
 	RepoString := extractLastString(src)
 
 	spinner := newSpinner(fmt.Sprintf("\r Extracting files from %s \n", RepoString))

--- a/pkg/goloc/goloc.go
+++ b/pkg/goloc/goloc.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/SonarSource-Demos/sonar-golc/pkg/analyzer"
@@ -213,7 +214,13 @@ func getRepoPath(params Params) (string, error) {
 	if len(params.Branch) != 0 {
 		return gogit.Getrepos(params.Path, params.Branch, params.Token)
 	}
-	return getter.Getter(params.Path)
+	// Resolve to absolute path so local directories work on Windows (relative and absolute
+	// paths are handled consistently by the getter and downstream path comparison).
+	absPath, err := filepath.Abs(params.Path)
+	if err != nil {
+		return "", err
+	}
+	return getter.Getter(absPath)
 }
 
 // findGitRoot returns the repository root directory (containing .git) for the given path,
@@ -240,8 +247,41 @@ func findGitRoot(path string) string {
 	}
 }
 
+// pathUnderRoot reports whether path is under root (path equals root or is a descendant).
+// On Windows, comparison is case-insensitive. Paths are normalized (absolute, clean, slash form).
+func pathUnderRoot(path, root string) (under bool, rel string) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false, ""
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false, ""
+	}
+	normPath := filepath.ToSlash(filepath.Clean(absPath))
+	normRoot := filepath.ToSlash(filepath.Clean(absRoot))
+	if runtime.GOOS == "windows" {
+		normPath = strings.ToLower(normPath)
+		normRoot = strings.ToLower(normRoot)
+	}
+	if normRoot != "" && normRoot[len(normRoot)-1] == '/' {
+		normRoot = strings.TrimSuffix(normRoot, "/")
+	}
+	if !strings.HasPrefix(normPath, normRoot) {
+		return false, ""
+	}
+	if len(normPath) > len(normRoot) && normPath[len(normRoot)] != '/' {
+		return false, ""
+	}
+	rel = strings.TrimPrefix(normPath, normRoot)
+	rel = strings.TrimPrefix(rel, "/")
+	return true, rel
+}
+
 // buildGitignoreFunc returns an IgnoreFunc that skips paths matching the repo's .gitignore,
 // or nil if path is not in a git repo or the matcher cannot be built.
+// Path comparison is cross-platform: paths are normalized to absolute form and on Windows
+// comparison is case-insensitive so that local analysis works with any path casing.
 func buildGitignoreFunc(scanPath string) analyzer.IgnoreFunc {
 	repoRoot := findGitRoot(scanPath)
 	if repoRoot == "" {
@@ -252,21 +292,8 @@ func buildGitignoreFunc(scanPath string) analyzer.IgnoreFunc {
 		return nil
 	}
 	return func(absolutePath string, isDir bool) bool {
-		clean := filepath.Clean(absolutePath)
-		if !strings.HasPrefix(clean, repoRoot) {
-			return false
-		}
-		// Ensure path is exactly repoRoot or has a path separator immediately after the prefix,
-		// so that "/home/user/proj" does not match "/home/user/project/file.go" (would yield "ect/file.go").
-		if len(clean) > len(repoRoot) {
-			next := clean[len(repoRoot)]
-			if next != filepath.Separator && next != '/' {
-				return false
-			}
-		}
-		rel := strings.TrimPrefix(clean, repoRoot)
-		rel = strings.TrimPrefix(filepath.ToSlash(rel), "/")
-		if rel == "" {
+		under, rel := pathUnderRoot(absolutePath, repoRoot)
+		if !under || rel == "" {
 			return false
 		}
 		return m.MatchPath(rel, isDir)


### PR DESCRIPTION
## Symptom
On Windows, local mode analysis was reported as "not willing to follow either relative or absolute path". The same configuration worked on Linux/macOS.

## Root causes

1. **Case-sensitive path comparison** — buildGitignoreFunc and canAdd used strings.HasPrefix/TrimPrefix; Windows paths can differ by case (C:\Repo vs c:\repo).

2. **Relative vs absolute** — ignore callback could receive relative paths while repoRoot was absolute, so prefix comparison failed.

3. **Exclude-path prefix** — canAdd used HasPrefix; case/slash differences on Windows broke exclusion.

4. **Local path not resolved** — relative paths were passed to the getter as-is.

5. **Getter and drive paths** — C:\repo might not be recognized as local; converting to file:/// URL on Windows fixes getter acceptance.

## Fixes applied

- **pkg/goloc**: pathUnderRoot (normalize + case-insensitive on Windows), buildGitignoreFunc uses it; getRepoPath resolves to absolute before getter.

- **pkg/analyzer**: pathHasPrefix (normalize + case-insensitive on Windows), canAdd uses it for exclude checks.

- **pkg/getter**: toFileURL for Windows; Getter converts local drive paths to file:/// URLs so go-getter accepts them.

See docs/WINDOWS_INVESTIGATION.md for full details.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 3e862e0cafe3a09e859d666cf51f166e12172652. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->