### PR TITLE
feat: improve advanced options UI — exclusions, scoping, and org toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,14 @@ Credentials are entered in the browser and saved automatically — no config fil
 | `Branch` | string | Analyze a specific branch name across all repos. Leave blank for auto. |
 | `Multithreading` | bool | Enable parallel analysis. Default: `true`. |
 | `Workers` | int | Concurrent workers. Default: `10`. |
-| `ExcludePaths` | array | Directories to exclude per repo (e.g. `["test", "vendor"]`). |
-| `ExtExclusion` | array | File extensions to exclude (e.g. `[".css", ".min.js"]`). |
+| `FolderKeywords` | array | Exclude folders whose name contains the keyword as a whole word at any depth. Word boundaries are delimiters `-`, `_`, `.` — so `"test"` matches `integration-test/` and `test_helpers/` but not `protest/` or `latest/`. |
+| `FileNamePatterns` | array | Exclude files whose name matches a glob pattern (e.g. `["*_test.go", "*.min.js", "*.spec.ts"]`). The `*` wildcard is matched against the file name only, not the full path. |
+| `ExtExclusion` | array | Exclude all files with these extensions, regardless of language (e.g. `[".css", ".html"]`). |
+| `ExcludeTests` | bool | Shortcut that adds common test-directory keywords to `FolderKeywords`: `test`, `tests`, `spec`, `specs`, `e2e`, `testdata`, `fixtures`, `mocks`, `integration`. |
+| `ExcludeVendor` | bool | Shortcut that adds common vendor-directory keywords to `FolderKeywords`: `vendor`, `node_modules`, `bower_components`, `third_party`, `external`. |
 | `Project` | string | Limit to a specific project key (Bitbucket, Azure DevOps). |
-| `Repos` | string | Limit to specific repo slugs (comma-separated). |
-| `Org` | bool | `true` = organization, `false` = personal account (GitHub only). |
+| `Repos` | string | Limit to specific repositories (comma-separated). GitHub/GHE: repository name. Bitbucket: repository slug. Azure DevOps: repository name. Not applicable for GitLab — use the Group URL slug field instead. |
+| `Org` | bool | `true` = analyze an organization account, `false` = analyze a personal account. GitHub and GitHub Enterprise only. Default: `true`. |
 
 
 ---

--- a/golc.go
+++ b/golc.go
@@ -397,6 +397,17 @@ func getExcludePaths(configValue interface{}) []string {
 	return []string{}
 }
 
+func getStringSliceConfig(platformConfig map[string]interface{}, key string) []string {
+	v, ok := platformConfig[key]
+	if !ok || v == nil {
+		return []string{}
+	}
+	if items, ok := v.([]interface{}); ok {
+		return convertToSliceString(items)
+	}
+	return []string{}
+}
+
 // Analysis functions for different repository types
 
 // Analysis functions for Bitbucket Cloud
@@ -406,6 +417,8 @@ func analyseBitCRepo(project interface{}, DestinationResult string, platformConf
 
 	excludeExtensions = convertToSliceString(platformConfig["ExtExclusion"].([]interface{}))
 	excludePath := getExcludePaths(platformConfig["ExcludePaths"])
+	folderKeywords := getStringSliceConfig(platformConfig, "FolderKeywords")
+	fileNamePatterns := getStringSliceConfig(platformConfig, "FileNamePatterns")
 
 	// Determine git clone URL format
 	// For git operations with API tokens, use x-bitbucket-api-token-auth (static username for API tokens)
@@ -435,7 +448,7 @@ func analyseBitCRepo(project interface{}, DestinationResult string, platformConf
 		MainBranch: p.MainBranch,
 		PathToScan: pathToScan,
 	}
-	performRepoAnalysis(params, DestinationResult, spin, results, count, excludeExtensions, excludePath, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool))
+	performRepoAnalysis(params, DestinationResult, spin, results, count, excludeExtensions, excludePath, folderKeywords, fileNamePatterns, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool))
 }
 
 // Analysis functions for Bitbucket DC
@@ -445,6 +458,8 @@ func analyseBitSRVRepo(project interface{}, DestinationResult string, platformCo
 
 	excludeExtensions = convertToSliceString(platformConfig["ExtExclusion"].([]interface{}))
 	excludePath := getExcludePaths(platformConfig["ExcludePaths"])
+	folderKeywords := getStringSliceConfig(platformConfig, "FolderKeywords")
+	fileNamePatterns := getStringSliceConfig(platformConfig, "FileNamePatterns")
 
 	params := RepoParams{
 		ProjectKey: p.ProjectKey,
@@ -453,7 +468,7 @@ func analyseBitSRVRepo(project interface{}, DestinationResult string, platformCo
 		MainBranch: p.MainBranch,
 		PathToScan: fmt.Sprintf("%s://%s:%s@%sscm/%s/%s.git", platformConfig["Protocol"].(string), platformConfig["Users"].(string), platformConfig["AccessToken"].(string), trimmedURL, p.ProjectKey, p.RepoSlug),
 	}
-	performRepoAnalysis(params, DestinationResult, spin, results, count, excludeExtensions, excludePath, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool))
+	performRepoAnalysis(params, DestinationResult, spin, results, count, excludeExtensions, excludePath, folderKeywords, fileNamePatterns, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool))
 }
 
 // Analysis functions for GitHub
@@ -463,6 +478,8 @@ func analyseGithubRepo(project interface{}, DestinationResult string, platformCo
 
 	excludeExtensions = convertToSliceString(platformConfig["ExtExclusion"].([]interface{}))
 	excludePath := getExcludePaths(platformConfig["ExcludePaths"])
+	folderKeywords := getStringSliceConfig(platformConfig, "FolderKeywords")
+	fileNamePatterns := getStringSliceConfig(platformConfig, "FileNamePatterns")
 
 	baseapi := extractDomain(platformConfig["Baseapi"].(string))
 	params := RepoParams{
@@ -472,7 +489,7 @@ func analyseGithubRepo(project interface{}, DestinationResult string, platformCo
 		MainBranch: p.MainBranch,
 		PathToScan: fmt.Sprintf("%s://%s:x-oauth-basic@%s/%s/%s.git", platformConfig["Protocol"].(string), platformConfig["AccessToken"].(string), baseapi, p.Org, p.RepoSlug),
 	}
-	performRepoAnalysis(params, DestinationResult, spin, results, count, excludeExtensions, excludePath, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool))
+	performRepoAnalysis(params, DestinationResult, spin, results, count, excludeExtensions, excludePath, folderKeywords, fileNamePatterns, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool))
 }
 
 // Analysis functions for GitLab
