### PR TITLE
feat: add debug logging system with downloadable debug.log from webui

### DIFF
--- a/golc.go
+++ b/golc.go
@@ -64,12 +64,7 @@ type SelfLink struct {
 
 type Config struct {
 	Platforms map[string]interface{} `json:"platforms"`
-	Logging   LoggingConfig          `json:"logging"`
 	Release   ReleaseConfig          `json:"release"`
-}
-
-type LoggingConfig struct {
-	Level logrus.Level `json:"level"`
 }
 
 type ReleaseConfig struct {

--- a/golc.go
+++ b/golc.go
@@ -987,9 +987,8 @@ func runGolcInProcess(platform string) {
 	}
 	_ = os.Remove("Logs/Logs.log")
 	_ = os.Remove("Logs/debug.log")
-	logger = utils.NewLogger()
-	// Do not override the level: NewLogger sets DebugLevel so all entries reach the hooks.
-	// The infoAndAbove hook already gates what appears on stdout/SSE.
+	utils.ResetSharedLogger()
+	logger = utils.SharedLogger()
 	logger.Info("✅ Configuration loaded successfully and version matched!")
 
 	// Resolve platform config

--- a/golc.go
+++ b/golc.go
@@ -1390,13 +1390,9 @@ func runGolcInProcess(platform string) {
 		os.Exit(1)
 	}
 
-	// Repository summary reports are only applicable to DevOps platform modes,
-	// not file mode (which has no platform-specific analysis_result_*.json).
-	if platformConfig["DevOps"].(string) != "file" {
-		err = utils.GenerateRepositorySummaryReports(baseResultsDir)
-		if err != nil {
-			logger.Errorf("❌ Error creating repository summary reports: %v", err)
-		}
+	err = utils.GenerateRepositorySummaryReports(baseResultsDir)
+	if err != nil {
+		logger.Errorf("❌ Error creating repository summary reports: %v", err)
 	}
 
 	fmt.Printf("\n")

--- a/golc.go
+++ b/golc.go
@@ -986,8 +986,10 @@ func runGolcInProcess(platform string) {
 		}
 	}
 	_ = os.Remove("Logs/Logs.log")
+	_ = os.Remove("Logs/debug.log")
 	logger = utils.NewLogger()
-	logger.SetLevel(AppConfig.Logging.Level)
+	// Do not override the level: NewLogger sets DebugLevel so all entries reach the hooks.
+	// The infoAndAbove hook already gates what appears on stdout/SSE.
 	logger.Info("✅ Configuration loaded successfully and version matched!")
 
 	// Resolve platform config
@@ -1208,6 +1210,9 @@ func runGolcInProcess(platform string) {
 				}
 			}
 		}
+		logger.Debugf("→ file mode: %d exclusion(s) loaded", len(ListExclusion))
+		logger.Debugf("→ file mode: %d director(ies) to scan", len(ListDirectory))
+
 		// Expand to immediate subdirectories when ScanSubDirs is set
 		scanSubDirs, _ := platformConfig["ScanSubDirs"].(bool)
 		if scanSubDirs {
@@ -1232,7 +1237,11 @@ func runGolcInProcess(platform string) {
 			}
 			if len(expanded) > 0 {
 				ListDirectory = expanded
+				logger.Debugf("→ file mode: ScanSubDirs expanded to %d director(ies)", len(ListDirectory))
 			}
+		}
+		for _, d := range ListDirectory {
+			logger.Debugf("→ directory %s: analyzing", d)
 		}
 		startTime = time.Now()
 		AnalyseReposListFile(ListDirectory, ListExclusion, excludeExtensions, getStringSliceConfig(platformConfig, "FolderKeywords"), getStringSliceConfig(platformConfig, "FileNamePatterns"), platformConfig["ResultByFile"].(bool), platformConfig["ResultAll"].(bool), DestinationResult)
@@ -1432,16 +1441,5 @@ func runGolcInProcess(platform string) {
 		logger.Errorf("❌ Error writing to file:%v", err)
 		return
 	}
-
-	/*if platformConfig["ResultByFile"].(bool) {
-		logger.Infof(" ℹ️  To generate and visualize results on a web interface, follow these steps: ")
-		logger.Infof("\t✅ run : ResultByfiles")
-	} else {*/
-
-	logger.Infof(" ℹ️  To generate and visualize results on a web interface, follow these steps: ")
-	logger.Infof("\t✅ run : ResultsAll")
-	//}
-	//fmt.Println("\nℹ️  To generate and visualize results on a web interface, follow these steps: ")
-	//fmt.Println("\t✅ run : ResultsAll")
 
 }

--- a/golc.go
+++ b/golc.go
@@ -1390,12 +1390,13 @@ func runGolcInProcess(platform string) {
 		os.Exit(1)
 	}
 
