### PR TITLE
hotfix: Windows path handling, configurable logging, and report robus…

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ To exclude directories from your repository from the analysis, initialize the va
 ```
 ❗️ The '**Projects**' entry is supported exclusively on the BitBucket and AzureDevops platform.
 
+❗️ **Log level.** You can control output verbosity for troubleshooting. In **config.json**, set `"Logging": { "Level": "info" }` to one of `trace`, `debug`, `info`, `warn`, or `error` (default is `info`). From the command line, use **`-log-level=<level>`** to override the config (e.g. `-log-level=debug`), or **`-verbose`** / **`-v`** to set the level to debug. Use `debug` or `trace` for file-level and report-level troubleshooting (files found, excluded, scanned; reports created with metrics).
+
  ## Run GoLC
 
  To launch GoLC with the following command, you must specify your DevOps platform. In this example, we analyze repositories hosted on Bitbucket Cloud. The supported flags for -devops are :
@@ -334,6 +336,8 @@ To exclude directories from your repository from the analysis, initialize the va
 flag : <BitBucketSRV>||<BitBucket>||<Github>||<GithubEnterprise>||<Gitlab>||<Azure>||<File>
 
  ```
+ You can fine-tune log output with **`-log-level=debug`** (or `trace`, `info`, `warn`, `error`) or **`-verbose`** / **`-v`** for debug-level logging. Run **`golc -help`** to see all flags.
+
  ❗️ GoLC runs on Windows, Linux, and OSX, but the preferred platforms are OSX or Linux.
 
 ```bash

--- a/create_release_sample.sh
+++ b/create_release_sample.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
-export TAG="V1.0.9" # Release TAG in GitHub
-export Release1="v1.0.9" # Release Number
+export TAG="XXXXXX" # Release TAG in GitHub
+export Release1="XXXXXX" # Release Number
 export buildpath="XXXXXXX"  # Replace with the path where the release files are located
 
-GITHUB_TOKEN="XXXXXXXXX" # Replace with your token
+# Use GITHUB_TOKEN from environment (set before running: export GITHUB_TOKEN=ghp_...)
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "Error: GITHUB_TOKEN is not set. Set it with: export GITHUB_TOKEN=your_token"
+  exit 1
+fi
 GITHUB_ORG="SonarSource-Demos"    # Replace with your organization name
 GITHUB_REPO="sonar-golc"   # Replace with the name of your GitHub repository
 
@@ -23,7 +27,7 @@ create_release() {
   local body="$3"
 
   echo "Création d'une nouvelle release avec le tag '$tag'..."
-  curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+  curl -s -L -X POST -H "Authorization: token $GITHUB_TOKEN" \
     -H "Content-Type: application/json" \
     "https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases" -d "{
       \"tag_name\": \"$tag\",
@@ -42,8 +46,8 @@ find_asset_id() {
   local asset_name="$1"
   local release_id="$2"
   
-  echo $(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-    "https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO=/releases/$release_id/assets" | \
+  echo $(curl -s -L -H "Authorization: token $GITHUB_TOKEN" \
+    "https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/$release_id/assets" | \
     jq -r ".[] | select(.name == \"$asset_name\") | .id")
 }
 
@@ -77,7 +81,7 @@ update_release_description() {
   local new_body="$2"
 
   echo "Updated release description..."
-  curl -s -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
+  curl -s -L -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
     -H "Content-Type: application/json" \
     "https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/$release_id" -d "{
       \"body\": \"$new_body\"
@@ -277,15 +281,14 @@ fi
 # Begin to push Releae in GitHub Repository
 
 # Retrieve information from existing release
-RELEASE_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+RELEASE_RESPONSE=$(curl -s -L -H "Authorization: token $GITHUB_TOKEN" \
   "https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/tags/$TAG")
-
 
 if [[ $(echo "$RELEASE_RESPONSE" | jq -r '.message') == "Not Found" ]]; then
   echo "The release for tag '$TAG' does not exist. Creating release..."
   create_release "$TAG" "$TAG" "$RELEASE_DESCRIPTION"
   # Retrieve information from the newly created release
-  RELEASE_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+  RELEASE_RESPONSE=$(curl -s -L -H "Authorization: token $GITHUB_TOKEN" \
     "https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/tags/$TAG")
 fi
 
@@ -293,11 +296,31 @@ fi
 UPLOAD_URL=$(echo "$RELEASE_RESPONSE" | jq -r '.upload_url' | sed "s/{?name,label}//")
 RELEASE_ID=$(echo "$RELEASE_RESPONSE" | jq -r '.id')
 
-# Description update
-update_release_description "$RELEASE_ID" "$RELEASE_DESCRIPTION"
+# If we still don't have a valid release (e.g. API returned redirect/error), try creating it
+if [ -z "$RELEASE_ID" ] || [ "$RELEASE_ID" = "null" ] || [ -z "$UPLOAD_URL" ] || [ "$UPLOAD_URL" = "null" ]; then
+  echo "Could not get release (tag may not exist). Creating release..."
+  create_release "$TAG" "$TAG" "$RELEASE_DESCRIPTION"
+  RELEASE_RESPONSE=$(curl -s -L -H "Authorization: token $GITHUB_TOKEN" \
+    "https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/tags/$TAG")
+  UPLOAD_URL=$(echo "$RELEASE_RESPONSE" | jq -r '.upload_url' | sed "s/{?name,label}//")
+  RELEASE_ID=$(echo "$RELEASE_RESPONSE" | jq -r '.id')
+fi
+
+# Only update description if we got a valid release ID
+if [ -n "$RELEASE_ID" ] && [ "$RELEASE_ID" != "null" ]; then
+  update_release_description "$RELEASE_ID" "$RELEASE_DESCRIPTION"
+else
+  echo "Warning: Could not get release ID (API may have redirected). Skipping description update."
+fi
+
+# Bail out if we don't have a valid release (uploads would fail)
+if [ -z "$UPLOAD_URL" ] || [ "$UPLOAD_URL" = "null" ] || [ -z "$RELEASE_ID" ] || [ "$RELEASE_ID" = "null" ]; then
+  echo "Error: Could not get release or upload URL. Check GITHUB_TOKEN and repo access."
+  exit 1
+fi
 
 # Retrieve the list of files from the release
-ASSETS_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+ASSETS_RESPONSE=$(curl -s -L -H "Authorization: token $GITHUB_TOKEN" \
   "https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/$RELEASE_ID/assets")
 
 

--- a/golc.go
+++ b/golc.go
@@ -67,12 +67,31 @@ type SelfLink struct {
 
 type Config struct {
 	Platforms map[string]interface{} `json:"platforms"`
-	Logging   LoggingConfig          `json:"logging"`
+	Logging   LoggingConfig          `json:"Logging"`
 	Release   ReleaseConfig          `json:"release"`
 }
 
+// LogLevel unmarshals from JSON string (e.g. "info", "debug") so config files can use readable values.
+type LogLevel logrus.Level
+
+// UnmarshalJSON parses level from a JSON string (e.g. "Info", "debug") using logrus.ParseLevel.
+func (l *LogLevel) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	level, err := logrus.ParseLevel(strings.ToLower(s))
+	if err != nil {
+		return err
+	}
+	*l = LogLevel(level)
+	return nil
+}
+
+func (l LogLevel) ToLogrus() logrus.Level { return logrus.Level(l) }
+
 type LoggingConfig struct {
-	Level logrus.Level `json:"level"`
+	Level LogLevel `json:"level"`
 }
 
 type ReleaseConfig struct {
@@ -678,7 +697,7 @@ func AnalyseReposListAzure(DestinationResult string, platformConfig map[string]i
 
 /* ---------------- Analyse Directory ---------------- */
 
-func AnalyseReposListFile(Listdirectorie, fileexclusionEX []string, extexclusion []string, ResultByFile bool, ResultAll bool) {
+func AnalyseReposListFile(resultsDir string, Listdirectorie, fileexclusionEX []string, extexclusion []string, ResultByFile bool, ResultAll bool) {
 
 	type Configuration struct {
 		ExcludeExtensions []string
@@ -719,7 +738,7 @@ func AnalyseReposListFile(Listdirectorie, fileexclusionEX []string, extexclusion
 				OrderByComment:    false,
 				Order:             "DESC",
 				OutputName:        outputFileName,
-				OutputPath:        "Results",
+				OutputPath:        resultsDir,
 				ReportFormats:     []string{"json"},
 				Branch:            "",
 				Token:             "",
@@ -931,11 +950,10 @@ func init() {
 		logrus.Fatalf("❌ Failed to delete old log file: %v", err)
 	}
 
-	// Set Loggin
-	// Create a new logger instance
-
+	// Set global log level so all packages (via utils.NewLogger()) respect config
+	utils.SetGlobalLevel(AppConfig.Logging.Level.ToLogrus())
+	// Create a new logger instance for main
 	logger = utils.NewLogger()
-	logger.SetLevel(AppConfig.Logging.Level)
 }
 
 // ApplicationFlags holds command line arguments
@@ -946,6 +964,8 @@ type ApplicationFlags struct {
 	Help        bool
 	Languages   bool
 	Version     bool
+	LogLevel    string // e.g. "trace", "debug", "info", "warn", "error"; empty = use config
+	Verbose     bool   // -verbose or -v sets level to debug
 }
 
 // parseAndValidateFlags processes command line arguments and validates them
@@ -957,6 +977,9 @@ func parseAndValidateFlags() (ApplicationFlags, map[string]interface{}) {
 	helpFlag := flag.Bool("help", false, "Show help message")
 	languagesFlag := flag.Bool("languages", false, "Show all supported languages")
 	versionflag := flag.Bool("version", false, "Show version")
+	logLevelFlag := flag.String("log-level", "", "Log level: trace, debug, info, warn, error (default from config)")
+	verboseFlag := flag.Bool("verbose", false, "Set log level to debug (short: -v)")
+	vFlag := flag.Bool("v", false, "Same as -verbose")
 
 	flag.Parse()
 
@@ -969,6 +992,8 @@ func parseAndValidateFlags() (ApplicationFlags, map[string]interface{}) {
 		fmt.Println("  golc -devops Github                    # Analyze main branches only")
 		fmt.Println("  golc -devops Github -all-branches      # Analyze ALL branches")
 		fmt.Println("  golc -devops Github -fast              # Fast analysis mode")
+		fmt.Println("  golc -devops Github -log-level=debug   # Verbose logging for troubleshooting")
+		fmt.Println("  golc -devops Github -verbose           # Same as -log-level=debug")
 		flag.PrintDefaults()
 		os.Exit(0)
 	}
@@ -997,6 +1022,7 @@ func parseAndValidateFlags() (ApplicationFlags, map[string]interface{}) {
 		os.Exit(1)
 	}
 
+	verbose := *verboseFlag || *vFlag
 	return ApplicationFlags{
 		DevOps:      *devopsFlag,
 		Fast:        *fastFlag,
@@ -1004,7 +1030,37 @@ func parseAndValidateFlags() (ApplicationFlags, map[string]interface{}) {
 		Help:        *helpFlag,
 		Languages:   *languagesFlag,
 		Version:     *versionflag,
+		LogLevel:    *logLevelFlag,
+		Verbose:     verbose,
 	}, platformConfig
+}
+
+// resolveLogLevel returns the effective log level from CLI flags; if no override, returns the current global level.
+func resolveLogLevel(flags ApplicationFlags) logrus.Level {
+	if flags.LogLevel != "" {
+		s := strings.ToLower(flags.LogLevel)
+		// logrus v1 has no TraceLevel; treat "trace" as debug for maximum verbosity
+		if s == "trace" {
+			return logrus.DebugLevel
+		}
+		level, err := logrus.ParseLevel(s)
+		if err != nil {
+			logger.Warnf("Invalid -log-level=%q, using config default: %v", flags.LogLevel, err)
+			return utils.GetGlobalLevel()
+		}
+		return level
+	}
+	if flags.Verbose {
+		return logrus.DebugLevel
+	}
+	return utils.GetGlobalLevel()
+}
+
+// applyLogLevel applies the effective log level from flags to the global logger and main's logger.
+func applyLogLevel(flags ApplicationFlags) {
+	level := resolveLogLevel(flags)
+	utils.SetGlobalLevel(level)
+	logger.SetLevel(level)
 }
 
 // setupResultsDirectory handles Results directory creation and backup logic
@@ -1013,7 +1069,7 @@ func setupResultsDirectory(flags ApplicationFlags) string {
 	if err != nil {
 		fmt.Println("Error:", err)
 	}
-	DestinationResult := pwd + "/Results"
+	DestinationResult := filepath.Join(pwd, "Results")
 
 	logger.Infof("✅ Using configuration for DevOps platform '%s'\n", flags.DevOps)
 
@@ -1067,6 +1123,8 @@ func main() {
 
 	// Parse and validate command line flags
 	flags, platformConfig := parseAndValidateFlags()
+	// Apply -log-level / -verbose override so all packages use the same level
+	applyLogLevel(flags)
 
 	// Setup results directory
 	DestinationResult := setupResultsDirectory(flags)
@@ -1275,7 +1333,7 @@ func main() {
 			}
 		}
 		startTime = time.Now()
-		AnalyseReposListFile(ListDirectory, ListExclusion, excludeExtensions, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool))
+		AnalyseReposListFile(DestinationResult, ListDirectory, ListExclusion, excludeExtensions, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool))
 	}
 
 	/*---------------------------------- End Select type of DevOps Platform ----------------------------------------------------*/
@@ -1291,14 +1349,11 @@ func main() {
 	spin.Start()
 
 	if platformConfig["ResultAll"].(bool) {
-
-		DestinationResult = DestinationResult + "/bylanguage-report/"
+		DestinationResult = filepath.Join(DestinationResult, "bylanguage-report")
 	} else if platformConfig["ResultByFile"].(bool) {
-
-		DestinationResult = DestinationResult + "/byfile-report/"
+		DestinationResult = filepath.Join(DestinationResult, "byfile-report")
 	} else {
-
-		DestinationResult = DestinationResult + "/bylanguage-report/"
+		DestinationResult = filepath.Join(DestinationResult, "bylanguage-report")
 	}
 
 	// List files in the directory
@@ -1307,9 +1362,17 @@ func main() {
 		logger.Errorf("❌ Error listing files:%v", err)
 		os.Exit(1)
 	}
+	jsonCount := 0
+	for _, f := range files {
+		if !f.IsDir() && strings.HasSuffix(f.Name(), ".json") {
+			jsonCount++
+		}
+	}
+	logger.Debugf("report phase: listing path=%q entries=%d json_files=%d", DestinationResult, len(files), jsonCount)
 
 	// Initialize the sum of TotalCodeLines (excluding JSON to match SonarQube behavior)
 	totalCodeLinesSum := 0
+	resultFileCount := 0
 
 	// Analyse All file
 	for _, file := range files {
@@ -1340,8 +1403,18 @@ func main() {
 				}
 			}
 			codeLinesForTotal := result.TotalCodeLines - jsonLOC
+			// Fallback: byfile JSON has same top-level TotalCodeLines; if 0, sum from Results (e.g. format or encoding quirk)
+			if codeLinesForTotal == 0 && len(result.Results) > 0 {
+				for _, r := range result.Results {
+					if strings.TrimSpace(r.Language) != utils.LanguageExcludedFromTotalLOC {
+						codeLinesForTotal += r.CodeLines
+					}
+				}
+			}
 
 			totalCodeLinesSum += codeLinesForTotal
+			resultFileCount++
+			logger.Debugf("report result file: name=%s TotalCodeLines=%d TotalLines=%d", file.Name(), result.TotalCodeLines, result.TotalLines)
 
 			// Check if this repo has a higher TotalCodeLines (excl. JSON) than the current maximum
 			if codeLinesForTotal > maxTotalCodeLines {
@@ -1360,6 +1433,7 @@ func main() {
 		}
 
 	}
+	logger.Infof("report analysis: %d result file(s) processed, total LOC sum=%d", resultFileCount, totalCodeLinesSum)
 	maxTotalCodeLines1 := utils.FormatCodeLines(float64(maxTotalCodeLines))
 	totalCodeLinesSum1 := utils.FormatCodeLines(float64(totalCodeLinesSum))
 
@@ -1386,23 +1460,28 @@ func main() {
 		logger.Errorf("❌ Error during JSON encoding in Gobal Report:%v", err)
 		return
 	}
-	// Created Global Result json file
-	file1, err := os.Create("Results/GlobalReport.json")
+	// Determine base Results directory (parent of current DestinationResult)
+	baseResultsDir := filepath.Dir(filepath.Clean(DestinationResult))
+
+	// Created Global Result json file (use baseResultsDir for Windows-safe path)
+	globalReportJSONPath := filepath.Join(baseResultsDir, "GlobalReport.json")
+	file1, err := os.Create(globalReportJSONPath)
 	if err != nil {
 		logger.Errorf("❌ Error during file creation Gobal Report:%v", err)
 		return
 	}
-	defer file.Close()
-
 	_, err = file1.Write(jsonData)
 	if err != nil {
+		file1.Close()
 		logger.Errorf("❌ Error writing to file:%v", err)
 		return
 	}
+	if err := file1.Close(); err != nil {
+		logger.Errorf("❌ Error closing GlobalReport.json: %v", err)
+		return
+	}
+	logger.Infof("GlobalReport.json written to %s (total LOC=%s)", globalReportJSONPath, totalCodeLinesSum1)
 	spin.Stop()
-
-	// Determine base Results directory (parent of current DestinationResult)
-	baseResultsDir := filepath.Dir(filepath.Clean(DestinationResult))
 
 	// Generated Global Report (walks the directory for Result_* files)
 	// Pass the base Results directory for consistency across platforms.

--- a/golc.go
+++ b/golc.go
@@ -1054,11 +1054,10 @@ func resolveLogLevel(flags ApplicationFlags) logrus.Level {
 	return utils.GetGlobalLevel()
 }
 
-// applyLogLevel applies the effective log level from flags to the global logger and main's logger.
+// applyLogLevel applies the effective log level from flags (updates global level and shared logger).
 func applyLogLevel(flags ApplicationFlags) {
 	level := resolveLogLevel(flags)
 	utils.SetGlobalLevel(level)
-	logger.SetLevel(level)
 }
 
 // setupResultsDirectory handles Results directory creation and backup logic

--- a/golc.go
+++ b/golc.go
@@ -1036,15 +1036,17 @@ func parseAndValidateFlags() (ApplicationFlags, map[string]interface{}) {
 }
 
 // resolveLogLevel returns the effective log level from CLI flags; if no override, returns the current global level.
+// Invalid -log-level is treated as no override, so -verbose still applies (e.g. -verbose -log-level=typo → debug).
 func resolveLogLevel(flags ApplicationFlags) logrus.Level {
 	if flags.LogLevel != "" {
 		s := strings.ToLower(flags.LogLevel)
 		level, err := logrus.ParseLevel(s)
 		if err != nil {
-			logger.Warnf("Invalid -log-level=%q, using config default: %v", flags.LogLevel, err)
-			return utils.GetGlobalLevel()
+			logger.Warnf("Invalid -log-level=%q, ignoring and using other flags/config: %v", flags.LogLevel, err)
+			// Fall through to consider -verbose and then config default
+		} else {
+			return level
 		}
-		return level
 	}
 	if flags.Verbose {
 		return logrus.DebugLevel

--- a/golc.go
+++ b/golc.go
@@ -1039,10 +1039,6 @@ func parseAndValidateFlags() (ApplicationFlags, map[string]interface{}) {
 func resolveLogLevel(flags ApplicationFlags) logrus.Level {
 	if flags.LogLevel != "" {
 		s := strings.ToLower(flags.LogLevel)
-		// logrus v1 has no TraceLevel; treat "trace" as debug for maximum verbosity
-		if s == "trace" {
-			return logrus.DebugLevel
-		}
 		level, err := logrus.ParseLevel(s)
 		if err != nil {
 			logger.Warnf("Invalid -log-level=%q, using config default: %v", flags.LogLevel, err)
@@ -1132,7 +1128,7 @@ func main() {
 
 	// Create Global Report File
 
-	GlobalReport := DestinationResult + "/GlobalReport.txt"
+	GlobalReport := filepath.Join(DestinationResult, "GlobalReport.txt")
 	file, err := os.Create(GlobalReport)
 	if err != nil {
 		logger.Errorf("❌ Error creating file:%v", err)

--- a/golc_test.go
+++ b/golc_test.go
@@ -25,7 +25,7 @@ const (
 	testLogsDir              = "Logs"
 	testExclusionFile        = "test_exclusion.txt"
 	sampleExclusionContent   = "repo1\nrepo2\n"
-	validConfigContent       = `{"platforms": {"test": {}}, "logging": {"level": "info"}, "release": {"version": "1.0.9"}}`
+	validConfigContent       = `{"platforms": {"test": {}}, "Logging": {"level": "info"}, "release": {"version": "1.0.9"}}`
 	invalidConfigContent     = `{"invalid": "json"`
 	testBackupSource         = "test_backup_source"
 	testBackupTarget         = "test_backup.zip"
@@ -590,7 +590,7 @@ func TestAnalysisListFunctions(t *testing.T) {
 					t.Errorf("AnalyseReposListFile panicked: %v", r)
 				}
 			}()
-			AnalyseReposListFile(emptyDirs, emptyExclusions, emptyExtensions, false, false)
+			AnalyseReposListFile("Results", emptyDirs, emptyExclusions, emptyExtensions, false, false)
 		}()
 	})
 }

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -4,6 +4,8 @@ import (
 	"io/fs"
 	"path/filepath"
 	"strings"
+
+	"github.com/SonarSource-Demos/sonar-golc/pkg/utils"
 )
 
 type Analyzer struct {
@@ -38,6 +40,7 @@ func NewAnalyzer(
 
 func (a *Analyzer) MatchingFiles() ([]FileMetadata, error) {
 	var files []FileMetadata
+	log := utils.NewLogger()
 
 	err := filepath.Walk(a.path, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
@@ -49,18 +52,23 @@ func (a *Analyzer) MatchingFiles() ([]FileMetadata, error) {
 		}
 
 		fileExtension := a.getFileExtension(path)
-		if a.canAdd(path, fileExtension) {
+		ok, excludeReason := a.canAddWithReason(path, fileExtension)
+		if ok {
 			fm := FileMetadata{
 				FilePath:  path,
 				Extension: fileExtension,
 				Language:  a.SupportedExtensions[fileExtension],
 			}
 			files = append(files, fm)
+			log.Debugf("file included: path=%s extension=%s language=%s", path, fileExtension, fm.Language)
+		} else {
+			log.Debugf("file excluded: path=%s reason=%s", path, excludeReason)
 		}
 
 		return nil
 	})
 
+	log.Debugf("matching files: %d found under %s", len(files), a.path)
 	return files, err
 }
 
@@ -74,22 +82,29 @@ func (a *Analyzer) getFileExtension(path string) string {
 	return extension
 }
 
-func (a *Analyzer) canAdd(path string, extension string) bool {
+// canAddWithReason returns whether the file should be included and, if not, a short reason for troubleshooting.
+func (a *Analyzer) canAddWithReason(path string, extension string) (bool, string) {
 	for _, pathToExclude := range a.excludePaths {
 		if strings.HasPrefix(path, pathToExclude) {
-			return false
+			return false, "excluded path"
 		}
 	}
 
 	if len(a.includeExtensions) > 0 {
 		_, ok := a.includeExtensions[a.getFileExtension(path)]
-		return ok
+		if !ok {
+			return false, "not in include list"
+		}
+		return true, ""
 	}
 
 	if _, ok := a.excludeExtensions[a.getFileExtension(path)]; ok {
-		return false
+		return false, "excluded extension"
 	}
 
 	_, ok := a.SupportedExtensions[extension]
-	return ok
+	if !ok {
+		return false, "unsupported extension"
+	}
+	return true, ""
 }

--- a/pkg/goloc/goloc.go
+++ b/pkg/goloc/goloc.go
@@ -224,11 +224,13 @@ func initAnalyzerScannerReporters(path string, params Params, excludePaths []str
 }
 
 func (gc *GCloc) Run() error {
+	log := utils.NewLogger()
 
 	files, err := gc.analyzer.MatchingFiles()
 	if err != nil {
 		return err
 	}
+	log.Debugf("files to scan: %d (path=%s)", len(files), gc.Params.Path)
 
 	scanResult, err := gc.scanner.Scan(files)
 	if err != nil {
@@ -236,6 +238,8 @@ func (gc *GCloc) Run() error {
 	}
 
 	summary := gc.scanner.Summary(scanResult)
+	log.Debugf("scan complete: files=%d total_lines=%d total_loc=%d blanks=%d comments=%d",
+		summary.TotalFiles, summary.TotalLines, summary.TotalCodeLines, summary.TotalBlankLines, summary.TotalComments)
 
 	sortedSummary := gc.sortSummary(summary)
 
@@ -332,19 +336,19 @@ func getReporters(reportFormats []string, outputName, outputPath string, byfile 
 
 			if byfile {
 
-				typereportPath := "/byfile-report"
+				byfileReportPath := filepath.Join(outputPath, "byfile-report")
 				reporters = append(reporters, json.JsonReporter{
 					OutputName: outputName + indicemode,
-					OutputPath: outputPath + typereportPath,
+					OutputPath: byfileReportPath,
 				})
 
 				reporters = append(reporters, csv.CsvReporter{
 					OutputName: outputName + indicemode,
-					OutputPath: outputPath + typereportPath + "/csv-report",
+					OutputPath: filepath.Join(byfileReportPath, "csv-report"),
 				})
 				reporters = append(reporters, pdf.PdfReporter{
 					OutputName: outputName + indicemode,
-					OutputPath: outputPath + typereportPath + "/pdf-report",
+					OutputPath: filepath.Join(byfileReportPath, "pdf-report"),
 				})
 
 				/*reporterG := pdf.PdfReporter{
@@ -357,10 +361,10 @@ func getReporters(reportFormats []string, outputName, outputPath string, byfile 
 				}*/
 			} else {
 
-				typereportPath := "/bylanguage-report"
+				bylanguageReportPath := filepath.Join(outputPath, "bylanguage-report")
 				reporters = append(reporters, json.JsonReporter{
 					OutputName: outputName,
-					OutputPath: outputPath + typereportPath,
+					OutputPath: bylanguageReportPath,
 				})
 			}
 

--- a/pkg/reporter/csv/csv_reporter.go
+++ b/pkg/reporter/csv/csv_reporter.go
@@ -139,5 +139,6 @@ func (c CsvReporter) writeCsv(csvReport *report) error {
 	}
 
 	loggers.Infof("\t✅ CSV report exported to %s", path)
+	loggers.Debugf("CSV report metrics: path=%s total_loc=%d total_files=%d", path, csvReport.TotalCodeLines, csvReport.TotalFiles)
 	return nil
 }

--- a/pkg/reporter/json/json_reporter.go
+++ b/pkg/reporter/json/json_reporter.go
@@ -106,6 +106,7 @@ func (j JsonReporter) writeJson(jsonReport *report) error {
 	}
 
 	loggers.Infof("\t✅ json report exported to %s", path)
+	loggers.Debugf("json report metrics: path=%s total_loc=%d total_files=%d", path, jsonReport.TotalCodeLines, jsonReport.TotalFiles)
 
 	return nil
 }

--- a/pkg/reporter/pdf/pdf_reporter.go
+++ b/pkg/reporter/pdf/pdf_reporter.go
@@ -230,6 +230,7 @@ func (p PdfReporter) writePdf(pdfReport *report) error {
 	}
 
 	loggers.Infof("\t✅ PDF report exported to %s", path)
+	loggers.Debugf("PDF report metrics: path=%s total_loc=%d total_lines=%d", path, pdfReport.TotalCodeLines, pdfReport.TotalLines)
 	return nil
 }
 

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/SonarSource-Demos/sonar-golc/pkg/analyzer"
 	"github.com/SonarSource-Demos/sonar-golc/pkg/goloc/language"
+	"github.com/SonarSource-Demos/sonar-golc/pkg/utils"
 	"github.com/schollz/progressbar/v3"
 )
 
@@ -32,6 +33,7 @@ func NewScanner(languages language.Languages) *Scanner {
 func (sc *Scanner) Scan(files []analyzer.FileMetadata) ([]scanResult, error) {
 	var results []scanResult
 	progress := sc.createProgressbar(len(files))
+	log := utils.NewLogger()
 
 	for _, file := range files {
 		result, err := sc.scanFile(file)
@@ -40,6 +42,8 @@ func (sc *Scanner) Scan(files []analyzer.FileMetadata) ([]scanResult, error) {
 		}
 		progress.Add(1)
 		results = append(results, result)
+		log.Debugf("scanned file: path=%s lines=%d loc=%d blank=%d comments=%d",
+			result.Metadata.FilePath, result.Lines, result.CodeLines, result.BlankLines, result.Comments)
 	}
 
 	return results, nil

--- a/pkg/utils/globalreport.go
+++ b/pkg/utils/globalreport.go
@@ -110,9 +110,15 @@ func CreateGlobalReport(directory string) error {
 }
 
 // collectLanguageTotals walks result files and aggregates language totals.
+// When both bylanguage-report and byfile-report exist (e.g. ResultAll), only bylanguage-report
+// is walked to avoid double-counting the same repository.
 func collectLanguageTotals(directory string) (map[string]int, error) {
 	ligneDeCodeParLangage := make(map[string]int)
-	err := filepath.Walk(directory, func(path string, info os.FileInfo, err error) error {
+	walkRoot := directory
+	if info, err := os.Stat(filepath.Join(directory, "bylanguage-report")); err == nil && info.IsDir() {
+		walkRoot = filepath.Join(directory, "bylanguage-report")
+	}
+	err := filepath.Walk(walkRoot, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/utils/globalreport.go
+++ b/pkg/utils/globalreport.go
@@ -69,16 +69,25 @@ func CreateGlobalReport(directory string) error {
 		loggers.Errorf("❌ Error reading files : %v", err)
 		return err
 	}
+	totalLOC := 0
+	for _, n := range totals {
+		totalLOC += n
+	}
+	loggers.Debugf("global report: %d language(s) in totals, total LOC=%d; output paths: %s, %s",
+		len(totals), totalLOC,
+		filepath.Join(directory, "code_lines_by_language.json"),
+		filepath.Join(directory, "GlobalReport.pdf"))
 
 	// Persist code_lines_by_language.json and keep marshaled bytes for later
-	outputData, err := writeLanguageTotalsJSON(totals)
+	outputData, err := writeLanguageTotalsJSON(directory, totals)
 	if err != nil {
 		loggers.Errorf("❌ Error creating output JSON file : %v", err)
 		return err
 	}
 
-	// Reading data from the GlobalReport JSON file
-	ginfo, err := readGlobalInfoFromFile("Results/GlobalReport.json")
+	// Reading data from the GlobalReport JSON file (use directory for Windows-safe path)
+	globalReportPath := filepath.Join(directory, "GlobalReport.json")
+	ginfo, err := readGlobalInfoFromFile(globalReportPath)
 	if err != nil {
 		return err
 	}
@@ -91,12 +100,12 @@ func CreateGlobalReport(directory string) error {
 		return err
 	}
 
-	// Create a PDF
-	if err := renderGlobalPDF(languages, ginfo); err != nil {
+	// Create a PDF (output path under directory for Windows-safe path)
+	if err := renderGlobalPDF(filepath.Join(directory, "GlobalReport.pdf"), languages, ginfo); err != nil {
 		return err
 	}
 
-	loggers.Infof("✅ Global PDF report exported to %s", "Results/GlobalReport.pdf")
+	loggers.Infof("✅ Global PDF report exported to %s", filepath.Join(directory, "GlobalReport.pdf"))
 	return nil
 }
 
@@ -118,16 +127,14 @@ func collectLanguageTotals(directory string) (map[string]int, error) {
 	return ligneDeCodeParLangage, nil
 }
 
-// isEligibleResultFile returns true for top-level Result_*.json files that are not _byfile.
+// isEligibleResultFile returns true for Result_*.json files (by-language or by-file).
+// Including _byfile.json ensures language totals are populated when only byfile-report exists.
 func isEligibleResultFile(info os.FileInfo, path string) bool {
 	if info.IsDir() {
 		return false
 	}
 	name := info.Name()
 	if !strings.HasPrefix(name, "Result_") {
-		return false
-	}
-	if strings.Contains(name, "_byfile") {
 		return false
 	}
 	return filepath.Ext(path) == ".json"
@@ -151,8 +158,8 @@ func accumulateLanguageTotalsFromFile(path string, totals map[string]int) error 
 	return nil
 }
 
-// writeLanguageTotalsJSON writes Results/code_lines_by_language.json and returns the serialized bytes.
-func writeLanguageTotalsJSON(totals map[string]int) ([]byte, error) {
+// writeLanguageTotalsJSON writes code_lines_by_language.json under directory and returns the serialized bytes.
+func writeLanguageTotalsJSON(directory string, totals map[string]int) ([]byte, error) {
 	loggers := NewLogger()
 	var resultats []LanguageData1
 	for lang, total := range totals {
@@ -165,11 +172,16 @@ func writeLanguageTotalsJSON(totals map[string]int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	const outputFile = "Results/code_lines_by_language.json"
+	outputFile := filepath.Join(directory, "code_lines_by_language.json")
 	if err := os.WriteFile(outputFile, outputData, 0644); err != nil {
 		return nil, err
 	}
+	totalLOC := 0
+	for _, n := range totals {
+		totalLOC += n
+	}
 	loggers.Infof("✅ Results analysis recorded in %s", outputFile)
+	loggers.Debugf("code_lines_by_language.json: path=%s languages=%d total_loc=%d", outputFile, len(totals), totalLOC)
 	return outputData, nil
 }
 
@@ -190,7 +202,7 @@ func readGlobalInfoFromFile(path string) (Globalinfo, error) {
 }
 
 // renderGlobalPDF generates the GlobalReport.pdf from languages and global info.
-func renderGlobalPDF(languages []LanguageData, ginfo Globalinfo) error {
+func renderGlobalPDF(outputPath string, languages []LanguageData, ginfo Globalinfo) error {
 	var unit = "%"
 	loggers := NewLogger()
 	Org := "Organization : " + ginfo.Organization
@@ -264,7 +276,7 @@ func renderGlobalPDF(languages []LanguageData, ginfo Globalinfo) error {
 		rowCount++
 	}
 
-	if err := pdf.OutputFileAndClose("Results/GlobalReport.pdf"); err != nil {
+	if err := pdf.OutputFileAndClose(outputPath); err != nil {
 		loggers.Errorf("❌ Error saving PDF file: %v", err)
 		return err
 	}

--- a/pkg/utils/globalreport_test.go
+++ b/pkg/utils/globalreport_test.go
@@ -108,6 +108,36 @@ func TestCollectLanguageTotalsAggregatesByfileAndBylanguage(t *testing.T) {
 	}
 }
 
+// TestCollectLanguageTotalsPrefersBylanguageReportWhenBothExist ensures that when both
+// bylanguage-report and byfile-report exist (e.g. ResultAll), we only aggregate from
+// bylanguage-report to avoid double-counting the same repository.
+func TestCollectLanguageTotalsPrefersBylanguageReportWhenBothExist(t *testing.T) {
+	dir, cleanup := setupGlobalReportEnv(t)
+	defer cleanup()
+	bylanguageDir := filepath.Join(dir, "bylanguage-report")
+	byfileDir := filepath.Join(dir, "byfile-report")
+	if err := os.MkdirAll(bylanguageDir, 0755); err != nil {
+		t.Fatalf("mkdir bylanguage-report: %v", err)
+	}
+	if err := os.MkdirAll(byfileDir, 0755); err != nil {
+		t.Fatalf("mkdir byfile-report: %v", err)
+	}
+	// Same repo: by-language says 10, by-file says 10 (would double-count to 20 if both walked)
+	writeResultJSON(t, bylanguageDir, "Result_org_repo_main.json", FileData{
+		Results: []LanguageData1{{Language: "Go", CodeLines: 10}},
+	})
+	writeResultJSON(t, byfileDir, "Result_org_repo_main_byfile.json", FileData{
+		Results: []LanguageData1{{Language: "Go", CodeLines: 10}},
+	})
+	totals, err := collectLanguageTotals(dir)
+	if err != nil {
+		t.Fatalf("collectLanguageTotals error: %v", err)
+	}
+	if totals["Go"] != 10 {
+		t.Errorf("expected 10 (bylanguage only, no double-count), got %d", totals["Go"])
+	}
+}
+
 func TestWriteLanguageTotalsJSONAndReadGlobalInfoAndRenderPDF(t *testing.T) {
 	_, cleanup := setupGlobalReportEnv(t)
 	defer cleanup()

--- a/pkg/utils/globalreport_test.go
+++ b/pkg/utils/globalreport_test.go
@@ -53,8 +53,9 @@ func TestIsEligibleResultFile(t *testing.T) {
 	if !isEligibleResultFile(fiRes, result) {
 		t.Errorf("expected %s to be eligible", result)
 	}
-	if isEligibleResultFile(fiBy, byfile) {
-		t.Errorf("did not expect %s to be eligible", byfile)
+	// byfile is now eligible so language totals are populated when only byfile-report exists
+	if !isEligibleResultFile(fiBy, byfile) {
+		t.Errorf("expected %s to be eligible (byfile reports used for language totals)", byfile)
 	}
 	if isEligibleResultFile(fiO, other) {
 		t.Errorf("did not expect %s to be eligible", other)
@@ -84,10 +85,10 @@ func TestAccumulateLanguageTotalsFromFile(t *testing.T) {
 	}
 }
 
-func TestCollectLanguageTotalsSkipsByfile(t *testing.T) {
+func TestCollectLanguageTotalsAggregatesByfileAndBylanguage(t *testing.T) {
 	dir, cleanup := setupGlobalReportEnv(t)
 	defer cleanup()
-	// arrange result files
+	// arrange result files: both by-language and by-file are aggregated
 	writeResultJSON(t, dir, "Result_org_a_main.json", FileData{
 		Results: []LanguageData1{{Language: "Go", CodeLines: 10}},
 	})
@@ -101,8 +102,9 @@ func TestCollectLanguageTotalsSkipsByfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("collectLanguageTotals error: %v", err)
 	}
-	if totals["Go"] != 10 {
-		t.Errorf("expected 10, got %d", totals["Go"])
+	// Only Result_* files are included (random.json is skipped); both by-language and byfile are summed
+	if totals["Go"] != 1010 {
+		t.Errorf("expected 1010 (10+1000), got %d", totals["Go"])
 	}
 }
 
@@ -126,8 +128,8 @@ func TestWriteLanguageTotalsJSONAndReadGlobalInfoAndRenderPDF(t *testing.T) {
 		t.Fatalf("failed writing GlobalReport.json: %v", err)
 	}
 
-	// write language totals
-	data, err := writeLanguageTotalsJSON(map[string]int{"Go": 100})
+	// write language totals (directory as first arg for Windows-safe paths)
+	data, err := writeLanguageTotalsJSON("Results", map[string]int{"Go": 100})
 	if err != nil {
 		t.Fatalf("writeLanguageTotalsJSON error: %v", err)
 	}

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -5,10 +5,32 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/fatih/color"
 	"github.com/sirupsen/logrus"
 )
+
+var (
+	globalLevel   = logrus.InfoLevel
+	globalLevelMu sync.RWMutex
+)
+
+// SetGlobalLevel sets the log level used by all loggers returned from NewLogger().
+// Call this early (e.g. from main after loading config and parsing CLI) so that
+// every package respects the same level.
+func SetGlobalLevel(level logrus.Level) {
+	globalLevelMu.Lock()
+	defer globalLevelMu.Unlock()
+	globalLevel = level
+}
+
+// GetGlobalLevel returns the current global log level.
+func GetGlobalLevel() logrus.Level {
+	globalLevelMu.RLock()
+	defer globalLevelMu.RUnlock()
+	return globalLevel
+}
 
 type CustomFormatter struct{}
 
@@ -38,7 +60,10 @@ func NewLogger() *logrus.Logger {
 	logger := logrus.New()
 	logger.SetFormatter(&CustomFormatter{})
 
-	logger.SetLevel(logrus.DebugLevel)
+	globalLevelMu.RLock()
+	level := globalLevel
+	globalLevelMu.RUnlock()
+	logger.SetLevel(level)
 
 	logFile, err := os.OpenFile("Logs/Logs.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -19,12 +19,16 @@ var (
 )
 
 // SetGlobalLevel sets the log level used by all loggers returned from NewLogger().
-// Call this early (e.g. from main after loading config and parsing CLI) so that
-// every package respects the same level.
+// It updates both the global default and the shared logger instance if it has
+// already been created, so callers can change the level at any time (e.g. after
+// parsing CLI flags).
 func SetGlobalLevel(level logrus.Level) {
 	globalLevelMu.Lock()
 	defer globalLevelMu.Unlock()
 	globalLevel = level
+	if sharedLogger != nil {
+		sharedLogger.SetLevel(level)
+	}
 }
 
 // GetGlobalLevel returns the current global log level.

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -12,8 +12,10 @@ import (
 )
 
 var (
-	globalLevel   = logrus.InfoLevel
-	globalLevelMu sync.RWMutex
+	globalLevel     = logrus.InfoLevel
+	globalLevelMu   sync.RWMutex
+	sharedLogger    *logrus.Logger
+	sharedLoggerOnce sync.Once
 )
 
 // SetGlobalLevel sets the log level used by all loggers returned from NewLogger().
@@ -56,22 +58,29 @@ func (f *CustomFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	return []byte(msg), nil
 }
 
+// NewLogger returns a shared logger that writes to stdout and Logs/Logs.log.
+// The log file is opened once per process to avoid file descriptor leaks when
+// NewLogger() is called in hot paths (e.g. per-repository analysis).
 func NewLogger() *logrus.Logger {
-	logger := logrus.New()
-	logger.SetFormatter(&CustomFormatter{})
+	sharedLoggerOnce.Do(func() {
+		logger := logrus.New()
+		logger.SetFormatter(&CustomFormatter{})
 
-	globalLevelMu.RLock()
-	level := globalLevel
-	globalLevelMu.RUnlock()
-	logger.SetLevel(level)
+		globalLevelMu.RLock()
+		level := globalLevel
+		globalLevelMu.RUnlock()
+		logger.SetLevel(level)
 
-	logFile, err := os.OpenFile("Logs/Logs.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-	if err != nil {
-		// Fallback to stdout only when log file cannot be created (e.g. read-only fs, Docker)
-		logger.SetOutput(os.Stdout)
-		return logger
-	}
+		logFile, err := os.OpenFile("Logs/Logs.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err != nil {
+			// Fallback to stdout only when log file cannot be created (e.g. read-only fs, Docker)
+			logger.SetOutput(os.Stdout)
+			sharedLogger = logger
+			return
+		}
 
-	logger.SetOutput(io.MultiWriter(os.Stdout, logFile))
-	return logger
+		logger.SetOutput(io.MultiWriter(os.Stdout, logFile))
+		sharedLogger = logger
+	})
+	return sharedLogger
 }

--- a/pkg/utils/repository_summary.go
+++ b/pkg/utils/repository_summary.go
@@ -457,19 +457,21 @@ func GenerateRepositorySummaryReports(directory string) error {
 
 	// Get output paths using helper function
 	csvOutputPath, jsonOutputPath, pdfOutputPath := createReportFilePaths(directory)
+	csvFilePath := filepath.Join(csvOutputPath, "repository_summary.csv")
+	jsonFilePath := filepath.Join(jsonOutputPath, "repository_summary.json")
+	pdfFilePath := filepath.Join(pdfOutputPath, "repository_summary.pdf")
+	loggers.Debugf("repository summary reports: generating CSV=%s JSON=%s PDF=%s (repos=%d total_LOC=%d)",
+		csvFilePath, jsonFilePath, pdfFilePath, summary.TotalRepositories, summary.TotalCodeLines)
 
 	// Generate reports with consistent error handling
-	csvFilePath := filepath.Join(csvOutputPath, "repository_summary.csv")
 	generateReportWithErrorHandling("CSV", csvFilePath, func() error {
 		return generateRepositoryCSVReport(summary, csvOutputPath)
 	})
 
-	jsonFilePath := filepath.Join(jsonOutputPath, "repository_summary.json")
 	generateReportWithErrorHandling("JSON", jsonFilePath, func() error {
 		return generateRepositoryJSONReport(summary, jsonOutputPath)
 	})
 
-	pdfFilePath := filepath.Join(pdfOutputPath, "repository_summary.pdf")
 	generateReportWithErrorHandling("PDF", pdfFilePath, func() error {
 		return generateRepositoryPDFReport(summary, pdfOutputPath)
 	})


### PR DESCRIPTION
…tness

Windows-safe paths:
- Use filepath.Join() instead of string concatenation for all result paths (Results, bylanguage-report, byfile-report, GlobalReport.json, etc.) in golc.go, pkg/goloc/goloc.go, pkg/utils/globalreport.go, and pkg/utils/repository_summary.go.
- AnalyseReposListFile now accepts resultsDir and uses it for OutputPath so the same path logic works on Windows and Unix.

Logging:
- Add configurable log level via config.json "Logging": { "level": "info" } (supported: trace, debug, info, warn, error). Config key is "Logging" (capital L) with custom LogLevel unmarshaling from string.
- Add CLI flags: -log-level=<level>, -verbose, -v (debug). Flags override config. Main applies effective level via utils.SetGlobalLevel() so all packages (analyzer, scanner, reporters, utils) respect it.
- Add debug/trace logs: file include/exclude reasons, per-file scan stats, report phase (files processed, total LOC), reporter metrics, global report paths.

GlobalReport and aggregation:
- Write GlobalReport.json under base Results dir using filepath.Join; fix misuse of defer file.Close() and add proper file1 close/error handling.
- Include Result_*_byfile.json in eligible result files so language totals work when only byfile-report exists. Add fallback LOC sum from result.Results when TotalCodeLines is 0.
- Tests updated for new writeLanguageTotalsJSON(directory, ...) and isEligibleResultFile behavior (byfile eligible, aggregated totals).

Docs and help:
- README: document Logging.Level and -log-level/-verbose. Mention -help.
- -help output: show -log-level=debug and -verbose examples.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core execution flow (results path construction, global report aggregation, and logging initialization) which could affect report outputs and troubleshooting behavior across platforms; changes are mostly mechanical but wide-reaching.
> 
> **Overview**
> Improves cross-platform reliability by switching result/report path construction to `filepath.Join()` across GoLC and report generation, including passing an explicit results directory into file-mode analysis and fixing `GlobalReport.json`/PDF output locations and file-close handling.
> 
> Adds configurable logging via config `Logging.level` (string → logrus level) plus CLI overrides (`-log-level`, `-verbose`/`-v`), backed by a shared global logger/level in `utils`, and introduces targeted debug logs for file inclusion/exclusion, scanning, and report generation metrics.
> 
> Hardens global report aggregation to include `_byfile` result files when needed while avoiding double-counting when both report types exist, adds a LOC fallback when JSON totals are missing, updates tests accordingly, and refreshes docs/help text and the sample GitHub release script (env token, redirects, and stronger error handling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c86275766e032b11ae549c2af975c3eaa53a65f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->