@@ -482,6 +499,8 @@ func analyseGitlabRepo(project interface{}, DestinationResult string, platformCo
 
 	excludeExtensions = convertToSliceString(platformConfig["ExtExclusion"].([]interface{}))
 	excludePath := getExcludePaths(platformConfig["ExcludePaths"])
+	folderKeywords := getStringSliceConfig(platformConfig, "FolderKeywords")
+	fileNamePatterns := getStringSliceConfig(platformConfig, "FileNamePatterns")
 
 	domain := extractDomain(platformConfig["Url"].(string))
 
@@ -492,7 +511,7 @@ func analyseGitlabRepo(project interface{}, DestinationResult string, platformCo
 		MainBranch: p.MainBranch,
 		PathToScan: fmt.Sprintf("%s://gitlab-ci-token:%s@%s/%s.git", platformConfig["Protocol"].(string), platformConfig["AccessToken"].(string), domain, p.Namespace),
 	}
-	performRepoAnalysis(params, DestinationResult, spin, results, count, excludeExtensions, excludePath, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool))
+	performRepoAnalysis(params, DestinationResult, spin, results, count, excludeExtensions, excludePath, folderKeywords, fileNamePatterns, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool))
 }
 
 func analyseAzurebRepo(project interface{}, DestinationResult string, platformConfig map[string]interface{}, spin *spinner.Spinner, results chan int, count *int) {
@@ -501,6 +520,8 @@ func analyseAzurebRepo(project interface{}, DestinationResult string, platformCo
 
 	excludeExtensions = convertToSliceString(platformConfig["ExtExclusion"].([]interface{}))
 	excludePath := getExcludePaths(platformConfig["ExcludePaths"])
+	folderKeywords := getStringSliceConfig(platformConfig, "FolderKeywords")
+	fileNamePatterns := getStringSliceConfig(platformConfig, "FileNamePatterns")
 
 	params := RepoParams{
 		ProjectKey: p.ProjectKey,
@@ -509,22 +530,23 @@ func analyseAzurebRepo(project interface{}, DestinationResult string, platformCo
 		MainBranch: p.MainBranch,
 		PathToScan: fmt.Sprintf("%s://%s@%s/%s/%s/%s/%s", platformConfig["Protocol"].(string), platformConfig["AccessToken"].(string), "dev.azure.com", platformConfig["Organization"].(string), p.ProjectKey, "_git", p.RepoSlug),
 	}
-	performRepoAnalysis(params, DestinationResult, spin, results, count, excludeExtensions, excludePath, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool))
+	performRepoAnalysis(params, DestinationResult, spin, results, count, excludeExtensions, excludePath, folderKeywords, fileNamePatterns, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool))
 }
 
 // Perform repository analysis (common logic)