-	// Generate Repository Summary Reports
-	// Ensure we pass the base Results directory to generate summary reports,
-	// since it creates outputs under <Results>/byfile-report/*.
-	err = utils.GenerateRepositorySummaryReports(baseResultsDir)
-	if err != nil {
-		logger.Errorf("❌ Error creating repository summary reports: %v", err)
+	// Repository summary reports are only applicable to DevOps platform modes,
+	// not file mode (which has no platform-specific analysis_result_*.json).
+	if platformConfig["DevOps"].(string) != "file" {
+		err = utils.GenerateRepositorySummaryReports(baseResultsDir)
+		if err != nil {
+			logger.Errorf("❌ Error creating repository summary reports: %v", err)
+		}
 	}
 
 	fmt.Printf("\n")

--- a/pkg/devops/getazure/getazure.go
+++ b/pkg/devops/getazure/getazure.go
@@ -213,7 +213,7 @@ func GetRepoAzureList(platformConfig map[string]interface{}, exclusionFile strin
 	var largestRepoBranch, largesRepo string
 	var exclusionList *utils.ExclusionList
 	var err error
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	ApiURL := platformConfig["Url"].(string) + platformConfig["Organization"].(string)
 
@@ -375,7 +375,7 @@ func findLargestRepository(importantBranches []ProjectBranch, totalSize *int64) 
 
 func printSummary(Org string, stats SummaryStats) {
 
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	loggers.Infof("✅ The largest Repository is <%s> in the organization <%s> with the branch <%s> ", stats.LargestRepo, Org, stats.LargestRepoBranch)
 	loggers.Infof("✅ Total Repositories that will be analyzed: %d - Find empty : %d - Excluded : %d - Archived : %d", stats.NbRepos-stats.EmptyRepo-stats.TotalExclude-stats.TotalArchiv, stats.EmptyRepo, stats.TotalExclude, stats.TotalArchiv)
@@ -389,7 +389,7 @@ func getRepoAnalyse(params ParamsProjectAzure, gitClient git.Client) ([]ProjectB
 	var importantBranches []ProjectBranch
 	var NBRrepo, TotalBranches int
 	var messageF = ""
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	NBRrepos := 0
 	cptarchiv := 0
@@ -482,7 +482,7 @@ func getRepoAnalyse(params ParamsProjectAzure, gitClient git.Client) ([]ProjectB
 func listReposForProject(parms ParamsProjectAzure, projectKey string, gitClient git.Client) (int, int, int, []git.GitRepository, error) {
 	var allRepos []git.GitRepository
 	var archivedCount, emptyCount, excludedCount int
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	// Convert SingleRepos to a slice if it's not empty
 	var singleReposList []string
@@ -551,7 +551,7 @@ func analyzeRepoBranches(parms ParamsProjectAzure, projectKey string, repo strin
 	var nbrbranch int
 	var err error
 	var brsize int64
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	largestRepoBranch, brsize, nbrbranch, err = getMostImportantBranch(parms.Context, gitClient, projectKey, repo, parms.Period, parms.DefaultB, parms.SingleBranch)
 	if err != nil {
@@ -724,7 +724,7 @@ func getCommitCount(ctx context.Context, gitClient git.Client, projectID string,
 }
 func SaveResult(result AnalysisResult) error {
 
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	// Open or create the file
 	file, err := os.Create("Results/config/analysis_result_azure.json")
 	if err != nil {

--- a/pkg/devops/getazure/getazure.go
+++ b/pkg/devops/getazure/getazure.go
@@ -442,7 +442,7 @@ func getRepoAnalyse(params ParamsProjectAzure, gitClient git.Client) ([]ProjectB
 		}
 
 		for _, repo := range repos {
-
+			loggers.Debugf("→ repo %s/%s: analyzing", *project.Name, *repo.Name)
 			largestRepoBranch, repobranches, brsize, err := analyzeRepoBranches(params, *project.Name, *repo.Name, gitClient, cpt, spin1)
 
 			if err != nil {
@@ -491,6 +491,7 @@ func listReposForProject(parms ParamsProjectAzure, projectKey string, gitClient 
 	}
 
 	// Get repositories
+	loggers.Debugf("→ project %s: fetching repos from API", projectKey)
 	repos, err := gitClient.GetRepositories(parms.Context, git.GetRepositoriesArgs{
 		Project: &projectKey,
 	})
@@ -498,17 +499,20 @@ func listReposForProject(parms ParamsProjectAzure, projectKey string, gitClient 
 		loggers.Errorf("Error get GetRepositories ")
 		return 0, 0, 0, nil, err
 	}
+	loggers.Debugf("→ project %s: API returned %d repos", projectKey, len(*repos))
 
 	for _, repo := range *repos {
 		repoName := *repo.Name
 
 		// If SingleRepos is specified, skip repositories not in the list
 		if len(parms.SingleRepos) > 0 && !contains(singleReposList, repoName) {
+			loggers.Debugf("→ repo %s/%s: skipped (not in single-repo filter)", projectKey, repoName)
 			continue
 		}
 
 		// check if exclude
 		if isRepoExcluded(parms.Exclusionlist, projectKey, repoName) {
+			loggers.Debugf("→ repo %s/%s: skipped (excluded)", projectKey, repoName)
 			excludedCount++
 			continue
 		}
@@ -520,6 +524,7 @@ func listReposForProject(parms ParamsProjectAzure, projectKey string, gitClient 
 			return 0, 0, 0, nil, err
 		}
 		if isEmpty {
+			loggers.Debugf("→ repo %s/%s: skipped (empty)", projectKey, repoName)
 			emptyCount++
 			continue
 		}

--- a/pkg/devops/getbitbucket/getbitbucket.go
+++ b/pkg/devops/getbitbucket/getbitbucket.go
@@ -420,6 +420,7 @@ func getAllProjects(client *bitbucket.Client, workspace string, exclusionList *u
 func getAllProjectsWithAuth(workspace, accessToken, users, bitbucketURLBase string, exclusionList *utils.ExclusionList) ([]Projectc, int, error) {
 	var projects []Projectc
 	var excludedCount int
+	loggers := utils.NewLogger()
 
 	url := fmt.Sprintf("%sworkspaces/%s/projects", bitbucketURLBase, workspace)
 
@@ -429,11 +430,13 @@ func getAllProjectsWithAuth(workspace, accessToken, users, bitbucketURLBase stri
 	}
 	req.Header.Set("Authorization", getAuthHeader(users, accessToken))
 
+	loggers.Debugf("GET %s", url)
 	resp, err := utils.HTTPClient.Do(req)
 	if err != nil {
 		return nil, 0, err
 	}
 	defer resp.Body.Close()
+	loggers.Debugf("GET %s → %s", url, resp.Status)
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -518,6 +521,7 @@ func getAllProjectsWithAuth(workspace, accessToken, users, bitbucketURLBase stri
 func getSepecificProjectsWithAuth(workspace, projectKeys, accessToken, users, bitbucketURLBase string, exclusionList *utils.ExclusionList) ([]Projectc, int, error) {
 	var projects []Projectc
 	var excludedCount int
+	loggers := utils.NewLogger()
 
 	// Split projectKeys by comma if multiple projects are specified
 	projectKeyList := strings.Split(projectKeys, ",")
@@ -536,10 +540,12 @@ func getSepecificProjectsWithAuth(workspace, projectKeys, accessToken, users, bi
 		}
 		req.Header.Set("Authorization", getAuthHeader(users, accessToken))
 
+		loggers.Debugf("GET %s", url)
 		resp, err := utils.HTTPClient.Do(req)
 		if err != nil {
 			continue
 		}
+		loggers.Debugf("GET %s → %s", url, resp.Status)
 
 		if resp.StatusCode != http.StatusOK {
 			resp.Body.Close()
@@ -800,6 +806,7 @@ func listRepos(parms ParamsProjectBitbucket, projectKey string, reposRes *bitbuc
 		for _, repo := range reposRes.Items {
 			repoCopy := repo
 			if isRepoExcluded(parms.Exclusionlist, projectKey, repo.Slug) {
+				loggers.Debugf("→ repo %s/%s: skipped (excluded)", projectKey, repo.Slug)
 				excludedCount++
 				continue
 			}
@@ -809,9 +816,11 @@ func listRepos(parms ParamsProjectBitbucket, projectKey string, reposRes *bitbuc
 				loggers.Errorf("❌ Error when Testing if repo is empty %s: %v\n", repo.Slug, err)
 			}
 			if isEmpty {
+				loggers.Debugf("→ repo %s/%s: skipped (empty)", projectKey, repo.Slug)
 				emptyOrArchivedCount++
 				continue
 			}
+			loggers.Debugf("→ repo %s/%s: analyzing", projectKey, repo.Slug)
 			allRepos = append(allRepos, &repoCopy)
 		}
 	} else {

--- a/pkg/devops/getbitbucket/getbitbucket.go
+++ b/pkg/devops/getbitbucket/getbitbucket.go
@@ -140,7 +140,7 @@ func GetProjectBitbucketListCloud(platformConfig map[string]interface{}, exclusi
 	var exclusionList *utils.ExclusionList
 	var err error
 	var totalSize int
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	//	result := AnalysisResult{}
 
@@ -241,7 +241,7 @@ func findLargestRepository(importantBranches []ProjectBranch, totalSize *int) (s
 
 func printSummary(Org string, stats SummaryStats) {
 
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	loggers.Infof("✅ The largest Repository is <%s> in the organization <%s> with the branch <%s> ", stats.LargestRepo, Org, stats.LargestRepoBranch)
 	loggers.Infof("✅ Total Repositories that will be analyzed: %d - Find empty : %d - Excluded : %d - Archived : %d", stats.NbRepos-stats.EmptyRepo-stats.TotalExclude-stats.TotalArchiv, stats.EmptyRepo, stats.TotalExclude, stats.TotalArchiv)
@@ -420,7 +420,7 @@ func getAllProjects(client *bitbucket.Client, workspace string, exclusionList *u
 func getAllProjectsWithAuth(workspace, accessToken, users, bitbucketURLBase string, exclusionList *utils.ExclusionList) ([]Projectc, int, error) {
 	var projects []Projectc
 	var excludedCount int
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	url := fmt.Sprintf("%sworkspaces/%s/projects", bitbucketURLBase, workspace)
 
@@ -521,7 +521,7 @@ func getAllProjectsWithAuth(workspace, accessToken, users, bitbucketURLBase stri
 func getSepecificProjectsWithAuth(workspace, projectKeys, accessToken, users, bitbucketURLBase string, exclusionList *utils.ExclusionList) ([]Projectc, int, error) {
 	var projects []Projectc
 	var excludedCount int
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	// Split projectKeys by comma if multiple projects are specified
 	projectKeyList := strings.Split(projectKeys, ",")
@@ -617,7 +617,7 @@ func getRepoAnalyse(params ParamsProjectBitbucket) ([]ProjectBranch, int, int, i
 	var importantBranches []ProjectBranch
 	var NBRrepo, TotalBranches int
 	var messageF = ""
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	NBRrepos := 0
 	cptarchiv := 0
 
@@ -799,7 +799,7 @@ func listReposForProject(parms ParamsProjectBitbucket, projectKey string) (int, 
 func listRepos(parms ParamsProjectBitbucket, projectKey string, reposRes *bitbucket.RepositoriesRes) (int, int, []*bitbucket.Repository, error) {
 	var allRepos []*bitbucket.Repository
 	var excludedCount, emptyOrArchivedCount int
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	if len(parms.SingleRepos) == 0 {
 
@@ -931,7 +931,7 @@ func analyzeRepoBranches(parms ParamsProjectBitbucket, repo *bitbucket.Repositor
 	var largestRepoBranch string
 	var err error
 	var brsize, nbrbranche int
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	spin1.Prefix = "\r Analyzing branches"
 	spin1.Start()
@@ -1031,7 +1031,7 @@ func getAllBranches(client *bitbucket.Client, workspace, repoSlug string) ([]*bi
 func determineLargestBranch(parms ParamsProjectBitbucket, repo *bitbucket.Repository, branches []*bitbucket.RepositoryBranch) (string, int) {
 	var largestRepoBranch string
 	var maxCommits, branchSize int
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	for _, branch := range branches {
 		commits, err := getCommitsForLastMonth(parms.Client, parms.Workspace, repo.Slug, branch.Name, parms.Period)
@@ -1062,7 +1062,7 @@ func determineLargestBranch(parms ParamsProjectBitbucket, repo *bitbucket.Reposi
 func getCommitsForLastMonth(client *bitbucket.Client, workspace, repoSlug, branchName string, periode int) ([]interface{}, error) {
 	now := time.Now()
 	lastMonth := now.AddDate(0, -periode, 0)
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	commits, err := client.Repositories.Commits.GetCommits(&bitbucket.CommitsOptions{
 		Owner:       workspace,
@@ -1092,7 +1092,7 @@ func getCommitsForLastMonth(client *bitbucket.Client, workspace, repoSlug, branc
 
 func SaveResult(result AnalysisResult) error {
 
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	// Open or create the file
 	file, err := os.Create("Results/config/analysis_result_bitbucket.json")
 	if err != nil {

--- a/pkg/devops/getbitbucketdc/getbitbucketdc.go
+++ b/pkg/devops/getbitbucketdc/getbitbucketdc.go
@@ -201,7 +201,7 @@ func GetReposProject(projects []Project, parms ParamsReposProjectDC, bitbucketUR
 	var importantBranches []ProjectBranch
 	emptyRepo := 0
 	result := AnalysisResult{}
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	spin1 := spinner.New(spinner.CharSets[35], 100*time.Millisecond)
 	spin1.Prefix = "Get Projects... "
@@ -251,7 +251,7 @@ func GetReposProject(projects []Project, parms ParamsReposProjectDC, bitbucketUR
 
 func processRepo(projectKey string, repo Repo, parms ParamsReposProjectDC, bitbucketURLBase string, spin1 *spinner.Spinner, importantBranches *[]ProjectBranch) error {
 
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	isEmpty, err := isRepositoryEmpty(projectKey, repo.Slug, parms.AccessToken, bitbucketURLBase, parms.APIVersion)
 	if err != nil {
 		return fmt.Errorf("testing if repo is empty %s: %w", repo.Name, err)
@@ -347,7 +347,7 @@ func GetRepos(project string, repos []Repo, parms ParamsReposDC, bitbucketURLBas
 	var largestRepoBranch string
 	var importantBranches []ProjectBranch
 	var branches []Branch
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	emptyRepo := 0
 	nbRepos := 1
 	result := AnalysisResult{}
@@ -406,7 +406,7 @@ func GetRepos(project string, repos []Repo, parms ParamsReposDC, bitbucketURLBas
 }
 
 func logAndExit(message string, spin *spinner.Spinner) {
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	loggers.Errorln(message)
 	if spin != nil {
 		spin.Stop()
@@ -439,7 +439,7 @@ func getBranches(project, repoSlug string, parms ParamsReposDC) ([]Branch, error
 func getBranches1(projectKey string, repo Repo, parms ParamsReposProjectDC) ([]Branch, error) {
 	var branches []Branch
 	var err error
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	if parms.DefaultB {
 		urlbr := fmt.Sprintf("%s%s%s/projects/%s/repos/%s/branches?limit=100", parms.URL, parms.BaseAPI, parms.APIVersion, projectKey, repo.Slug)
@@ -466,7 +466,7 @@ func getBranches1(projectKey string, repo Repo, parms ParamsReposProjectDC) ([]B
 func findLargestBranch(project, repoSlug string, branches []Branch, parms ParamsReposDC) (int, string, error) {
 	var largestRepoSize int
 	var largestRepoBranch string
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	for _, branch := range branches {
 		parms.Spin.Prefix = fmt.Sprintf("\t   Analysis branch <%s> size...", branch.Name)
@@ -556,7 +556,7 @@ func GetProjectBitbucketList(platformConfig map[string]interface{}, exclusionFil
 	var exclusionList *utils.ExclusionList
 	var err error
 	var nbRepos int
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	bitbucketURLBase := platformConfig["Url"].(string)
 	bitbucketURL := fmt.Sprintf("%s%s%s/projects", platformConfig["Url"].(string), platformConfig["Baseapi"].(string), platformConfig["Apiver"].(string))
@@ -667,7 +667,7 @@ func determineProjectsAndRepos(platformConfig map[string]interface{}, exclusionL
 func summarizeAnalysisResults(importantBranches []ProjectBranch, nbRepos int) []ProjectBranch {
 	var totalSize, largestRepoSize int
 	var largestRepoProject, largestRepoBranch, largestRepo string
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	for _, branch := range importantBranches {
 		if branch.LargestSize > largestRepoSize {
@@ -759,7 +759,7 @@ func fetchAllProjects(url string, accessToken string, exclusionList *utils.Exclu
 
 func fetchOnelProjects(url string, accessToken string, exclusionList *utils.ExclusionList) ([]Project, error) {
 	var allProjects []Project
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	projectsResp, err := fetchProjects(url, accessToken, false)
 	if err != nil {
@@ -784,7 +784,7 @@ func fetchOnelProjects(url string, accessToken string, exclusionList *utils.Excl
 
 func fetchOneRepos(url string, accessToken string, exclusionList *utils.ExclusionList) ([]Repo, error) {
 	var allRepos []Repo
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	reposResp, err := fetchRepos(url, accessToken, false)
 	if err != nil {
@@ -812,7 +812,7 @@ func fetchOneRepos(url string, accessToken string, exclusionList *utils.Exclusio
 
 func fetchProjects(url string, accessToken string, isProjectResponse bool) (interface{}, error) {
 	var projectsResp interface{}
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -870,7 +870,7 @@ func isRepoExcluded(exclusionList *utils.ExclusionList, repo string) bool {
 
 func fetchAllRepos(url string, accessToken string, exclusionList *utils.ExclusionList) ([]Repo, error) {
 	var allRepos []Repo
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	for {
 		reposResp, err := fetchRepos(url, accessToken, true)
 		if err != nil {
@@ -952,7 +952,7 @@ func fetchAllBranches(url string, accessToken string) ([]Branch, error) {
 }
 
 func fetchBranches(url string, accessToken string) (*BranchResponse, error) {
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -1036,7 +1036,7 @@ func fetchFileResponse(url string, accessToken string) (FileResponse, error) {
 }
 func calculateTotalSize(files []File, params FetchParams) (int, error) {
 	var wg sync.WaitGroup
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	wg.Add(len(files))
 
 	totalSize := 0

--- a/pkg/devops/getbitbucketdc/getbitbucketdc.go
+++ b/pkg/devops/getbitbucketdc/getbitbucketdc.go
@@ -226,6 +226,7 @@ func GetReposProject(projects []Project, parms ParamsReposProjectDC, bitbucketUR
 		loggers.Infof("\t  ✅ The number of Repo(s) found is: %d", len(repos))
 
 		for _, repo := range repos {
+			loggers.Debugf("→ repo %s/%s: analyzing", project.Key, repo.Name)
 			if err := processRepo(project.Key, repo, parms, bitbucketURLBase, spin1, &importantBranches); err != nil {
 				if err == ErrEmptyRepo {
 					emptyRepo++
@@ -811,6 +812,7 @@ func fetchOneRepos(url string, accessToken string, exclusionList *utils.Exclusio
 
 func fetchProjects(url string, accessToken string, isProjectResponse bool) (interface{}, error) {
 	var projectsResp interface{}
+	loggers := utils.NewLogger()
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -818,11 +820,13 @@ func fetchProjects(url string, accessToken string, isProjectResponse bool) (inte
 	}
 	req.Header.Set("Authorization", tokenOpt+accessToken)
 
+	loggers.Debugf("GET %s", url)
 	resp, err := utils.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	loggers.Debugf("GET %s → %s", url, resp.Status)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -866,6 +870,7 @@ func isRepoExcluded(exclusionList *utils.ExclusionList, repo string) bool {
 
 func fetchAllRepos(url string, accessToken string, exclusionList *utils.ExclusionList) ([]Repo, error) {
 	var allRepos []Repo
+	loggers := utils.NewLogger()
 	for {
 		reposResp, err := fetchRepos(url, accessToken, true)
 		if err != nil {
@@ -878,7 +883,9 @@ func fetchAllRepos(url string, accessToken string, exclusionList *utils.Exclusio
 			if len(exclusionList.Projects) == 0 && len(exclusionList.Repos) == 0 {
 				allRepos = append(allRepos, repo)
 			} else {
-				if !isRepoExcluded(exclusionList, KEYTEST) {
+				if isRepoExcluded(exclusionList, KEYTEST) {
+					loggers.Debugf("→ repo %s: skipped (excluded)", KEYTEST)
+				} else {
 					allRepos = append(allRepos, repo)
 				}
 			}
@@ -945,17 +952,20 @@ func fetchAllBranches(url string, accessToken string) ([]Branch, error) {
 }
 
 func fetchBranches(url string, accessToken string) (*BranchResponse, error) {
+	loggers := utils.NewLogger()
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Authorization", tokenOpt+accessToken)
 
+	loggers.Debugf("GET %s", url)
 	resp, err := utils.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	loggers.Debugf("GET %s → %s", url, resp.Status)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/devops/getgithub/getgithub.go
+++ b/pkg/devops/getgithub/getgithub.go
@@ -289,6 +289,7 @@ func GetReposGithub(parms ParamsReposGithub, ctx context.Context, client *github
 	for _, repo := range parms.Repos {
 		repoName := *repo.Name
 		if repo.GetArchived() {
+			loggers.Debugf("→ repo %s: skipped (archived)", repoName)
 			cptarchiv++
 			continue
 		}
@@ -302,7 +303,11 @@ func GetReposGithub(parms ParamsReposGithub, ctx context.Context, client *github
 			fmt.Print(err.Error())
 			continue
 		}
+		if isEmpty {
+			loggers.Debugf("→ repo %s: skipped (empty)", repoName)
+		}
 		if !isEmpty {
+			loggers.Debugf("→ repo %s: analyzing", repoName)
 			largestRepoBranch, repoBranches := analyzeRepoBranches(parms, ctx, client, repo, cpt, spin1)
 			importantBranches = append(importantBranches, ProjectBranch{
 				Org:         parms.Organization,

--- a/pkg/devops/getgithub/getgithub.go
+++ b/pkg/devops/getgithub/getgithub.go
@@ -132,7 +132,7 @@ const MessageApiRate = "❗️ Rate limit exceeded. Waiting for rate limit reset
 const ApiHeader1 = "application/vnd.github.v3+json"
 const ErrorMesssage1 = "❌ Error saving repositories in file Results/config/analysis_repos_github.json: %v\n"
 
-//var loggers = utils.NewLogger()
+//var loggers = utils.SharedLogger()
 
 // Load repository ignore map from file
 func loadExclusionRepos1(filename string) (ExclusionRepos, error) {
@@ -278,7 +278,7 @@ func GetReposGithub(parms ParamsReposGithub, ctx context.Context, client *github
 	var TotalBranches, notAnalyzedCount, emptyRepo, cpt, cptarchiv int
 	var importantBranches []ProjectBranch
 	cpt = 1
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	spin1 := spinner.New(spinner.CharSets[35], 100*time.Millisecond)
 	spin1.Color("green", "bold")
@@ -338,7 +338,7 @@ func analyzeRepoBranches(parms ParamsReposGithub, ctx context.Context, client *g
 	var branches []*github.Branch
 	var allEvents []*github.Event
 	var branchPushes map[string]*BranchInfoEvents
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	opt := &github.BranchListOptions{
 		ListOptions: github.ListOptions{PerPage: 100},
@@ -454,7 +454,7 @@ func getAllEvents(ctx context.Context, client *github.Client, repoName, organiza
 func countBranchPushes(events []*github.Event, period int) map[string]*BranchInfoEvents {
 	branchPushes := make(map[string]*BranchInfoEvents)
 	oneMonthAgo := time.Now().AddDate(0, period, 0)
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	for _, event := range events {
 		if event.CreatedAt != nil && event.CreatedAt.After(oneMonthAgo) {
@@ -495,7 +495,7 @@ func analyzeBranches(ctx context.Context, client *github.Client, parms ParamsRep
 
 func analyzeWithStats(ctx context.Context, client *github.Client, organization, repoName string, oneMonthAgo time.Time, info *BranchInfoEvents) {
 	contributorsStats, _, err := client.Repositories.ListContributorsStats(ctx, organization, repoName)
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	if err != nil {
 		if rateLimitErr, ok := err.(*github.AbuseRateLimitError); ok {
 			fmt.Println(MessageApiRate)
@@ -526,7 +526,7 @@ func analyzeWithoutStats(ctx context.Context, client *github.Client, organizatio
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
 	var allCommits []*github.RepositoryCommit
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	for {
 		commits, resp, err := client.Repositories.ListCommits(ctx, organization, repoName, opt)
 		if err != nil {
@@ -579,7 +579,7 @@ func determineLargestBranch(parms ParamsReposGithub, repo *github.Repository, br
 // GetAllBranchesForRepositories takes a repository list and expands it to analyze all branches
 func GetAllBranchesForRepositories(platformConfig map[string]interface{}, repositories []ProjectBranch) ([]ProjectBranch, error) {
 	var allBranches []ProjectBranch
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	client := github.NewClient(nil).WithAuthToken(platformConfig["AccessToken"].(string))
 	ctx := context.Background()
@@ -726,7 +726,7 @@ type RepoProcessingStats struct {
 }
 
 func GetRepoGithubListAllBranches(platformConfig map[string]interface{}, exclusionfile string, fast bool) ([]ProjectBranch, error) {
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	stats := &RepoProcessingStats{}
 
 	client := github.NewClient(nil).WithAuthToken(platformConfig["AccessToken"].(string))
@@ -809,7 +809,7 @@ func GetRepoGithubList(platformConfig map[string]interface{}, exclusionfile stri
 	var repositories []*github.Repository
 	var exclusionList ExclusionRepos
 	var err1 error
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	opt := &github.RepositoryListByOrgOptions{
 		ListOptions: github.ListOptions{PerPage: 100},
@@ -901,7 +901,7 @@ func loadExclusionList(exclusionfile string) (ExclusionList, error) {
 func loadExclusionFile(exclusionfile string, spin *spinner.Spinner) (ExclusionRepos, error) {
 	var exclusionList ExclusionRepos
 	var err error
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	if exclusionfile == "0" {
 		exclusionList = make(map[string]bool)
@@ -941,7 +941,7 @@ func initializeGithubClient(platformConfig map[string]interface{}) (context.Cont
 		// Create client for GitHub Enterprise Server
 		client, err := github.NewClient(nil).WithAuthToken(accessToken).WithEnterpriseURLs(baseURL, baseURL)
 		if err != nil {
-			loggers := utils.NewLogger()
+			loggers := utils.SharedLogger()
 			loggers.Errorf("❌ Failed to create GitHub Enterprise client: %v", err)
 			// Fallback to regular client
 			client = github.NewClient(nil).WithAuthToken(accessToken)
@@ -973,7 +973,7 @@ func fetchUserRepositories(ctx context.Context, client *github.Client, opt *gith
 
 func fetchAllRepositories(ctx context.Context, client *github.Client, organization string, opt *github.RepositoryListByOrgOptions) ([]*github.Repository, error) {
 	var repositories []*github.Repository
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	for {
 		repos, resp, err := client.Repositories.ListByOrg(ctx, organization, opt)
 		if err != nil {
@@ -991,7 +991,7 @@ func fetchAllRepositories(ctx context.Context, client *github.Client, organizati
 
 func fetchSingleRepository(ctx context.Context, client *github.Client, platformConfig map[string]interface{}) ([]*github.Repository, error) {
 	repos, _, err := client.Repositories.Get(ctx, platformConfig["Organization"].(string), platformConfig["Repos"].(string))
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	if err != nil {
 		loggers.Errorf("❌ Error fetching repository: %v\n", err)
 		return nil, err
@@ -1034,7 +1034,7 @@ func findLargestRepository(importantBranches []ProjectBranch, totalSize *int64) 
 }
 
 func printSummary(config PlatformConfig, stats SummaryStats) {
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	fmt.Printf("\n")
 	loggers.Infof("✅ The largest Repository is <%s> in the organization <%s> with the branch <%s> ", stats.LargestRepo, config.Organization, stats.LargestRepoBranch)
@@ -1052,7 +1052,7 @@ func FastAnalys(platformConfig map[string]interface{}, exlusionfile string) erro
 	var err1 error
 	var emptyRepo int
 	nbRepos := 0
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	opt := &github.RepositoryListByOrgOptions{
 		ListOptions: github.ListOptions{PerPage: 100},
 	} // Number Object by page in API Request

--- a/pkg/devops/getgitlab/getgitlab.go
+++ b/pkg/devops/getgitlab/getgitlab.go
@@ -458,12 +458,14 @@ func analyzeMainBranchForProjects(client *gitlab.Client, projects []*gitlab.Proj
 				spin1.Prefix = messageB
 				spin1.Start()
 
+		loggers.Debugf("→ project %s: analyzing", project.Name)
 		mainBranch, largestSize, nbrsize, err := getMainBranchDetails(client, project, since, until)
 				if err != nil {
 					spin1.Stop()
 			loggers.Errorf("%s", err.Error())
 			continue
 				}
+		loggers.Debugf("→ project %s: branch selected %s (largest=%d, total=%d)", project.Name, mainBranch, largestSize, nbrsize)
 		result = append(result, ProjectBranch{
 			Org:         org,
 					Namespace:   project.PathWithNamespace,

--- a/pkg/devops/getgitlab/getgitlab.go
+++ b/pkg/devops/getgitlab/getgitlab.go
@@ -113,7 +113,7 @@ func getAllGroupProjects(client *gitlab.Client, groupName string) ([]*gitlab.Pro
 	if err != nil {
 		return nil, err
 	}
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	loggers.Infof("🔍 Group <%s> → resolved to ID %d (full path: %s)", groupName, group.ID, group.FullPath)
 	projects, err := listGroupProjectsWithSubgroups(client, group.ID)
 	if err != nil {
@@ -260,7 +260,7 @@ func isExcluded(projectName string, exclusionList map[string]bool) bool {
 
 func SaveResult(result AnalysisResult) error {
 	const resultPath = "Results/config/analysis_result_gitlab.json"
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	if err := os.MkdirAll("Results/config", 0755); err != nil {
 		loggers.Errorf("❌ Error creating Results/config directory: %v", err)
 		return err
@@ -327,7 +327,7 @@ func analyzeProj(analyzeProject AnalyzeProject) (ProjectBranch, int, int, int) {
 func processProject(analyzeProject AnalyzeProject, cpt int, spin1 *spinner.Spinner, projectBranches []ProjectBranch, emptyRepos, archivedRepos, excludedProjects *int) ([]ProjectBranch, int) {
 	projectBranche, ExcludedProject, EmptyRepos, ArchivedRepos := analyzeProj(analyzeProject)
 
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	if EmptyRepos > 0 {
 		(*emptyRepos)++
@@ -350,7 +350,7 @@ func processProject(analyzeProject AnalyzeProject, cpt int, spin1 *spinner.Spinn
 }
 
 func isProjectExcludedOrInvalid(project *gitlab.Project, exclusionList ExclusionRepos, emptyRepos, archivedRepos *int) (bool, bool, bool) {
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	if isExcluded(project.PathWithNamespace, exclusionList) {
 		loggers.Infof("⏭️  Skipping <%s>: in exclusion list", project.Name)
 		return true, false, false
@@ -451,7 +451,7 @@ func filterValidProjects(projects []*gitlab.Project, exclusionList ExclusionRepo
 func analyzeMainBranchForProjects(client *gitlab.Client, projects []*gitlab.Project, org string, since, until time.Time, spin1 *spinner.Spinner) ([]ProjectBranch, int) {
 	var result []ProjectBranch
 	totalBranches := 0
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	cpt := 1
 	for _, project := range projects {
 				messageB := fmt.Sprintf(Message2, project.Name)
@@ -484,7 +484,7 @@ func analyzeMainBranchForProjects(client *gitlab.Client, projects []*gitlab.Proj
 // analyzeSpecificBranchForProjects computes the size for a given branch across projects.
 func analyzeSpecificBranchForProjects(client *gitlab.Client, projects []*gitlab.Project, org, branch string, spin1 *spinner.Spinner) ([]ProjectBranch, int) {
 	var result []ProjectBranch
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	cpt := 1
 	totalBranches := 0
 	for _, project := range projects {
@@ -554,7 +554,7 @@ type nonDefaultCtx struct {
 func nonDefaultAllProjectsAllBranches(ctx nonDefaultCtx) ([]ProjectBranch, int) {
 	return analyzeOrgsWithProjects(ctx, func(org string, projects []*gitlab.Project, spin1 *spinner.Spinner) ([]ProjectBranch, int) {
 		valid := filterValidProjects(projects, ctx.exclusions, ctx.emptyRepos, ctx.archivedRepos, ctx.excludedProjects)
-		utils.NewLogger().Infof(msgGroupToAnalyze, org, len(valid))
+		utils.SharedLogger().Infof(msgGroupToAnalyze, org, len(valid))
 		return analyzeMainBranchForProjects(ctx.client, valid, org, ctx.since, ctx.until, spin1)
 	})
 }
@@ -585,7 +585,7 @@ func nonDefaultSpecificProjectAllBranches(ctx nonDefaultCtx) ([]ProjectBranch, i
 		found = true
 	}
 	if !found {
-		utils.NewLogger().Fatalf(MessageError2b, ctx.config["Project"].(string))
+		utils.SharedLogger().Fatalf(MessageError2b, ctx.config["Project"].(string))
 	}
 	return projectBranches, totalBranches
 }
@@ -605,7 +605,7 @@ func nonDefaultSpecificProjectSpecificBranch(ctx nonDefaultCtx) ([]ProjectBranch
 		})
 		totalBranches = 1
 	} else {
-		utils.NewLogger().Fatalf(MessageError2b, ctx.config["Project"].(string))
+		utils.SharedLogger().Fatalf(MessageError2b, ctx.config["Project"].(string))
 	}
 	return projectBranches, totalBranches
 }
@@ -615,7 +615,7 @@ func nonDefaultAllProjectsSpecificBranch(ctx nonDefaultCtx) ([]ProjectBranch, in
 	branch := ctx.config["Branch"].(string)
 	return analyzeOrgsWithProjects(ctx, func(org string, projects []*gitlab.Project, spin1 *spinner.Spinner) ([]ProjectBranch, int) {
 		valid := filterValidProjects(projects, ctx.exclusions, ctx.emptyRepos, ctx.archivedRepos, ctx.excludedProjects)
-		utils.NewLogger().Infof(msgGroupToAnalyze, org, len(valid))
+		utils.SharedLogger().Infof(msgGroupToAnalyze, org, len(valid))
 		return analyzeSpecificBranchForProjects(ctx.client, valid, org, branch, spin1)
 	})
 }
@@ -624,7 +624,7 @@ func nonDefaultAllProjectsSpecificBranch(ctx nonDefaultCtx) ([]ProjectBranch, in
 func analyzeOrgsWithProjects(ctx nonDefaultCtx, perOrg func(org string, projects []*gitlab.Project, spin1 *spinner.Spinner) ([]ProjectBranch, int)) ([]ProjectBranch, int) {
 	var projectBranches []ProjectBranch
 	totalBranches := 0
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	for _, org := range ctx.orgs {
 		projects, _, spin1, err := getProjectsAndAnalyze(ctx.client, org, ctx.spin)
 			if err != nil {
@@ -714,7 +714,7 @@ type defaultCtx struct {
 func handleDefaultBranchCase(ctx defaultCtx) ([]ProjectBranch, int) {
 	var projectBranches []ProjectBranch
 	totalBranches := 0
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	if ctx.config["Project"].(string) == "" {
 		for _, org := range ctx.orgs {
@@ -772,7 +772,7 @@ func GetRepoGitLabList(platformConfig map[string]interface{}, exclusionfile stri
 	var exclusionList ExclusionRepos
 	var err1 error
 	var totalSize int
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	excludedProjects := 0
 	result := AnalysisResult{}
@@ -889,7 +889,7 @@ func GetRepoGitLabList(platformConfig map[string]interface{}, exclusionfile stri
 func getProjectsAndAnalyze(gitlabClient *gitlab.Client, organization string, spin *spinner.Spinner) ([]*gitlab.Project, int, *spinner.Spinner, error) {
 
 	cpt := 1
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	projects, err := getAllGroupProjects(gitlabClient, organization)
 	if err != nil {

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -10,43 +10,85 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// CustomFormatter writes coloured log lines to terminal/SSE output.
 type CustomFormatter struct{}
 
-// Format formate l'enregistrement log
 func (f *CustomFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	// Définir la couleur en fonction du niveau de log
+	msg := entry.Message
 	switch entry.Level {
 	case logrus.DebugLevel:
-		entry.Message = color.HiBlueString(entry.Message)
+		msg = color.HiBlueString(msg)
 	case logrus.InfoLevel:
-		entry.Message = color.WhiteString(entry.Message)
+		msg = color.WhiteString(msg)
 	case logrus.WarnLevel:
-		entry.Message = color.YellowString(entry.Message)
+		msg = color.YellowString(msg)
 	case logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel:
-		entry.Message = color.RedString(entry.Message)
+		msg = color.RedString(msg)
 	}
-
-	// Formater le temps
 	timestamp := entry.Time.Format("2006-01-02 15:04:05")
-
-	// Construire le message final
-	msg := fmt.Sprintf("[%s] %s %s\n", timestamp, strings.ToUpper(entry.Level.String()), entry.Message)
-	return []byte(msg), nil
+	line := fmt.Sprintf("[%s] %s %s\n", timestamp, strings.ToUpper(entry.Level.String()), msg)
+	return []byte(line), nil
 }
 
+// plainFormatter writes plain (no ANSI colour) log lines — used for debug.log.
+type plainFormatter struct{}
+
+func (f *plainFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	timestamp := entry.Time.Format("2006-01-02 15:04:05")
+	line := fmt.Sprintf("[%s] %s %s\n", timestamp, strings.ToUpper(entry.Level.String()), entry.Message)
+	return []byte(line), nil
+}
+
+// writerHook routes log entries matching the given levels to a writer.
+type writerHook struct {
+	writer    io.Writer
+	formatter logrus.Formatter
+	levels    []logrus.Level
+}
+
+func (h *writerHook) Levels() []logrus.Level { return h.levels }
+
+func (h *writerHook) Fire(entry *logrus.Entry) error {
+	b, err := h.formatter.Format(entry)
+	if err != nil {
+		return err
+	}
+	_, err = h.writer.Write(b)
+	return err
+}
+
+var infoAndAbove = []logrus.Level{
+	logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel,
+	logrus.WarnLevel, logrus.InfoLevel,
+}
+
+var allLevels = []logrus.Level{
+	logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel,
+	logrus.WarnLevel, logrus.InfoLevel, logrus.DebugLevel, logrus.TraceLevel,
+}
+
+// NewLogger returns a logger that:
+//   - writes Info+ (coloured) to stdout and Logs/Logs.log  — visible in the UI SSE stream
+//   - writes Debug+ (plain text) to Logs/debug.log         — downloadable from the UI
 func NewLogger() *logrus.Logger {
 	logger := logrus.New()
-	logger.SetFormatter(&CustomFormatter{})
-
 	logger.SetLevel(logrus.DebugLevel)
+	logger.SetOutput(io.Discard) // all output goes through hooks
 
-	logFile, err := os.OpenFile("Logs/Logs.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-	if err != nil {
-		// Fallback to stdout only when log file cannot be created (e.g. read-only fs, Docker)
-		logger.SetOutput(os.Stdout)
-		return logger
+	coloured := &CustomFormatter{}
+	plain := &plainFormatter{}
+
+	// Info+ → stdout (+ Logs.log when available)
+	var mainOut io.Writer = os.Stdout
+	if logFile, err := os.OpenFile("Logs/Logs.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666); err == nil {
+		mainOut = io.MultiWriter(os.Stdout, logFile)
+	}
+	logger.AddHook(&writerHook{writer: mainOut, formatter: coloured, levels: infoAndAbove})
+
+	// Debug+ → Logs/debug.log (plain, all levels)
+	if debugFile, err := os.OpenFile("Logs/debug.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666); err == nil {
+		logger.AddHook(&writerHook{writer: debugFile, formatter: plain, levels: allLevels})
 	}
 
-	logger.SetOutput(io.MultiWriter(os.Stdout, logFile))
 	return logger
 }

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -5,10 +5,44 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/fatih/color"
 	"github.com/sirupsen/logrus"
 )
+
+// sharedLog is the process-wide singleton, reset once per analysis run.
+var (
+	sharedLog   *logrus.Logger
+	sharedLogMu sync.RWMutex
+)
+
+// ResetSharedLogger creates a fresh singleton logger, opening new file handles.
+// Call this once at the start of each analysis run, after Logs/ has been created.
+func ResetSharedLogger() {
+	sharedLogMu.Lock()
+	defer sharedLogMu.Unlock()
+	sharedLog = NewLogger()
+}
+
+// SharedLogger returns the process-wide singleton, initialising it on first use.
+// All platform packages should use this instead of NewLogger() to avoid FD leaks.
+func SharedLogger() *logrus.Logger {
+	sharedLogMu.RLock()
+	if sharedLog != nil {
+		l := sharedLog
+		sharedLogMu.RUnlock()
+		return l
+	}
+	sharedLogMu.RUnlock()
+
+	sharedLogMu.Lock()
+	defer sharedLogMu.Unlock()
+	if sharedLog == nil {
+		sharedLog = NewLogger()
+	}
+	return sharedLog
+}
 
 // CustomFormatter writes coloured log lines to terminal/SSE output.
 type CustomFormatter struct{}

--- a/pkg/utils/repository_summary.go
+++ b/pkg/utils/repository_summary.go
@@ -77,7 +77,8 @@ func detectPlatformAndReadAnalysis() (string, []byte, error) {
 		"azure":       "Results/config/analysis_result_azure.json",
 		"bitbucket":   "Results/config/analysis_result_bitbucket.json",
 		"gitlab":      "Results/config/analysis_result_gitlab.json",
-		"bitbucketdc": "Results/config/analysis_repos_bitbucketdc.json", // Different naming pattern
+		"bitbucketdc": "Results/config/analysis_repos_bitbucketdc.json",
+		"file":        "Results/config/analysis_result_file.json",
 	}
 
 	for platform, fileName := range platformFiles {
@@ -143,13 +144,23 @@ func getRepositoryData() ([]RepositoryData, error) {
 	i := 0
 	for _, branch := range repoMap {
 		i++
-		// Construct filename for byfile report using platform-specific logic
-		firstPart := getFirstPartForPlatform(platform, branch, branch.RepoSlug)
-		fileName := fmt.Sprintf("Results/byfile-report/Result_%s_%s_%s_byfile.json",
-			firstPart, branch.RepoSlug, branch.MainBranch)
+		// Construct file paths using platform-specific naming.
+		// File mode uses a shorter pattern (no project key or branch suffix)
+		// because goloc names files as Result_<dirname>_byfile.json in that mode.
+		var byfilePath, byLanguagePath string
+		if platform == "file" {
+			byfilePath = fmt.Sprintf("Results/byfile-report/Result_%s_byfile.json", branch.RepoSlug)
+			byLanguagePath = fmt.Sprintf("Results/bylanguage-report/Result_%s.json", branch.RepoSlug)
+		} else {
+			firstPart := getFirstPartForPlatform(platform, branch, branch.RepoSlug)
+			byfilePath = fmt.Sprintf("Results/byfile-report/Result_%s_%s_%s_byfile.json",
+				firstPart, branch.RepoSlug, branch.MainBranch)
+			byLanguagePath = fmt.Sprintf("Results/bylanguage-report/Result_%s_%s_%s.json",
+				firstPart, branch.RepoSlug, branch.MainBranch)
+		}
 
 		// Read the byfile report
-		fileData, err := os.ReadFile(fileName)
+		fileData, err := os.ReadFile(byfilePath)
 		if err != nil {
 			// Skip this repository if file doesn't exist
 			continue
@@ -171,8 +182,6 @@ func getRepositoryData() ([]RepositoryData, error) {
 
 		// Code lines for report total: exclude JSON to match SonarQube behavior
 		codeLinesForReport := reportData.TotalCodeLines
-		byLanguagePath := fmt.Sprintf("Results/bylanguage-report/Result_%s_%s_%s.json",
-			firstPart, branch.RepoSlug, branch.MainBranch)
 		if langData, err := os.ReadFile(byLanguagePath); err == nil {
 			var byLang struct {
 				Results []struct {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,4 @@ sonar.projectName=Sonar GoLC
 sonar.projectVersion=2.0
 sonar.go.coverage.reportPaths=coverage-pkg.out,coverage-golc.out,coverage-resultsall.out
 sonar.organization=sonar-solutions
+sonar.test.inclusions=**/*_test.go

--- a/webui.go
+++ b/webui.go
@@ -1085,8 +1085,8 @@ const htmlTemplate = `<!DOCTYPE html>
   .btn-stop { background:linear-gradient(135deg,#dc2626,#b91c1c); border:none; border-radius:8px; font-weight:600; color:#fff !important; }
   .btn-stop:hover { background:linear-gradient(135deg,#b91c1c,#991b1b); color:#fff !important; }
   .btn-success-view { background:linear-gradient(135deg,#059669,#0d6efd); border:none; border-radius:9999px;
-    font-weight:600; padding:.375rem .75rem; color:#fff; }
-  .btn-success-view:hover { background:linear-gradient(135deg,#047857,#0b5ed7); color:#fff; }
+    font-weight:700; font-size:1.1rem; padding:.6rem 2.2rem; color:#fff; box-shadow:0 4px 14px rgba(13,110,253,.35); }
+  .btn-success-view:hover { background:linear-gradient(135deg,#047857,#0b5ed7); color:#fff; box-shadow:0 6px 18px rgba(13,110,253,.5); }
   .btn-download-log { border:2px solid #0d6efd; color:#6ea8fe; background:transparent;
     border-radius:9999px; font-weight:600; padding:.375rem .75rem; }
   .btn-download-log:hover { border-color:#0a58ca; color:#9ec5fe; background:rgba(13,110,253,.12); }

--- a/webui.go
+++ b/webui.go
@@ -980,6 +980,19 @@ func handleOpenResults(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"url": fmt.Sprintf("http://localhost:%d", port)})
 }
 
+func handleDownloadDebug(w http.ResponseWriter, r *http.Request) {
+	const debugLog = "Logs/debug.log"
+	f, err := os.Open(debugLog)
+	if err != nil {
+		http.Error(w, "debug.log not found", http.StatusNotFound)
+		return
+	}
+	defer f.Close()
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="debug.log"`)
+	_, _ = io.Copy(w, f)
+}
+
 var staticHandler = func() http.Handler {
 	sub, err := fs.Sub(distFS, "dist")
 	if err != nil {
@@ -1013,6 +1026,7 @@ func main() {
 	mux.HandleFunc("/api/events", handleEvents)
 	mux.HandleFunc("/api/status", handleStatus)
 	mux.HandleFunc("/api/open-results", handleOpenResults)
+	mux.HandleFunc("/api/download-debug", handleDownloadDebug)
 	mux.HandleFunc("/dist/", handleStatic)
 
 	port := findFreePort(webuiPort)
@@ -1073,6 +1087,9 @@ const htmlTemplate = `<!DOCTYPE html>
   .btn-success-view { background:linear-gradient(135deg,#059669,#0d6efd); border:none; border-radius:8px;
     font-weight:700; font-size:1.05rem; padding:.65rem 2rem; color:#fff; }
   .btn-success-view:hover { background:linear-gradient(135deg,#047857,#0b5ed7); color:#fff; }
+  .btn-download-log { border:2px solid #0d6efd; color:#6ea8fe; background:transparent;
+    border-radius:9999px; font-weight:600; padding:.375rem .75rem; }
+  .btn-download-log:hover { border-color:#0a58ca; color:#9ec5fe; background:rgba(13,110,253,.12); }
   .progress { height:10px; border-radius:99px; background:rgba(255,255,255,.08); }
   .progress-bar { border-radius:99px; background:linear-gradient(90deg,#0d6efd,#6366f1); transition:width .4s ease; }
   @keyframes bar-scan { 0% { background-position:100% center; } 100% { background-position:-100% center; } }
@@ -1346,13 +1363,16 @@ const htmlTemplate = `<!DOCTYPE html>
           <div class="big-icon" id="result-icon">✅</div>
           <h5 id="result-title" style="color:#86efac;">Analysis Complete!</h5>
           <p id="result-msg" style="color:#94a3b8;font-size:.9rem;"></p>
-          <div class="d-flex gap-3 justify-content-center mt-3">
+          <div class="d-flex gap-3 justify-content-center align-items-center mt-3">
             <button class="btn btn-success-view" onclick="viewResults()">
               <i class="fas fa-chart-bar me-2"></i>View Results
             </button>
             <button class="btn btn-outline-secondary" onclick="goToStep(1)">
               <i class="fas fa-redo me-2"></i>New Analysis
             </button>
+            <a class="btn btn-download-log" href="/api/download-debug" download="debug.log">
+              <i class="fas fa-bug me-2"></i>Download Debug Log
+            </a>
           </div>
         </div>
       </div>

--- a/webui.go
+++ b/webui.go
@@ -243,7 +243,6 @@ func savePlatformConfig(platformKey string, platformCfg map[string]interface{}) 
 		// If config.json doesn't exist yet, build a minimal one
 		full = map[string]interface{}{
 			"platforms": map[string]interface{}{},
-			"Logging":   map[string]interface{}{"Level": "debug"},
 			"Release":   map[string]interface{}{"Version": "2.0"},
 		}
 	}

--- a/webui.go
+++ b/webui.go
@@ -1363,16 +1363,20 @@ const htmlTemplate = `<!DOCTYPE html>
           <div class="big-icon" id="result-icon">✅</div>
           <h5 id="result-title" style="color:#86efac;">Analysis Complete!</h5>
           <p id="result-msg" style="color:#94a3b8;font-size:.9rem;"></p>
-          <div class="d-flex gap-3 justify-content-center align-items-center mt-3">
-            <button class="btn btn-download-log" onclick="goToStep(1)">
-              <i class="fas fa-redo me-2"></i>New Analysis
-            </button>
+          <div style="display:grid;grid-template-columns:1fr auto 1fr;gap:1rem;align-items:center;margin-top:1rem;">
+            <div style="display:flex;justify-content:flex-end;">
+              <button class="btn btn-download-log" onclick="goToStep(1)">
+                <i class="fas fa-redo me-2"></i>New Analysis
+              </button>
+            </div>
             <button class="btn btn-success-view" onclick="viewResults()">
               <i class="fas fa-chart-bar me-2"></i>View Results
             </button>
-            <a class="btn btn-download-log" href="/api/download-debug" download="debug.log">
-              <i class="fas fa-bug me-2"></i>Download Debug Log
-            </a>
+            <div style="display:flex;justify-content:flex-start;">
+              <a class="btn btn-download-log" href="/api/download-debug" download="debug.log">
+                <i class="fas fa-bug me-2"></i>Download Debug Log
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/webui.go
+++ b/webui.go
@@ -1084,8 +1084,8 @@ const htmlTemplate = `<!DOCTYPE html>
   .btn-primary:hover { background:linear-gradient(135deg,#0b5ed7,#4f46e5); color:#fff !important; }
   .btn-stop { background:linear-gradient(135deg,#dc2626,#b91c1c); border:none; border-radius:8px; font-weight:600; color:#fff !important; }
   .btn-stop:hover { background:linear-gradient(135deg,#b91c1c,#991b1b); color:#fff !important; }
-  .btn-success-view { background:linear-gradient(135deg,#059669,#0d6efd); border:none; border-radius:8px;
-    font-weight:700; font-size:1.05rem; padding:.65rem 2rem; color:#fff; }
+  .btn-success-view { background:linear-gradient(135deg,#059669,#0d6efd); border:none; border-radius:9999px;
+    font-weight:600; padding:.375rem .75rem; color:#fff; }
   .btn-success-view:hover { background:linear-gradient(135deg,#047857,#0b5ed7); color:#fff; }
   .btn-download-log { border:2px solid #0d6efd; color:#6ea8fe; background:transparent;
     border-radius:9999px; font-weight:600; padding:.375rem .75rem; }
@@ -1364,11 +1364,11 @@ const htmlTemplate = `<!DOCTYPE html>
           <h5 id="result-title" style="color:#86efac;">Analysis Complete!</h5>
           <p id="result-msg" style="color:#94a3b8;font-size:.9rem;"></p>
           <div class="d-flex gap-3 justify-content-center align-items-center mt-3">
+            <button class="btn btn-download-log" onclick="goToStep(1)">
+              <i class="fas fa-redo me-2"></i>New Analysis
+            </button>
             <button class="btn btn-success-view" onclick="viewResults()">
               <i class="fas fa-chart-bar me-2"></i>View Results
-            </button>
-            <button class="btn btn-outline-secondary" onclick="goToStep(1)">
-              <i class="fas fa-redo me-2"></i>New Analysis
             </button>
             <a class="btn btn-download-log" href="/api/download-debug" download="debug.log">
               <i class="fas fa-bug me-2"></i>Download Debug Log


### PR DESCRIPTION
## Summary

- **Dual-hook logger**: rewrites `pkg/utils/logger.go` to route Info+ to stdout/SSE (visible in UI) and all levels including Debug to `Logs/debug.log` (plain text, downloadable). Logger level is no longer overridden by config so `Debugf` calls are never silently dropped.
- **Consistent debug coverage** across all 5 platforms and file mode: every repo that proceeds to analysis logs `→ repo project/repo: analyzing`; every filtered repo logs `→ repo project/repo: skipped (reason)`; Bitbucket/BitbucketDC log every HTTP GET; GitLab logs branch selection per project; file mode logs directory list and ScanSubDirs expansion.
- **Download Debug Log button**: new `/api/download-debug` endpoint serves `Logs/debug.log` as a file attachment; a blue-outlined pill button appears in the post-run actions panel alongside View Results and New Analysis.
- **Duplication fix**: extracts `NewExclusionList` constructor into `pkg/utils/annalyse.go`, removing copy-pasted `makeExclusionList` helpers from three test files (resolves SonarQube 14.2% duplication gate failure).
- **Cleanup**: removes the obsolete `ℹ️ To generate and visualize results… run: ResultsAll` log message no longer applicable in webui mode; removes leftover dead comment block.