### PR TITLE
Update languages.go

### DIFF
--- a/assets/languages.go
+++ b/assets/languages.go
@@ -79,7 +79,7 @@ var Languages = language.Languages{
 		Extensions:        []string{".html", ".htm", ".cshtml", ".vbhtml", ".aspx", ".ascx", ".rhtml", ".erb", ".shtml", ".shtm", ".cmp"},
 	},
 	"JCL": {
-		LineComments:      []string{"*", "//*"},
+		LineComments:      []string{"//*"},
 		MultiLineComments: [][]string{},
 		Extensions:        []string{".jcl", ".JCL", ".jjob", ".job"},
 	},


### PR DESCRIPTION
This pull request makes a minor update to the language definitions by adjusting the comment syntax for JCL files. Specifically, it removes the asterisk (`*`) as a recognized line comment for JCL, leaving only the double slash and asterisk (`//*`) as valid.

- JCL language definition: Removed `*` from the list of line comment prefixes, so only `//*` is now recognized as a line comment in JCL files.Implemented fix based on previous reviews

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 685dab454c2789ee9fbef57785ace703b799c6a0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->