### PR TITLE
fix: guard logo image to prevent PDF crash when imgs/Logob.png is missing

### DIFF
--- a/pkg/reporter/pdf/pdf_reporter.go
+++ b/pkg/reporter/pdf/pdf_reporter.go
@@ -145,7 +145,9 @@ func (p PdfReporter) writePdf(pdfReport *report) error {
 	pdf.Cell(0, 10, "Analysis Report")
 	pdf.Ln(20)
 
-	pdf.Image(logoImagePath, 10, 20, 50, 0, false, "", 0, "")
+	if _, err := os.Stat(logoImagePath); err == nil {
+		pdf.Image(logoImagePath, 10, 20, 50, 0, false, "", 0, "")
+	}
 
 	pdf.Ln(10)
 
@@ -251,7 +253,9 @@ func (p PdfReporter) GenerateGlobalReportByFile() error {
 	pdf.Cell(0, 10, "Full Analysis Report")
 	pdf.Ln(20)
 
-	pdf.Image(logoImagePath, 10, 20, 50, 0, false, "", 0, "")
+	if _, err := os.Stat(logoImagePath); err == nil {
+		pdf.Image(logoImagePath, 10, 20, 50, 0, false, "", 0, "")
+	}
 
 	pdf.Ln(10)
 

--- a/pkg/reporter/pdf/pdf_reporter.go
+++ b/pkg/reporter/pdf/pdf_reporter.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jung-kurt/gofpdf"
 )
 
-const logoImagePath = "imgs/Logob.png"
 
 type PdfReporter struct {
 	OutputName string
@@ -145,8 +144,8 @@ func (p PdfReporter) writePdf(pdfReport *report) error {
 	pdf.Cell(0, 10, "Analysis Report")
 	pdf.Ln(20)
 
-	if _, err := os.Stat(logoImagePath); err == nil {
-		pdf.Image(logoImagePath, 10, 20, 50, 0, false, "", 0, "")
+	if logoPath := utils.GetLogoPath(); logoPath != "" {
+		pdf.Image(logoPath, 10, 20, 50, 0, false, "", 0, "")
 	}
 
 	pdf.Ln(10)
@@ -253,8 +252,8 @@ func (p PdfReporter) GenerateGlobalReportByFile() error {
 	pdf.Cell(0, 10, "Full Analysis Report")
 	pdf.Ln(20)
 
-	if _, err := os.Stat(logoImagePath); err == nil {
-		pdf.Image(logoImagePath, 10, 20, 50, 0, false, "", 0, "")
+	if logoPath := utils.GetLogoPath(); logoPath != "" {
+		pdf.Image(logoPath, 10, 20, 50, 0, false, "", 0, "")
 	}
 
 	pdf.Ln(10)
@@ -313,7 +312,9 @@ func (p PdfReporter) GenerateGlobalReportByFile() error {
 				// Check if we need to add a new page
 				if tableCount >= maxTablesPerPage {
 					pdf.AddPage()
-					pdf.Image(logoImagePath, 10, 5, 50, 0, false, "", 0, "")
+					if logoPath := utils.GetLogoPath(); logoPath != "" {
+						pdf.Image(logoPath, 10, 5, 50, 0, false, "", 0, "")
+					}
 
 					pdf.Ln(10)
 					pdf.SetFont("Times", "B", 12)

--- a/pkg/utils/globalreport.go
+++ b/pkg/utils/globalreport.go
@@ -310,7 +310,7 @@ func renderGlobalPDF(languages []LanguageData, ginfo Globalinfo) error {
 	pdf.SetMargins(marginL, marginT, marginR)
 	pdf.SetAutoPageBreak(true, marginB+8)
 
-	logoPath := "imgs/Logob.png"
+	logoPath := GetLogoPath()
 	_, logoErr := os.Stat(logoPath)
 
 	pdf.SetHeaderFunc(func() {

--- a/pkg/utils/logo.go
+++ b/pkg/utils/logo.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// GetLogoPath returns the path to imgs/Logob.png, resolved relative to the
+// running executable so the binary finds the asset regardless of the caller's
+// working directory. Falls back to the CWD-relative path when the executable
+// path cannot be determined.
+func GetLogoPath() string {
+	const rel = "imgs/Logob.png"
+	if exePath, err := os.Executable(); err == nil {
+		candidate := filepath.Join(filepath.Dir(exePath), rel)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return rel
+}

--- a/pkg/utils/logo.go
+++ b/pkg/utils/logo.go
@@ -17,5 +17,8 @@ func GetLogoPath() string {
 			return candidate
 		}
 	}
-	return rel
+	if _, err := os.Stat(rel); err == nil {
+		return rel
+	}
+	return ""
 }

--- a/pkg/utils/logo_test.go
+++ b/pkg/utils/logo_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetLogoPath_Missing(t *testing.T) {
+	orig, _ := os.Getwd()
+	tmp, err := os.MkdirTemp("", "logo_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Chdir(orig)
+		_ = os.RemoveAll(tmp)
+	}()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := GetLogoPath(); got != "" {
+		t.Errorf("expected empty string when logo is absent, got %q", got)
+	}
+}
+
+func TestGetLogoPath_PresentInCWD(t *testing.T) {
+	orig, _ := os.Getwd()
+	tmp, err := os.MkdirTemp("", "logo_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Chdir(orig)
+		_ = os.RemoveAll(tmp)
+	}()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(tmp, "imgs"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "imgs", "Logob.png"), []byte("fake"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := GetLogoPath()
+	if got == "" {
+		t.Error("expected a non-empty path when logo exists in CWD")
+	}
+}

--- a/pkg/utils/repository_summary.go
+++ b/pkg/utils/repository_summary.go
@@ -372,7 +372,7 @@ func generateRepositoryPDFReport(summary *RepositorySummaryReport, outputPath st
 	pdf.AddPage()
 
 	// Add logo if it exists
-	logoPath := "imgs/Logob.png"
+	logoPath := GetLogoPath()
 	if _, err := os.Stat(logoPath); err == nil {
 		pdf.Image(logoPath, 10, 10, 50, 0, false, "", 0, "")
 	}


### PR DESCRIPTION
## Root cause

`pdf_reporter.go` called `pdf.Image()` unconditionally. When `imgs/Logob.png` is absent, `gofpdf` stores the error internally and surfaces it through `OutputFileAndClose`, causing **every ByAll analysis to fail** on all platforms (Mac, Windows, Linux).

The deeper issue was that all logo references used a CWD-relative path (`imgs/Logob.png`), which only resolves correctly when the binary is launched from its own directory.

## Changes

### `pkg/utils/logo.go` (new)
Centralises logo resolution in `GetLogoPath()`:
1. Tries the path relative to the running executable — so the binary finds the asset regardless of the caller's working directory
2. Falls back to the CWD-relative path, but only if the file actually exists there
3. Returns `""` when the file cannot be found in either location

### `pkg/reporter/pdf/pdf_reporter.go`
- Removed the unconditional `pdf.Image()` calls (3 sites)
- All sites now call `GetLogoPath()` and skip the image when it returns `""`

### `pkg/utils/globalreport.go` / `repository_summary.go`
- Replaced the hardcoded `"imgs/Logob.png"` literals with `GetLogoPath()`

### `pkg/utils/logo_test.go` (new)
- `TestGetLogoPath_Missing` — asserts `""` is returned when the logo is absent from both the executable directory and CWD
- `TestGetLogoPath_PresentInCWD` — asserts a non-empty path is returned when the logo exists in the CWD

## Test plan

- [ ] Run a ByAll analysis from a directory without `imgs/Logob.png` — should complete without error
- [ ] Run a ByAll analysis from the binary's own folder with `imgs/Logob.png` present — logo should appear in the PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)