### PR TITLE
fix: file mode repository detail links and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It connects to your DevOps platform, identifies the largest branch of each repos
 
 **Supported platforms:** GitHub.com · GitHub Enterprise Server · GitLab Cloud · GitLab Self-Managed · Bitbucket Cloud · Bitbucket Data Center · Azure DevOps Services · Local files/directories
 
-> Current version: **v2.0** — [`ver2.0`](https://github.com/sonar-solutions/sonar-golc/tree/ver2.0) branch.
+> Current version: **v2.0**
 
 ---
 
@@ -45,9 +45,14 @@ Then run it for your operating system:
 ./webui
 ```
 
-**Windows** (Command Prompt or PowerShell)
+**Windows** (Command Prompt)
 ```bat
 webui.exe
+```
+
+**Windows** (PowerShell)
+```powershell
+.\webui.exe
 ```
 
 Open the URL printed in the terminal (default: `http://localhost:8091`), then:

--- a/golc.go
+++ b/golc.go
@@ -693,8 +693,9 @@ func saveFileAnalysisResult(destDir, org string, dirs []string) error {
 	result := fileAnalysisResult{}
 	for _, d := range dirs {
 		result.ProjectBranches = append(result.ProjectBranches, fileProjectBranch{
-			Org:      org,
-			RepoSlug: filepath.Base(d),
+			Org:        org,
+			RepoSlug:   filepath.Base(d),
+			MainBranch: "file",
 		})
 	}
 	result.NumRepositories = len(result.ProjectBranches)


### PR DESCRIPTION
## Fix: Repository detail link broken in File mode

Clicking on a repository in the results table while using **File mode** returned
an HTTP 400 "Invalid repository URL" error.

### Root cause

`saveFileAnalysisResult` created `fileProjectBranch` entries without setting
`MainBranch`, leaving it as an empty string. The results table built the link as
`/repository/{slug}/` (empty branch segment), which the detail handler rejected.

### Fix

Set `MainBranch: "file"` when saving file-mode analysis results. The URL becomes
`/repository/{slug}/file`, which passes the handler's validation. The detail page
already handles `platform == "file"` by ignoring the branch when looking up report
files, so no further changes were needed.

### Impact

File mode only — GitHub, GitLab, Bitbucket, Bitbucket DC, and Azure are not affected.

---

## Docs: README updates

- Split Windows run instructions into separate Command Prompt (`webui.exe`) and PowerShell (`.\webui.exe`) blocks.
- Removed the `ver2.0` branch link from the version note (now merged into main).