-func performRepoAnalysis(params RepoParams, DestinationResult string, spin *spinner.Spinner, results chan int, count *int, excludeExtension []string, excludePaths []string, ResultByFile bool, ResultAll bool) {
+func performRepoAnalysis(params RepoParams, DestinationResult string, spin *spinner.Spinner, results chan int, count *int, excludeExtension []string, excludePaths []string, folderKeywords []string, fileNamePatterns []string, ResultByFile bool, ResultAll bool) {
 	// Always use a consistent filename pattern so downstream parsing works across platforms
 	// Format: Result_<OrgOrProjectKey>_<RepoSlug>_<Branch>
 	outputFileName := fmt.Sprintf("Result_%s_%s_%s", params.ProjectKey, params.RepoSlug, params.MainBranch)
 	golocParams := goloc.Params{
-		Path:         params.PathToScan,
-		ByFile:       ResultByFile,
-		ByAll:        ResultAll,
-		ExcludePaths: excludePaths,
-		//ExcludePaths:      []string{},
+		Path:             params.PathToScan,
+		ByFile:           ResultByFile,
+		ByAll:            ResultAll,
+		ExcludePaths:     excludePaths,
 		ExcludeExtensions: excludeExtension,
 		IncludeExtensions: []string{},
+		FolderKeywords:   folderKeywords,
+		FileNamePatterns: fileNamePatterns,
 		OrderByLang:       false,
 		OrderByFile:       false,
 		OrderByCode:       false,
@@ -715,7 +737,7 @@ func saveFileAnalysisResult(destDir, org string, dirs []string) error {
 /* ---------------- Analyse Directory ---------------- */
 
 // analyseDirectory runs the goloc analysis for a single directory entry.
-func analyseDirectory(dir string, ResultByFile, ResultAll bool, fileexclusionEX, extexclusion []string, destDir string, count *int) {
+func analyseDirectory(dir string, ResultByFile, ResultAll bool, fileexclusionEX, extexclusion, folderKeywords, fileNamePatterns []string, destDir string, count *int) {
 	params := goloc.Params{
 		Path:              dir,
 		ByFile:            ResultByFile,
@@ -723,6 +745,8 @@ func analyseDirectory(dir string, ResultByFile, ResultAll bool, fileexclusionEX,
 		ExcludePaths:      fileexclusionEX,
 		ExcludeExtensions: extexclusion,
 		IncludeExtensions: []string{},
+		FolderKeywords:    folderKeywords,
+		FileNamePatterns:  fileNamePatterns,
 		OrderByLang:       false,
 		OrderByFile:       false,
 		OrderByCode:       false,
@@ -794,7 +818,7 @@ func runGlocPasses(gc *goloc.GCloc, params goloc.Params, ResultAll bool) error {
 	return nil
 }
 
-func AnalyseReposListFile(Listdirectorie, fileexclusionEX []string, extexclusion []string, ResultByFile bool, ResultAll bool, destDir string) {
+func AnalyseReposListFile(Listdirectorie, fileexclusionEX []string, extexclusion, folderKeywords, fileNamePatterns []string, ResultByFile bool, ResultAll bool, destDir string) {
 	logger.Infof("🔎 Analysis of Directories ...\n")
 
 	var wg sync.WaitGroup
@@ -804,7 +828,7 @@ func AnalyseReposListFile(Listdirectorie, fileexclusionEX []string, extexclusion
 	for _, Listdirectories := range Listdirectorie {
 		go func(dir string) {
 			defer wg.Done()
-			analyseDirectory(dir, ResultByFile, ResultAll, fileexclusionEX, extexclusion, destDir, &count)
+			analyseDirectory(dir, ResultByFile, ResultAll, fileexclusionEX, extexclusion, folderKeywords, fileNamePatterns, destDir, &count)
 		}(Listdirectories)
 	}
 
@@ -1218,7 +1242,7 @@ func runGolcInProcess(platform string) {
 			}
 		}
 		startTime = time.Now()
-		AnalyseReposListFile(ListDirectory, ListExclusion, excludeExtensions, platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool), DestinationResult)
+		AnalyseReposListFile(ListDirectory, ListExclusion, excludeExtensions, getStringSliceConfig(platformConfig, "FolderKeywords"), getStringSliceConfig(platformConfig, "FileNamePatterns"), platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool), DestinationResult)
 
 		// Write analysis_result_file.json so ResultsAll can list the repos
 		if err := saveFileAnalysisResult(DestinationResult, platformConfig["Organization"].(string), ListDirectory); err != nil {

--- a/golc.go
+++ b/golc.go
@@ -398,14 +398,7 @@ func getExcludePaths(configValue interface{}) []string {
 }
 
 func getStringSliceConfig(platformConfig map[string]interface{}, key string) []string {
-	v, ok := platformConfig[key]
-	if !ok || v == nil {
-		return []string{}
-	}
-	if items, ok := v.([]interface{}); ok {
-		return convertToSliceString(items)
-	}
-	return []string{}
+	return getExcludePaths(platformConfig[key])
 }
 
 // Analysis functions for different repository types

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -7,11 +7,13 @@ import (
 )
 
 type Analyzer struct {
-	SupportedExtensions map[string]string
-	path                string
-	excludePaths        []string
-	excludeExtensions   map[string]bool
-	includeExtensions   map[string]bool
+	SupportedExtensions   map[string]string
+	path                  string
+	excludePaths          []string
+	excludeExtensions     map[string]bool
+	includeExtensions     map[string]bool
+	excludeFolderKeywords []string
+	excludeFilePatterns   []string
 }
 
 type FileMetadata struct {
@@ -26,13 +28,17 @@ func NewAnalyzer(
 	excludeExtensions map[string]bool,
 	includeExtensions map[string]bool,
 	extensions map[string]string,
+	excludeFolderKeywords []string,
+	excludeFilePatterns []string,
 ) *Analyzer {
 	return &Analyzer{
-		SupportedExtensions: extensions,
-		path:                path,
-		excludePaths:        excludePaths,
-		excludeExtensions:   excludeExtensions,
-		includeExtensions:   includeExtensions,
+		SupportedExtensions:   extensions,
+		path:                  path,
+		excludePaths:          excludePaths,
+		excludeExtensions:     excludeExtensions,
+		includeExtensions:     includeExtensions,
+		excludeFolderKeywords: excludeFolderKeywords,
+		excludeFilePatterns:   excludeFilePatterns,
 	}
 }
 
@@ -75,9 +81,35 @@ func (a *Analyzer) getFileExtension(path string) string {
 }
 
 func (a *Analyzer) canAdd(path string, extension string) bool {
+	// Exact prefix-based path exclusion (legacy behaviour, still supported)
 	for _, pathToExclude := range a.excludePaths {
 		if strings.HasPrefix(path, pathToExclude) {
 			return false
+		}
+	}
+
+	// Folder keyword exclusion: delimiter-aware word match on every folder segment at any depth
+	if len(a.excludeFolderKeywords) > 0 {
+		rel := strings.TrimPrefix(path, a.path+string(filepath.Separator))
+		dir := filepath.Dir(rel)
+		if dir != "." {
+			for _, segment := range strings.Split(dir, string(filepath.Separator)) {
+				for _, kw := range a.excludeFolderKeywords {
+					if folderSegmentContainsKeyword(segment, kw) {
+						return false
+					}
+				}
+			}
+		}
+	}
+
+	// File name pattern exclusion: standard * wildcard matched against the base name only
+	if len(a.excludeFilePatterns) > 0 {
+		base := filepath.Base(path)
+		for _, pattern := range a.excludeFilePatterns {
+			if matched, _ := filepath.Match(pattern, base); matched {
+				return false
+			}
 		}
 	}
 
@@ -92,4 +124,23 @@ func (a *Analyzer) canAdd(path string, extension string) bool {
 
 	_, ok := a.SupportedExtensions[extension]
 	return ok
+}
+
+// folderSegmentContainsKeyword returns true if kw is a whole word within segment.
+// Words are delimited by -, _ and . so "test" matches "integration-test" and
+// "test_helpers" but not "protest" or "latest".
+func folderSegmentContainsKeyword(segment, kw string) bool {
+	kw = strings.ToLower(kw)
+	segment = strings.ToLower(segment)
+	if segment == kw {
+		return true
+	}
+	for _, token := range strings.FieldsFunc(segment, func(r rune) bool {
+		return r == '-' || r == '_' || r == '.'
+	}) {
+		if token == kw {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -1,0 +1,114 @@
+package analyzer
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFolderSegmentContainsKeyword(t *testing.T) {
+	tests := []struct {
+		segment string
+		kw      string
+		want    bool
+	}{
+		// Exact match
+		{"test", "test", true},
+		{"vendor", "vendor", true},
+		// Delimiter-split matches
+		{"integration-test", "test", true},
+		{"test-helpers", "test", true},
+		{"my_test_suite", "test", true},
+		{"my.test.helpers", "test", true},
+		// Multiple delimiters
+		{"my.test_helpers", "test", true},
+		// Case insensitivity
+		{"Integration-Test", "test", true},
+		{"TEST", "test", true},
+		// Prefix substring — must NOT match
+		{"protest", "test", false},
+		{"testing", "test", false},
+		// Suffix substring — must NOT match
+		{"latest", "test", false},
+		{"contest", "test", false},
+		// Unrelated segments
+		{"src", "test", false},
+		{"main", "vendor", false},
+		// Generated keyword
+		{"generated-client", "generated", true},
+		{"generated_code", "generated", true},
+		{"ungenerated", "generated", false},
+	}
+
+	for _, tc := range tests {
+		got := folderSegmentContainsKeyword(tc.segment, tc.kw)
+		if got != tc.want {
+			t.Errorf("folderSegmentContainsKeyword(%q, %q) = %v, want %v", tc.segment, tc.kw, got, tc.want)
+		}
+	}
+}
+
+func TestCanAdd_FolderKeywords(t *testing.T) {
+	extensions := map[string]string{".go": "Golang"}
+	a := NewAnalyzer(
+		"/repo",
+		nil,
+		nil,
+		nil,
+		extensions,
+		[]string{"test", "vendor"},
+		nil,
+	)
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// Keyword matches at any depth
+		{filepath.Join("/repo", "test", "foo.go"), false},
+		{filepath.Join("/repo", "src", "integration-test", "foo.go"), false},
+		{filepath.Join("/repo", "src", "test_helpers", "foo.go"), false},
+		{filepath.Join("/repo", "vendor", "lib", "foo.go"), false},
+		// Non-matching paths
+		{filepath.Join("/repo", "src", "main.go"), true},
+		{filepath.Join("/repo", "protest", "foo.go"), true},  // substring, not whole word
+		{filepath.Join("/repo", "latest", "foo.go"), true},   // substring, not whole word
+	}
+
+	for _, tc := range tests {
+		got := a.canAdd(tc.path, ".go")
+		if got != tc.want {
+			t.Errorf("canAdd(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestCanAdd_FileNamePatterns(t *testing.T) {
+	extensions := map[string]string{".go": "Golang", ".js": "JavaScript"}
+	a := NewAnalyzer(
+		"/repo",
+		nil,
+		nil,
+		nil,
+		extensions,
+		nil,
+		[]string{"*_test.go", "*.min.js"},
+	)
+
+	tests := []struct {
+		path string
+		ext  string
+		want bool
+	}{
+		{filepath.Join("/repo", "src", "foo_test.go"), ".go", false},
+		{filepath.Join("/repo", "src", "bundle.min.js"), ".js", false},
+		{filepath.Join("/repo", "src", "main.go"), ".go", true},
+		{filepath.Join("/repo", "src", "app.js"), ".js", true},
+	}
+
+	for _, tc := range tests {
+		got := a.canAdd(tc.path, tc.ext)
+		if got != tc.want {
+			t.Errorf("canAdd(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}

--- a/pkg/goloc/goloc.go
+++ b/pkg/goloc/goloc.go
@@ -24,9 +24,11 @@ type Params struct {
 	Path              string
 	ByFile            bool
 	ByAll             bool
-	ExcludePaths      []string
-	ExcludeExtensions []string
-	IncludeExtensions []string
+	ExcludePaths        []string
+	ExcludeExtensions   []string
+	IncludeExtensions   []string
+	FolderKeywords      []string
+	FileNamePatterns    []string
 	OrderByLang       bool
 	OrderByFile       bool
 	OrderByCode       bool
@@ -215,6 +217,8 @@ func initAnalyzerScannerReporters(path string, params Params, excludePaths []str
 		utils.ConvertToMap(params.ExcludeExtensions),
 		utils.ConvertToMap(params.IncludeExtensions),
 		getExtensionsMap(languages),
+		params.FolderKeywords,
+		params.FileNamePatterns,
 	)
 	scanner := scanner.NewScanner(languages)
 

--- a/webui.go
+++ b/webui.go
@@ -141,12 +141,14 @@ var platformDefaults = map[string]map[string]interface{}{
 		"Multithreading": true, "Workers": float64(10), "NumberWorkerRepos": float64(10),
 		"ResultAll": true, "Org": true, "Period": float64(-1), "Factor": float64(33),
 		"DefaultBranch": true, "Stats": false, "ResultByFile": true,
+		"FolderKeywords": []interface{}{}, "FileNamePatterns": []interface{}{},
 	},
 	"GithubEnterprise": {
 		"DevOps": "github", "Apiver": "2022-11-28", "FileExclusion": "",
 		"Multithreading": true, "Workers": float64(10), "NumberWorkerRepos": float64(10),
 		"ResultAll": true, "Org": true, "Period": float64(-1), "Factor": float64(33),
 		"DefaultBranch": true, "Stats": false, "ResultByFile": true,
+		"FolderKeywords": []interface{}{}, "FileNamePatterns": []interface{}{},
 	},
 	"Gitlab": {
 		"DevOps": "gitlab", "Url": "https://gitlab.com/", "Apiver": "v4",
@@ -154,6 +156,7 @@ var platformDefaults = map[string]map[string]interface{}{
 		"Multithreading": true, "Workers": float64(10), "NumberWorkerRepos": float64(10),
 		"ResultAll": true, "Org": true, "Period": float64(-1), "Factor": float64(33),
 		"DefaultBranch": true, "Stats": false, "ResultByFile": true,
+		"FolderKeywords": []interface{}{}, "FileNamePatterns": []interface{}{},
 	},
 	"BitBucket": {
 		"DevOps": "bitbucket", "Url": "https://api.bitbucket.org/", "Apiver": "2.0",
@@ -161,6 +164,7 @@ var platformDefaults = map[string]map[string]interface{}{
 		"Multithreading": true, "Workers": float64(10), "NumberWorkerRepos": float64(10),
 		"ResultAll": true, "Org": true, "Period": float64(-1), "Factor": float64(33),
 		"DefaultBranch": true, "Stats": false, "ResultByFile": true,
+		"FolderKeywords": []interface{}{}, "FileNamePatterns": []interface{}{},
 	},
 	"BitBucketSRV": {
 		"DevOps": "bitbucket_dc", "Apiver": "1.0", "Baseapi": "rest/api/",
@@ -168,6 +172,7 @@ var platformDefaults = map[string]map[string]interface{}{
 		"Multithreading": true, "Workers": float64(10), "NumberWorkerRepos": float64(10),
 		"ResultAll": true, "Org": true, "Period": float64(-5), "Factor": float64(33),
 		"DefaultBranch": true, "Stats": false, "ResultByFile": true,
+		"FolderKeywords": []interface{}{}, "FileNamePatterns": []interface{}{},
 	},
 	"Azure": {
 		"DevOps": "azure", "Url": "https://dev.azure.com/", "Apiver": "7.1",
@@ -175,10 +180,12 @@ var platformDefaults = map[string]map[string]interface{}{
 		"Multithreading": true, "Workers": float64(10), "NumberWorkerRepos": float64(10),
 		"ResultAll": true, "Org": true, "Period": float64(-1), "Factor": float64(33),
 		"DefaultBranch": true, "Stats": false, "ResultByFile": true,
+		"FolderKeywords": []interface{}{}, "FileNamePatterns": []interface{}{},
 	},
 	"File": {
 		"DevOps": "file", "FileExclusion": "", "FileLoad": ".cloc_file_load",
 		"ResultAll": true, "ResultByFile": true, "ScanSubDirs": true,
+		"FolderKeywords": []interface{}{}, "FileNamePatterns": []interface{}{},
 	},
 }
 
@@ -1221,14 +1228,14 @@ const htmlTemplate = `<!DOCTYPE html>
               <label class="form-label d-block mb-2">Exclude from analysis</label>
               <div class="d-flex flex-wrap gap-3">
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="adv-excludeTests" onchange="syncPresetPaths()">
+                  <input class="form-check-input" type="checkbox" id="adv-excludeTests">
                   <label class="form-check-label form-label mb-0" for="adv-excludeTests">
                     <i class="fas fa-vial me-1" style="color:#60a5fa;"></i>Test directories
-                    <small class="text-muted d-block" style="font-size:.72rem;">test, tests, __tests__, spec, specs, e2e, testdata, fixtures, mocks</small>
+                    <small class="text-muted d-block" style="font-size:.72rem;">test, tests, spec, specs, e2e, testdata, fixtures, mocks, integration</small>
                   </label>
                 </div>
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="adv-excludeVendor" onchange="syncPresetPaths()">
+                  <input class="form-check-input" type="checkbox" id="adv-excludeVendor">
                   <label class="form-check-label form-label mb-0" for="adv-excludeVendor">
                     <i class="fas fa-box me-1" style="color:#a78bfa;"></i>Vendor &amp; modules
                     <small class="text-muted d-block" style="font-size:.72rem;">vendor, node_modules, bower_components, third_party, external</small>
@@ -1236,16 +1243,27 @@ const htmlTemplate = `<!DOCTYPE html>
                 </div>
               </div>
             </div>
+            <div class="col-md-6">
+              <label class="form-label" for="adv-folderKeywords">Exclude folder keywords <small class="text-muted">(comma-separated)</small></label>
+              <input class="form-control" id="adv-folderKeywords" placeholder="generated, legacy, migrations">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label" for="adv-filePatterns">Exclude file name patterns <small class="text-muted">(comma-separated)</small></label>
+              <input class="form-control" id="adv-filePatterns" placeholder="*_test.go, *.min.js, *.spec.ts">
+            </div>
             <div class="col-12">
-              <label class="form-label" for="adv-excludePaths">Additional exclude paths <small class="text-muted">(comma-separated, relative to repo root)</small></label>
-              <input class="form-control" id="adv-excludePaths" placeholder="pkg/generated,internal/legacy">
-              <div class="mt-2 px-3 py-2" style="background:rgba(96,165,250,.07);border-left:3px solid rgba(96,165,250,.4);border-radius:0 4px 4px 0;font-size:.75rem;color:#94a3b8;line-height:1.5;">
+              <div class="px-3 py-2" style="background:rgba(96,165,250,.07);border-left:3px solid rgba(96,165,250,.4);border-radius:0 4px 4px 0;font-size:.75rem;color:#94a3b8;line-height:1.7;">
                 <i class="fas fa-info-circle me-1" style="color:#60a5fa;"></i>
-                <strong style="color:#cbd5e1;">How exclusions work:</strong>
-                Paths are matched against the <strong style="color:#cbd5e1;">root of each cloned repository</strong> using glob patterns.
-                Once matched, exclusion is <strong style="color:#cbd5e1;">fully recursive</strong> — all files and subdirectories underneath are skipped.
-                For example, <code style="color:#93c5fd;">test</code> excludes <code style="color:#93c5fd;">/test/**</code> at the root, but not a nested <code style="color:#93c5fd;">src/test</code> directory.
-                To exclude a nested path, specify it explicitly: <code style="color:#93c5fd;">src/test</code>.
+                <strong style="color:#cbd5e1;">How exclusions work</strong>
+                <div class="mt-1"><strong style="color:#cbd5e1;">Folder keywords</strong> — excludes any folder whose name contains the keyword as a whole word, at <em>any</em> depth. Words are split on <code style="color:#93c5fd;">-</code> <code style="color:#93c5fd;">_</code> <code style="color:#93c5fd;">.</code></div>
+                <div style="font-family:monospace;margin:.25rem 0 .5rem .5rem;">
+                  <span style="color:#93c5fd;">test</span> → /test/, /integration-<span style="color:#93c5fd;">test</span>/, /<span style="color:#93c5fd;">test</span>-helpers/, /src/my_<span style="color:#93c5fd;">test</span>_suite/ &nbsp;<span style="color:#4ade80;">✓</span>&nbsp;&nbsp; /pro<span style="color:#f87171;">test</span>/, /la<span style="color:#f87171;">test</span>/ &nbsp;<span style="color:#f87171;">✗</span><br>
+                  <span style="color:#93c5fd;">generated</span> → /generated/, /src/<span style="color:#93c5fd;">generated</span>-client/, /api/<span style="color:#93c5fd;">generated</span>_code/
+                </div>
+                <div class="mt-1"><strong style="color:#cbd5e1;">File name patterns</strong> — standard <code style="color:#93c5fd;">*</code> wildcard matched against the file name only.</div>
+                <div style="font-family:monospace;margin:.25rem 0 0 .5rem;">
+                  <span style="color:#93c5fd;">*_test.go</span> → all Go test files &nbsp;&nbsp; <span style="color:#93c5fd;">*.min.js</span> → minified JS &nbsp;&nbsp; <span style="color:#93c5fd;">*.spec.ts</span> → TypeScript specs
+                </div>
               </div>
             </div>
             <div class="col-md-6" id="adv-repos-wrap">
@@ -1549,28 +1567,13 @@ function addDirRow(val) {
   list.appendChild(row);
 }
 
-const PRESET_TEST_PATHS   = ['test','tests','__tests__','spec','specs','e2e','testdata','fixtures','mocks','__mocks__','integration'];
-const PRESET_VENDOR_PATHS = ['vendor','node_modules','bower_components','third_party','external'];
-
-function syncPresetPaths() {
-  const excludeTests  = document.getElementById('adv-excludeTests').checked;
-  const excludeVendor = document.getElementById('adv-excludeVendor').checked;
-  const manualRaw = document.getElementById('adv-excludePaths').value;
-  // Strip preset paths from the manual field so they don't accumulate
-  const allPresets = new Set([...PRESET_TEST_PATHS, ...PRESET_VENDOR_PATHS]);
-  const manual = manualRaw.split(',').map(s=>s.trim()).filter(s=>s && !allPresets.has(s));
-  const active = [
-    ...(excludeTests  ? PRESET_TEST_PATHS  : []),
-    ...(excludeVendor ? PRESET_VENDOR_PATHS : []),
-    ...manual,
-  ];
-  document.getElementById('adv-excludePaths').value = active.join(',');
-}
+const PRESET_TEST_KEYWORDS   = ['test','tests','spec','specs','e2e','testdata','fixtures','mocks','integration'];
+const PRESET_VENDOR_KEYWORDS = ['vendor','node_modules','bower_components','third_party','external'];
 
 function populateAdvanced(key, saved) {
   const defaults = {DefaultBranch:true,Branch:'',Multithreading:true,Workers:10,
-    FileExclusion:'',ExtExclusion:[],ExcludePaths:[],ExcludeTests:false,ExcludeVendor:false,
-    Repos:'',Project:'',ResultByFile:true};
+    FileExclusion:'',ExtExclusion:[],ExcludeTests:false,ExcludeVendor:false,
+    FolderKeywords:[],FileNamePatterns:[],Repos:'',Project:'',ResultByFile:true};
   const cfg = Object.assign({}, defaults, saved);
 
   document.getElementById('adv-defaultBranch').checked = !!cfg.DefaultBranch;
@@ -1581,11 +1584,14 @@ function populateAdvanced(key, saved) {
     ? cfg.ExtExclusion.filter(Boolean).join(',') : (cfg.ExtExclusion||'');
   document.getElementById('adv-excludeTests').checked  = !!cfg.ExcludeTests;
   document.getElementById('adv-excludeVendor').checked = !!cfg.ExcludeVendor;
-  // Show additional paths (exclude preset paths — they're represented by the checkboxes)
-  const allPresets = new Set([...PRESET_TEST_PATHS, ...PRESET_VENDOR_PATHS]);
-  const storedPaths = Array.isArray(cfg.ExcludePaths) ? cfg.ExcludePaths : [];
-  const manualOnly = storedPaths.filter(p => p && !allPresets.has(p));
-  document.getElementById('adv-excludePaths').value = manualOnly.join(',');
+  // Show manual folder keywords (exclude preset keywords — they're represented by the checkboxes)
+  const allPresets = new Set([...PRESET_TEST_KEYWORDS, ...PRESET_VENDOR_KEYWORDS]);
+  const storedKeywords = Array.isArray(cfg.FolderKeywords) ? cfg.FolderKeywords : [];
+  const manualKeywords = storedKeywords.filter(k => k && !allPresets.has(k));
+  document.getElementById('adv-folderKeywords').value = manualKeywords.join(',');
+  // Show file name patterns
+  const storedPatterns = Array.isArray(cfg.FileNamePatterns) ? cfg.FileNamePatterns : [];
+  document.getElementById('adv-filePatterns').value = storedPatterns.filter(Boolean).join(',');
   document.getElementById('adv-repos').value = cfg.Repos || '';
   document.getElementById('adv-project').value = cfg.Project || '';
   syncBranchState();
@@ -1693,13 +1699,16 @@ function gatherConfig() {
   cfg.ExtExclusion = ext ? ext.split(',').map(s=>s.trim()).filter(Boolean) : [];
   cfg.ExcludeTests  = document.getElementById('adv-excludeTests').checked;
   cfg.ExcludeVendor = document.getElementById('adv-excludeVendor').checked;
-  const manualPaths = document.getElementById('adv-excludePaths').value.trim();
-  const manualArr   = manualPaths ? manualPaths.split(',').map(s=>s.trim()).filter(Boolean) : [];
-  const presetArr   = [
-    ...(cfg.ExcludeTests  ? PRESET_TEST_PATHS  : []),
-    ...(cfg.ExcludeVendor ? PRESET_VENDOR_PATHS : []),
+  const manualKwRaw = document.getElementById('adv-folderKeywords').value.trim();
+  const manualKw    = manualKwRaw ? manualKwRaw.split(',').map(s=>s.trim()).filter(Boolean) : [];
+  const presetKw    = [
+    ...(cfg.ExcludeTests  ? PRESET_TEST_KEYWORDS  : []),
+    ...(cfg.ExcludeVendor ? PRESET_VENDOR_KEYWORDS : []),
   ];
-  cfg.ExcludePaths  = [...new Set([...presetArr, ...manualArr])];
+  cfg.FolderKeywords = [...new Set([...presetKw, ...manualKw])];
+  const patRaw = document.getElementById('adv-filePatterns').value.trim();
+  cfg.FileNamePatterns = patRaw ? patRaw.split(',').map(s=>s.trim()).filter(Boolean) : [];
+  cfg.ExcludePaths = [];
   cfg.Repos = document.getElementById('adv-repos').value.trim();
   cfg.Project = document.getElementById('adv-project').value.trim();
   cfg.ResultByFile = true;

--- a/webui.go
+++ b/webui.go
@@ -1218,24 +1218,50 @@ const htmlTemplate = `<!DOCTYPE html>
               </div>
             </div>
 
-            <!-- Exclusions -->
-            <div class="col-md-6">
-              <label class="form-label" for="adv-extExclusion">Exclude extensions <small class="text-muted">(comma-separated)</small></label>
-              <input class="form-control" id="adv-extExclusion" placeholder=".css,.js">
+            <!-- Org vs personal toggle (GitHub only) -->
+            <div class="col-12" id="adv-org-wrap" style="display:none;">
+              <div style="background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.07);border-radius:8px;padding:.75rem 1rem;">
+                <div class="row g-2 align-items-center">
+                  <div class="col-md-6">
+                    <div class="form-check form-switch mt-1">
+                      <input class="form-check-input" type="checkbox" id="adv-org" checked>
+                      <label class="form-check-label form-label mb-0" for="adv-org">Analyze as organization</label>
+                    </div>
+                    <small class="text-muted" style="font-size:.72rem;">Uncheck to analyse a personal account instead of an organization.</small>
+                  </div>
+                </div>
+              </div>
             </div>
+
+            <!-- Repository / project scope -->
+            <div class="col-12" id="adv-repos-wrap">
+              <div class="d-flex gap-4 align-items-start">
+                <div style="flex:0 0 50%">
+                  <label class="form-label" for="adv-repos">Specific repositories <small class="text-muted" id="adv-repos-hint"></small></label>
+                  <input class="form-control" id="adv-repos">
+                </div>
+                <div id="adv-repos-desc" style="flex:1;padding-top:1.9rem;font-size:.75rem;color:#94a3b8;line-height:1.6;"></div>
+              </div>
+            </div>
+            <div class="col-md-6" id="adv-project-wrap">
+              <label class="form-label" for="adv-project">Specific project key</label>
+              <input class="form-control" id="adv-project" placeholder="PROJECT_KEY">
+            </div>
+
+            <!-- Exclusions -->
             <!-- Code exclusion presets -->
             <div class="col-12">
               <label class="form-label d-block mb-2">Exclude from analysis</label>
               <div class="d-flex flex-wrap gap-3">
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="adv-excludeTests">
+                  <input class="form-check-input" type="checkbox" id="adv-excludeTests" onchange="syncPresetKeywords()">
                   <label class="form-check-label form-label mb-0" for="adv-excludeTests">
                     <i class="fas fa-vial me-1" style="color:#60a5fa;"></i>Test directories
                     <small class="text-muted d-block" style="font-size:.72rem;">test, tests, spec, specs, e2e, testdata, fixtures, mocks, integration</small>
                   </label>
                 </div>
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="adv-excludeVendor">
+                  <input class="form-check-input" type="checkbox" id="adv-excludeVendor" onchange="syncPresetKeywords()">
                   <label class="form-check-label form-label mb-0" for="adv-excludeVendor">
                     <i class="fas fa-box me-1" style="color:#a78bfa;"></i>Vendor &amp; modules
                     <small class="text-muted d-block" style="font-size:.72rem;">vendor, node_modules, bower_components, third_party, external</small>
@@ -1243,13 +1269,17 @@ const htmlTemplate = `<!DOCTYPE html>
                 </div>
               </div>
             </div>
-            <div class="col-md-6">
+            <div class="col-12">
               <label class="form-label" for="adv-folderKeywords">Exclude folder keywords <small class="text-muted">(comma-separated)</small></label>
-              <input class="form-control" id="adv-folderKeywords" placeholder="generated, legacy, migrations">
+              <textarea class="form-control" id="adv-folderKeywords" rows="3" placeholder="generated, legacy, migrations"></textarea>
             </div>
             <div class="col-md-6">
               <label class="form-label" for="adv-filePatterns">Exclude file name patterns <small class="text-muted">(comma-separated)</small></label>
               <input class="form-control" id="adv-filePatterns" placeholder="*_test.go, *.min.js, *.spec.ts">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label" for="adv-extExclusion">Exclude extensions <small class="text-muted">(comma-separated)</small></label>
+              <input class="form-control" id="adv-extExclusion" placeholder=".css,.js">
             </div>
             <div class="col-12">
               <div class="px-3 py-2" style="background:rgba(96,165,250,.07);border-left:3px solid rgba(96,165,250,.4);border-radius:0 4px 4px 0;font-size:.75rem;color:#94a3b8;line-height:1.7;">
@@ -1261,18 +1291,14 @@ const htmlTemplate = `<!DOCTYPE html>
                   <span style="color:#93c5fd;">generated</span> → /generated/, /src/<span style="color:#93c5fd;">generated</span>-client/, /api/<span style="color:#93c5fd;">generated</span>_code/
                 </div>
                 <div class="mt-1"><strong style="color:#cbd5e1;">File name patterns</strong> — standard <code style="color:#93c5fd;">*</code> wildcard matched against the file name only.</div>
-                <div style="font-family:monospace;margin:.25rem 0 0 .5rem;">
+                <div style="font-family:monospace;margin:.25rem 0 .5rem .5rem;">
                   <span style="color:#93c5fd;">*_test.go</span> → all Go test files &nbsp;&nbsp; <span style="color:#93c5fd;">*.min.js</span> → minified JS &nbsp;&nbsp; <span style="color:#93c5fd;">*.spec.ts</span> → TypeScript specs
                 </div>
+                <div class="mt-1"><strong style="color:#cbd5e1;">Extensions</strong> — skips every file with a matching extension, regardless of language.</div>
+                <div style="font-family:monospace;margin:.25rem 0 0 .5rem;">
+                  <span style="color:#93c5fd;">.css,.html</span> → skip all CSS and HTML files &nbsp;&nbsp; <span style="color:#93c5fd;">.min.js</span> → skip minified bundles
+                </div>
               </div>
-            </div>
-            <div class="col-md-6" id="adv-repos-wrap">
-              <label class="form-label" for="adv-repos">Specific repositories <small class="text-muted">(comma-separated slugs)</small></label>
-              <input class="form-control" id="adv-repos" placeholder="repo-slug1,repo-slug2">
-            </div>
-            <div class="col-md-6" id="adv-project-wrap">
-              <label class="form-label" for="adv-project">Specific project key</label>
-              <input class="form-control" id="adv-project" placeholder="PROJECT_KEY">
             </div>
           </div>
         </div>
@@ -1431,7 +1457,15 @@ async function selectPlatform(key) {
   document.getElementById('adv-mt-wrap').style.display = isFile ? 'none' : '';
   document.getElementById('adv-workers-wrap').style.display = isFile ? 'none' : '';
   document.getElementById('adv-defaultBranch-wrap').style.display = isFile ? 'none' : '';
-  document.getElementById('adv-repos-wrap').style.display = isFile ? 'none' : '';
+  document.getElementById('adv-repos-wrap').style.display = (isFile || key === 'Gitlab') ? 'none' : '';
+  const isGithub = key === 'Github' || key === 'GithubEnterprise';
+  document.getElementById('adv-org-wrap').style.display = isGithub ? '' : 'none';
+  const reposDesc = document.getElementById('adv-repos-desc');
+  if (reposDesc) reposDesc.innerHTML = reposDescriptions[key] || '';
+  const reposHint = document.getElementById('adv-repos-hint');
+  if (reposHint) reposHint.textContent = reposHints[key] || '';
+  const reposInput = document.getElementById('adv-repos');
+  if (reposInput) reposInput.placeholder = reposPlaceholders[key] || '';
 
   goToStep(2);
 }
@@ -1567,13 +1601,54 @@ function addDirRow(val) {
   list.appendChild(row);
 }
 
+const reposDescriptions = {
+  Github:           'Analyse only these repositories. Enter repository names only — the organization is already set above (e.g. <code>api-service</code>, <code>backend</code>). Leave empty to analyse all repositories in the organization.',
+  GithubEnterprise: 'Analyse only these repositories. Enter repository names only — the organization is already set above (e.g. <code>api-service</code>, <code>backend</code>). Leave empty to analyse all repositories in the organization.',
+  Gitlab:           '<i class="fas fa-info-circle me-1"></i>Not applicable for GitLab — use the <em>Group URL slug(s)</em> field above to scope which groups are analysed.',
+  BitBucket:        'Analyse only these repositories. Enter slugs as they appear in Bitbucket Cloud (e.g. <code>my-repo</code>). Leave empty to analyse all repositories in the workspace.',
+  BitBucketSRV:     'Analyse only these repositories. Enter slugs as they appear in Bitbucket Data Center (e.g. <code>my-repo</code>). Leave empty to analyse all repositories in the organization.',
+  Azure:            'Enter <strong>repository names</strong> as they appear in Azure DevOps (e.g. <code>my-service</code>, <code>backend-api</code>). Note: this is the repository name, not the project name — use the <em>Specific project key</em> field above to scope by project. Leave empty to analyse all repositories.',
+};
+
+const reposHints = {
+  Github:           '(comma-separated repository names)',
+  GithubEnterprise: '(comma-separated repository names)',
+  Gitlab:           '(comma-separated paths)',
+  BitBucket:        '(comma-separated slugs)',
+  BitBucketSRV:     '(comma-separated slugs)',
+  Azure:            '(comma-separated repository names)',
+};
+
+const reposPlaceholders = {
+  Github:           'api-service, backend',
+  GithubEnterprise: 'api-service, backend',
+  Gitlab:           'my-group/my-project, my-group/other-project',
+  BitBucket:        'my-repo, another-repo',
+  BitBucketSRV:     'my-repo, another-repo',
+  Azure:            'my-service, backend-api',
+};
+
 const PRESET_TEST_KEYWORDS   = ['test','tests','spec','specs','e2e','testdata','fixtures','mocks','integration'];
 const PRESET_VENDOR_KEYWORDS = ['vendor','node_modules','bower_components','third_party','external'];
+
+function syncPresetKeywords() {
+  const excludeTests  = document.getElementById('adv-excludeTests').checked;
+  const excludeVendor = document.getElementById('adv-excludeVendor').checked;
+  const allPresets = new Set([...PRESET_TEST_KEYWORDS, ...PRESET_VENDOR_KEYWORDS]);
+  const raw = document.getElementById('adv-folderKeywords').value;
+  const manual = raw.split(',').map(s=>s.trim()).filter(s=>s && !allPresets.has(s));
+  const active = [
+    ...(excludeTests  ? PRESET_TEST_KEYWORDS  : []),
+    ...(excludeVendor ? PRESET_VENDOR_KEYWORDS : []),
+    ...manual,
+  ];
+  document.getElementById('adv-folderKeywords').value = active.join(', ');
+}
 
 function populateAdvanced(key, saved) {
   const defaults = {DefaultBranch:true,Branch:'',Multithreading:true,Workers:10,
     FileExclusion:'',ExtExclusion:[],ExcludeTests:false,ExcludeVendor:false,
-    FolderKeywords:[],FileNamePatterns:[],Repos:'',Project:'',ResultByFile:true};
+    FolderKeywords:[],FileNamePatterns:[],Repos:'',Project:'',ResultByFile:true,Org:true};
   const cfg = Object.assign({}, defaults, saved);
 
   document.getElementById('adv-defaultBranch').checked = !!cfg.DefaultBranch;
@@ -1582,16 +1657,16 @@ function populateAdvanced(key, saved) {
   document.getElementById('adv-workers').value = cfg.Workers || 10;
   document.getElementById('adv-extExclusion').value = Array.isArray(cfg.ExtExclusion)
     ? cfg.ExtExclusion.filter(Boolean).join(',') : (cfg.ExtExclusion||'');
+  document.getElementById('adv-org').checked = cfg.Org !== false;
   document.getElementById('adv-excludeTests').checked  = !!cfg.ExcludeTests;
   document.getElementById('adv-excludeVendor').checked = !!cfg.ExcludeVendor;
-  // Show manual folder keywords (exclude preset keywords — they're represented by the checkboxes)
+  // Seed the text field with manual-only keywords, then let syncPresetKeywords prepend checked presets
   const allPresets = new Set([...PRESET_TEST_KEYWORDS, ...PRESET_VENDOR_KEYWORDS]);
   const storedKeywords = Array.isArray(cfg.FolderKeywords) ? cfg.FolderKeywords : [];
-  const manualKeywords = storedKeywords.filter(k => k && !allPresets.has(k));
-  document.getElementById('adv-folderKeywords').value = manualKeywords.join(',');
-  // Show file name patterns
+  document.getElementById('adv-folderKeywords').value = storedKeywords.filter(k => k && !allPresets.has(k)).join(', ');
+  syncPresetKeywords();
   const storedPatterns = Array.isArray(cfg.FileNamePatterns) ? cfg.FileNamePatterns : [];
-  document.getElementById('adv-filePatterns').value = storedPatterns.filter(Boolean).join(',');
+  document.getElementById('adv-filePatterns').value = storedPatterns.filter(Boolean).join(', ');
   document.getElementById('adv-repos').value = cfg.Repos || '';
   document.getElementById('adv-project').value = cfg.Project || '';
   syncBranchState();
@@ -1697,15 +1772,12 @@ function gatherConfig() {
   cfg.FileExclusion = '';
   const ext = document.getElementById('adv-extExclusion').value.trim();
   cfg.ExtExclusion = ext ? ext.split(',').map(s=>s.trim()).filter(Boolean) : [];
+  cfg.Org = document.getElementById('adv-org').checked;
   cfg.ExcludeTests  = document.getElementById('adv-excludeTests').checked;
   cfg.ExcludeVendor = document.getElementById('adv-excludeVendor').checked;
-  const manualKwRaw = document.getElementById('adv-folderKeywords').value.trim();
-  const manualKw    = manualKwRaw ? manualKwRaw.split(',').map(s=>s.trim()).filter(Boolean) : [];
-  const presetKw    = [
-    ...(cfg.ExcludeTests  ? PRESET_TEST_KEYWORDS  : []),
-    ...(cfg.ExcludeVendor ? PRESET_VENDOR_KEYWORDS : []),
-  ];
-  cfg.FolderKeywords = [...new Set([...presetKw, ...manualKw])];
+  // Text field already contains preset keywords (kept in sync by syncPresetKeywords)
+  const kwRaw = document.getElementById('adv-folderKeywords').value.trim();
+  cfg.FolderKeywords = kwRaw ? [...new Set(kwRaw.split(',').map(s=>s.trim()).filter(Boolean))] : [];
   const patRaw = document.getElementById('adv-filePatterns').value.trim();
   cfg.FileNamePatterns = patRaw ? patRaw.split(',').map(s=>s.trim()).filter(Boolean) : [];
   cfg.ExcludePaths = [];


### PR DESCRIPTION
## Summary

- **New exclusion system**: replaced `ExcludePaths` with `FolderKeywords` (delimiter-aware word-boundary matching at any depth — `test` matches `integration-test/` but not `protest/`) and `FileNamePatterns` (glob against file name only). Preset checkboxes (Test directories, Vendor & modules) now visually populate the keywords field.
- **Exclusions layout**: folder keywords input is full-width textarea; file name patterns and extensions share the row below; guide panel updated with examples for all three exclusion types.
- **Specific repositories** moved before the exclusion section with platform-specific description, hint text, and placeholder per platform. Hidden entirely for GitLab (field has no effect there).
- **Org / personal toggle** restored for GitHub and GitHub Enterprise, defaulting to Organization.
- **README** `Optional Parameters` table updated: removed `ExcludePaths`, added `FolderKeywords`, `FileNamePatterns`, `ExcludeTests`, `ExcludeVendor`; clarified `Repos` (per-platform format) and `Org` fields.

## Test plan

- [ ] Test directories / Vendor & modules checkboxes populate the folder keywords field correctly on check/uncheck
- [ ] Manual keywords survive preset toggle without duplication
- [ ] File name patterns and extension exclusion fields save and restore correctly
- [ ] Specific repositories field shows correct platform-specific hint and placeholder for each platform; hidden on GitLab
- [ ] Org toggle appears only on GitHub / GitHub Enterprise; defaults to checked; personal-account analysis works when unchecked
- [ ] README Optional Parameters table matches actual behavior