### PR TITLE
fix: use local path directly for directory analysis (skip getter when…

### DIFF
--- a/golc.go
+++ b/golc.go
@@ -573,6 +573,7 @@ func performRepoAnalysis(params RepoParams, DestinationResult string, spin *spin
 			golocParams.ByFile = false
 			golocParams.Cloned = true
 			golocParams.Repopath = gc.Repopath
+			golocParams.RepopathDisposable = gc.RepopathDisposable
 
 			gc, err = goloc.NewGCloc(golocParams, assets.Languages)
 			if err != nil {
@@ -601,10 +602,12 @@ func performRepoAnalysis(params RepoParams, DestinationResult string, spin *spin
 			}
 		}
 
-		// Remove Repository Directory
-		err1 := os.RemoveAll(gc.Repopath)
-		if err1 != nil {
-			logger.Errorf(errorMessageDi, err1)
+		// Remove repository directory only if it is a temp clone, not the user's source directory
+		if gc.RepopathDisposable && gc.Repopath != "" {
+			err1 := os.RemoveAll(gc.Repopath)
+			if err1 != nil {
+				logger.Errorf(errorMessageDi, err1)
+			}
 		}
 		golocParams.Cloned = false
 		spin.Stop()
@@ -744,6 +747,7 @@ func AnalyseReposListFile(Listdirectorie, fileexclusionEX []string, extexclusion
 
 					params.Cloned = false
 					params.Repopath = gc.Repopath
+					params.RepopathDisposable = gc.RepopathDisposable
 
 					gc, err = goloc.NewGCloc(params, assets.Languages)
 					if err != nil {
@@ -828,11 +832,13 @@ func AnalyseRepo(DestinationResult string, Users string, AccessToken string, Dev
 	gc.Run()
 	cpt++
 
-	// Remove Repository Directory
-	err1 := os.RemoveAll(gc.Repopath)
-	if err != nil {
-		fmt.Printf(errorMessageDi, err1)
-		return
+	// Remove repository directory only if it is a temp clone, not the user's source directory
+	if gc.RepopathDisposable && gc.Repopath != "" {
+		err1 := os.RemoveAll(gc.Repopath)
+		if err1 != nil {
+			fmt.Printf(errorMessageDi, err1)
+			return
+		}
 	}
 
 	return cpt

--- a/pkg/goloc/goloc.go
+++ b/pkg/goloc/goloc.go
@@ -41,15 +41,17 @@ type Params struct {
 	Token             string
 	Cloned            bool
 	Repopath          string
+	RepopathDisposable bool // if true, Repopath is a temp clone safe to delete; if false, it is the user's directory and must not be removed
 }
 
 type GCloc struct {
-	Params    Params
-	analyzer  *analyzer.Analyzer
-	scanner   *scanner.Scanner
-	sorter    sorter.Sorter
-	reporters []reporter.Reporter
-	Repopath  string
+	Params              Params
+	analyzer            *analyzer.Analyzer
+	scanner             *scanner.Scanner
+	sorter              sorter.Sorter
+	reporters           []reporter.Reporter
+	Repopath            string
+	RepopathDisposable  bool // if true, Repopath is safe to delete (temp clone); if false, do not remove (user's directory)
 }
 
 /* func NewGCloc(params Params, languages language.Languages) (*GCloc, error) {
@@ -142,7 +144,7 @@ type GCloc struct {
 }*/
 
 func NewGCloc(params Params, languages language.Languages) (*GCloc, error) {
-	path, err := getRepoPath(params)
+	path, disposable, err := getRepoPath(params)
 	if err != nil {
 		return nil, err
 	}
@@ -163,39 +165,47 @@ func NewGCloc(params Params, languages language.Languages) (*GCloc, error) {
 	analyzer, scanner, reporters := initAnalyzerScannerReporters(path, params, excludePaths, languages)
 
 	params.Cloned = true
+	params.Repopath = path
+	params.RepopathDisposable = disposable
 
 	return &GCloc{
-		Params:    params,
-		analyzer:  analyzer,
-		scanner:   scanner,
-		sorter:    getSorter(params.ByFile, params.Order),
-		reporters: reporters,
-		Repopath:  path,
+		Params:             params,
+		analyzer:           analyzer,
+		scanner:            scanner,
+		sorter:             getSorter(params.ByFile, params.Order),
+		reporters:          reporters,
+		Repopath:           path,
+		RepopathDisposable: disposable,
 	}, nil
 }
 
-func getRepoPath(params Params) (string, error) {
+// getRepoPath returns the path to analyze and whether that path is disposable (safe to delete).
+// When disposable is true, the path is a temp clone from getter/gogit; when false, it is the user's directory.
+func getRepoPath(params Params) (path string, disposable bool, err error) {
 	if params.Cloned {
-		return params.Repopath, nil
+		return params.Repopath, params.RepopathDisposable, nil
 	}
 
 	if len(params.Branch) != 0 {
-		return gogit.Getrepos(params.Path, params.Branch, params.Token)
+		p, e := gogit.Getrepos(params.Path, params.Branch, params.Token)
+		return p, true, e
 	}
 	// Use local path directly when it is an existing directory (Directory / file analysis).
 	// The getter copies to temp, which can yield 0 files on some systems (e.g. Windows) or when
 	// the copy is a symlink and we then apply the wrong .gitignore; using the path as-is fixes that.
 	absPath, err := filepath.Abs(params.Path)
 	if err != nil {
-		return getter.Getter(params.Path)
+		p, e := getter.Getter(params.Path)
+		return p, true, e
 	}
 	// Normalize for trailing slash / "." so Stat works (e.g. "repo/." -> "repo")
 	absPath = filepath.Clean(absPath)
 	info, err := os.Stat(absPath)
 	if err == nil && info.IsDir() {
-		return absPath, nil
+		return absPath, false, nil
 	}
-	return getter.Getter(params.Path)
+	p, e := getter.Getter(params.Path)
+	return p, true, e
 }
 
 func initAnalyzerScannerReporters(path string, params Params, excludePaths []string, languages language.Languages) (*analyzer.Analyzer, *scanner.Scanner, []reporter.Reporter) {


### PR DESCRIPTION
… path exists)

- getRepoPath now returns absolute path when Path is an existing directory
- avoids getter temp copy which yielded 0 files on Windows
- reverted gitignore temp-extract workaround (root cause was getter)

Made-with: Cursor


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core repo-path resolution and cleanup behavior, which could affect what gets analyzed and whether temp directories are removed. Risk is mitigated by explicitly tracking whether a path is disposable before calling `RemoveAll`.
> 
> **Overview**
> Fixes directory/file analysis to **prefer analyzing an existing local directory in-place** (via an absolute, cleaned path) instead of routing through `getter` temp copies, addressing cases where temp extraction could yield *0 files* (notably on Windows).
> 
> Introduces a `RepopathDisposable` flag that is propagated across `NewGCloc` runs and used by callers to **only delete the analysis directory when it is a temp clone**, preventing accidental removal of a user-provided source directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70f8d8e0136fbae031967b0ade7130ac63b00b3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->