### PR TITLE
docs: add GitHub PAT requirements for organization analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [Usage](#usage)
   - [Environment Configuration](#environment-configuration)
   - [GitHub.com (Cloud) Basic Configuration](#githubcom-cloud-basic-configuration)
+  - [GitHub Personal Access Token (PAT) for organization analysis](#github-personal-access-token-pat-for-organization-analysis)
   - [GitHub Enterprise Server (on-premises) Basic Configuration](#github-enterprise-server-on-premises-basic-configuration)
   - [GitLab (Cloud and On-premises) Basic Configuration](#gitlab-cloud-and-on-premises-basic-configuration)
   - [Bitbucket Cloud Basic Configuration](#bitbucket-cloud-basic-configuration)
@@ -114,6 +115,13 @@ Specify the following parameters in the config.json file:
  ```
 
 Save the config.json file and [Run GoLC](#run-golc)
+
+### GitHub Personal Access Token (PAT) for organization analysis
+
+For organization-level analysis (`"Org": true`):
+
+- **Fine-grained PAT**: Set **Resource owner** to the **organization** (not your user). **Repository permissions**: Metadata: Read, Contents: Read. Grant access to all repos or to the repos you want to analyze. For each organization you analyze, use a separate PAT (one resource owner per token); add a separate platform entry in `config.json` per org and pass the matching `-devops` value.
+- **Classic PAT**: Use scopes **`repo`** and **`read:org`**. If the org uses SAML SSO, authorize the token for that organization in GitHub. One classic token can be authorized for multiple orgs.
 
 ## GitHub Enterprise Server (on-premises) Basic Configuration:
 


### PR DESCRIPTION
Adds README section on GitHub Personal Access Token (PAT) setup for organization-level analysis: resource owner = org for fine-grained PATs, permissions (Metadata + Contents Read), and one PAT per org vs classic PAT authorized per SAML org.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes with no code or behavior modifications.
> 
> **Overview**
> Adds a new README section clarifying **GitHub PAT requirements for organization-level analysis** (`"Org": true`), including fine-grained vs classic token setup, required permissions/scopes, and SAML SSO authorization notes.
> 
> Updates the Table of Contents to link to this new guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1e7ffde4cc722d69ee44b0abb7bddf4aa4d0069. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->