### PR TITLE
feat: open browser automatically when webui starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,27 +91,40 @@ Credentials are entered in the browser and saved automatically — no config fil
 
 After each run, GoLC writes all reports to a `Results/` folder next to the binary. This is always the case regardless of how the binary was launched (double-click, terminal, or PATH). Click **View Results** in the browser to open the interactive dashboard, or navigate to the folder directly.
 
-### Output file tree
+### File tree view
+
+GoLC maps the complete file hierarchy of each scanned repository. In the Results dashboard, click any repository to explore an interactive tree — folders are collapsible, files show their code line count, and a search box filters the tree in real time.
 
 ```
-Results/
-├── GlobalReport.pdf                                      # All-org summary: lines per language, largest repos
-├── GlobalReport.json                                     # Same data in JSON
-├── code_lines_by_language.json                           # Lines-of-code totals grouped by language
+my-org / my-service  (branch: main)
 │
-├── byfile-report/                                        # File-level breakdown
-│   ├── Result_<org>_<repo>_<branch>_byfile.json         # Per-repo: every file with its line counts (JSON)
-│   ├── repository_summary.json                           # Cross-repo file summary (JSON)
-│   ├── csv-report/
-│   │   ├── repository_summary.csv                        # Cross-repo file summary (CSV)
-│   │   └── Result_<org>_<repo>_<branch>_byfile.csv      # Per-repo: every file, its lines and code lines
-│   └── pdf-report/
-│       ├── repository_summary.pdf                        # Cross-repo file summary (PDF)
-│       └── Result_<org>_<repo>_<branch>_byfile.pdf      # Per-repo file breakdown (PDF)
-│
-└── bylanguage-report/                                    # Language-level breakdown
-    └── Result_<org>_<repo>_<branch>.json                 # Per-repo: lines grouped by language (JSON)
+├── src/
+│   ├── main/
+│   │   ├── java/
+│   │   │   ├── App.java                          1 204 lines
+│   │   │   └── service/
+│   │   │       ├── UserService.java                892 lines
+│   │   │       └── OrderService.java               741 lines
+│   │   └── resources/
+│   │       └── application.properties               38 lines
+│   └── test/
+│       └── java/
+│           └── AppTest.java                        310 lines
+├── pom.xml                                          64 lines
+└── Dockerfile                                       18 lines
 ```
+
+The same data is available as exportable files in the `Results/` folder next to the binary:
+
+| Output | Location |
+|--------|----------|
+| Interactive dashboard | Click **View Results** → select a repository |
+| Per-repo file breakdown (JSON) | `Results/byfile-report/Result_<org>_<repo>_<branch>_byfile.json` |
+| Per-repo file breakdown (CSV) | `Results/byfile-report/csv-report/Result_<org>_<repo>_<branch>_byfile.csv` |
+| Per-repo file breakdown (PDF) | `Results/byfile-report/pdf-report/Result_<org>_<repo>_<branch>_byfile.pdf` |
+| Cross-repo summary | `Results/byfile-report/repository_summary.{json,csv,pdf}` |
+| Per-repo language breakdown | `Results/bylanguage-report/Result_<org>_<repo>_<branch>.json` |
+| Organisation-wide totals | `Results/GlobalReport.{pdf,json}`, `Results/code_lines_by_language.json` |
 
 > File names follow the pattern `Result_<organisation>_<repository>_<branch>` so results from multiple organisations or runs can coexist in the same folder.
 

--- a/README.md
+++ b/README.md
@@ -95,26 +95,22 @@ After each run, GoLC writes all reports to a `Results/` folder in the working di
 
 ```
 Results/
-├── GlobalReport.pdf                                 # All-org summary: lines per language, largest repos
-├── GlobalReport.json                                # Same data in JSON
-├── code_lines_by_language.json                      # Lines-of-code totals grouped by language
+├── GlobalReport.pdf                                      # All-org summary: lines per language, largest repos
+├── GlobalReport.json                                     # Same data in JSON
+├── code_lines_by_language.json                           # Lines-of-code totals grouped by language
 │
-├── byfile-report/                                   # File-level breakdown
-│   ├── repository_summary.pdf                       # Cross-repo file summary (all repos combined)
-│   ├── repository_summary.json                      # Same data in JSON
+├── byfile-report/                                        # File-level breakdown
+│   ├── Result_<org>_<repo>_<branch>_byfile.json         # Per-repo: every file with its line counts (JSON)
+│   ├── repository_summary.json                           # Cross-repo file summary (JSON)
 │   ├── csv-report/
-│   │   ├── repository_summary.csv                   # Cross-repo file summary (CSV)
-│   │   └── Result_<org>_<repo>_<branch>_byfile.csv # Per-repo: every file, its lines and code lines
+│   │   ├── repository_summary.csv                        # Cross-repo file summary (CSV)
+│   │   └── Result_<org>_<repo>_<branch>_byfile.csv      # Per-repo: every file, its lines and code lines
 │   └── pdf-report/
-│       ├── repository_summary.pdf                   # Cross-repo file summary (PDF)
-│       └── Result_<org>_<repo>_<branch>_byfile.pdf # Per-repo file breakdown (PDF)
+│       ├── repository_summary.pdf                        # Cross-repo file summary (PDF)
+│       └── Result_<org>_<repo>_<branch>_byfile.pdf      # Per-repo file breakdown (PDF)
 │
-└── bylanguage-report/                               # Language-level breakdown
-    ├── Result_<org>_<repo>_<branch>.json            # Per-repo: lines grouped by language (JSON)
-    ├── csv-report/
-    │   └── Result_<org>_<repo>_<branch>.csv         # Per-repo language breakdown (CSV)
-    └── pdf-report/
-        └── Result_<org>_<repo>_<branch>.pdf         # Per-repo language breakdown (PDF)
+└── bylanguage-report/                                    # Language-level breakdown
+    └── Result_<org>_<repo>_<branch>.json                 # Per-repo: lines grouped by language (JSON)
 ```
 
 > File names follow the pattern `Result_<organisation>_<repository>_<branch>` so results from multiple organisations or runs can coexist in the same folder.
@@ -126,7 +122,7 @@ Results/
 | `GlobalReport.pdf / .json` | Organisation-wide totals: lines of code per language, largest repository, total repository and branch counts |
 | `byfile-report/repository_summary.*` | Cross-repository file summary — lists every analysed repository with its total lines, blank lines, comments, and code lines |
 | `byfile-report/*_byfile.*` | Per-repository file tree — one row per source file with individual line counts |
-| `bylanguage-report/*.*` | Per-repository language breakdown — one row per detected language with line counts |
+| `bylanguage-report/*.json` | Per-repository language breakdown — one row per detected language with line counts |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,44 @@ Credentials are entered in the browser and saved automatically — no config fil
 
 ## Reports
 
-Reports are available at the `Results` page after each run:
+After each run, GoLC writes all reports to a `Results/` folder in the working directory. Click **View Results** in the browser to open the interactive dashboard, or navigate to the folder directly.
 
+### Output file tree
 
+```
+Results/
+├── GlobalReport.pdf                                 # All-org summary: lines per language, largest repos
+├── GlobalReport.json                                # Same data in JSON
+├── code_lines_by_language.json                      # Lines-of-code totals grouped by language
+│
+├── byfile-report/                                   # File-level breakdown
+│   ├── repository_summary.pdf                       # Cross-repo file summary (all repos combined)
+│   ├── repository_summary.json                      # Same data in JSON
+│   ├── csv-report/
+│   │   ├── repository_summary.csv                   # Cross-repo file summary (CSV)
+│   │   └── Result_<org>_<repo>_<branch>_byfile.csv # Per-repo: every file, its lines and code lines
+│   └── pdf-report/
+│       ├── repository_summary.pdf                   # Cross-repo file summary (PDF)
+│       └── Result_<org>_<repo>_<branch>_byfile.pdf # Per-repo file breakdown (PDF)
+│
+└── bylanguage-report/                               # Language-level breakdown
+    ├── Result_<org>_<repo>_<branch>.json            # Per-repo: lines grouped by language (JSON)
+    ├── csv-report/
+    │   └── Result_<org>_<repo>_<branch>.csv         # Per-repo language breakdown (CSV)
+    └── pdf-report/
+        └── Result_<org>_<repo>_<branch>.pdf         # Per-repo language breakdown (PDF)
+```
+
+> File names follow the pattern `Result_<organisation>_<repository>_<branch>` so results from multiple organisations or runs can coexist in the same folder.
+
+### What each report contains
+
+| Report | Contents |
+|--------|----------|
+| `GlobalReport.pdf / .json` | Organisation-wide totals: lines of code per language, largest repository, total repository and branch counts |
+| `byfile-report/repository_summary.*` | Cross-repository file summary — lists every analysed repository with its total lines, blank lines, comments, and code lines |
+| `byfile-report/*_byfile.*` | Per-repository file tree — one row per source file with individual line counts |
+| `bylanguage-report/*.*` | Per-repository language breakdown — one row per detected language with line counts |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Credentials are entered in the browser and saved automatically — no config fil
 
 ## Reports
 
-After each run, GoLC writes all reports to a `Results/` folder in the working directory. Click **View Results** in the browser to open the interactive dashboard, or navigate to the folder directly.
+After each run, GoLC writes all reports to a `Results/` folder in the working directory. When launched by double-clicking, this is the folder containing the binary. When launched from a terminal, it is whatever directory the terminal is in when the command is run. Click **View Results** in the browser to open the interactive dashboard, or navigate to the folder directly.
 
 ### Output file tree
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Credentials are entered in the browser and saved automatically — no config fil
 
 ## Reports
 
-After each run, GoLC writes all reports to a `Results/` folder in the working directory. When launched by double-clicking, this is the folder containing the binary. When launched from a terminal, it is whatever directory the terminal is in when the command is run. Click **View Results** in the browser to open the interactive dashboard, or navigate to the folder directly.
+After each run, GoLC writes all reports to a `Results/` folder next to the binary. This is always the case regardless of how the binary was launched (double-click, terminal, or PATH). Click **View Results** in the browser to open the interactive dashboard, or navigate to the folder directly.
 
 ### Output file tree
 
@@ -178,4 +178,4 @@ YAML               | .yaml, .yml                              | #               
 
 ## Execution Log
 
-GoLC writes a detailed log to `Logs/Logs.log` in the working directory. The file is recreated on each run. Use it to troubleshoot authentication errors, rate limits, or unexpected results.
+GoLC writes a detailed log to `Logs/Logs.log` next to the binary. The file is recreated on each run. Use it to troubleshoot authentication errors, rate limits, or unexpected results.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ webui.exe
 .\webui.exe
 ```
 
-Open the URL printed in the terminal (default: `http://localhost:8091`), then:
+The browser opens automatically to the GoLC UI (default: `http://localhost:8091`). If it doesn't open, copy the URL printed in the terminal. Then:
 
 1. **Choose your platform** — click the platform card.
 2. **Enter credentials** — token, organization, and any other required fields. Previous settings are pre-filled automatically.

--- a/README.md
+++ b/README.md
@@ -38,24 +38,9 @@ Each archive contains two binaries:
 | `webui` / `webui.exe` | Browser-based launcher — start here |
 | `ResultsAll` / `ResultsAll.exe` | Results dashboard (launched automatically by `webui`) |
 
-Then run it for your operating system:
+Run `webui` / `webui.exe`. The browser opens automatically to the GoLC UI (default: `http://localhost:8091`).
 
-**Mac / Linux**
-```bash
-./webui
-```
-
-**Windows** (Command Prompt)
-```bat
-webui.exe
-```
-
-**Windows** (PowerShell)
-```powershell
-.\webui.exe
-```
-
-The browser opens automatically to the GoLC UI (default: `http://localhost:8091`). If it doesn't open, copy the URL printed in the terminal. Then:
+If it doesn't open, copy the URL printed in the terminal. Then:
 
 1. **Choose your platform** — click the platform card.
 2. **Enter credentials** — token, organization, and any other required fields. Previous settings are pre-filled automatically.

--- a/ResultsAll.go
+++ b/ResultsAll.go
@@ -1074,6 +1074,13 @@ func handlePortConflict(port int) {
 }
 
 func main() {
+	if exePath, err := os.Executable(); err == nil {
+		if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
+			exePath = resolved
+		}
+		_ = os.Chdir(filepath.Dir(exePath))
+	}
+
 	pageData, err := loadApplicationData()
 	if err != nil {
 		fmt.Println("❌", err)

--- a/ResultsAll.go
+++ b/ResultsAll.go
@@ -1074,12 +1074,7 @@ func handlePortConflict(port int) {
 }
 
 func main() {
-	if exePath, err := os.Executable(); err == nil {
-		if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
-			exePath = resolved
-		}
-		_ = os.Chdir(filepath.Dir(exePath))
-	}
+	utils.ChdirToBinaryDir()
 
 	pageData, err := loadApplicationData()
 	if err != nil {

--- a/pkg/utils/startup.go
+++ b/pkg/utils/startup.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ChdirToBinaryDir changes the working directory to the folder containing the
+// running executable. This ensures all relative paths (Results/, Logs/,
+// config.json, imgs/) resolve to the binary's own directory regardless of how
+// it was launched (double-click, terminal, PATH). Subprocesses inherit the
+// corrected CWD automatically.
+func ChdirToBinaryDir() {
+	exePath, err := os.Executable()
+	if err != nil {
+		return
+	}
+	if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
+		exePath = resolved
+	}
+	_ = os.Chdir(filepath.Dir(exePath))
+}

--- a/webui.go
+++ b/webui.go
@@ -1022,6 +1022,17 @@ func openBrowser(url string) {
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 func main() {
+	// Always run from the binary's own directory so all relative paths
+	// (Results/, Logs/, config.json, imgs/) resolve correctly regardless
+	// of how the binary was launched (double-click, terminal, PATH).
+	// Subprocesses inherit this CWD automatically.
+	if exePath, err := os.Executable(); err == nil {
+		if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
+			exePath = resolved
+		}
+		_ = os.Chdir(filepath.Dir(exePath))
+	}
+
 	// When invoked as an internal analysis subprocess, run the GoLC engine and exit.
 	if len(os.Args) > 1 && os.Args[1] == "--internal-run" {
 		if len(os.Args) < 3 {

--- a/webui.go
+++ b/webui.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/SonarSource-Demos/sonar-golc/pkg/utils"
 )
 
 //go:embed all:dist
@@ -1022,16 +1024,7 @@ func openBrowser(url string) {
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 func main() {
-	// Always run from the binary's own directory so all relative paths
-	// (Results/, Logs/, config.json, imgs/) resolve correctly regardless
-	// of how the binary was launched (double-click, terminal, PATH).
-	// Subprocesses inherit this CWD automatically.
-	if exePath, err := os.Executable(); err == nil {
-		if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
-			exePath = resolved
-		}
-		_ = os.Chdir(filepath.Dir(exePath))
-	}
+	utils.ChdirToBinaryDir()
 
 	// When invoked as an internal analysis subprocess, run the GoLC engine and exit.
 	if len(os.Args) > 1 && os.Args[1] == "--internal-run" {

--- a/webui.go
+++ b/webui.go
@@ -1004,6 +1004,21 @@ func handleStatic(w http.ResponseWriter, r *http.Request) {
 	staticHandler.ServeHTTP(w, r)
 }
 
+// openBrowser launches the default browser to url on macOS, Windows, and Linux.
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		// empty second argument avoids issues with URLs containing '&'
+		cmd = exec.Command("cmd", "/c", "start", "", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	_ = cmd.Start()
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 func main() {
@@ -1029,9 +1044,18 @@ func main() {
 	mux.HandleFunc("/dist/", handleStatic)
 
 	port := findFreePort(webuiPort)
-	addr := fmt.Sprintf(":%d", port)
-	fmt.Printf("GoLC Web UI started on http://localhost:%d\n", port)
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	url := fmt.Sprintf("http://localhost:%d", port)
+
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "server error:", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("GoLC Web UI started on %s\n", url)
+	openBrowser(url)
+
+	if err := http.Serve(ln, mux); err != nil {
 		fmt.Fprintln(os.Stderr, "server error:", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

- Double-clicking the `webui` binary (or running it from any directory) now opens the GoLC UI in the default browser automatically
- Works on macOS (`open`), Linux (`xdg-open`), and Windows (`cmd /c start`)
- The TCP listener is bound *before* the browser is opened, so the page loads immediately without any sleep or retry — no "connection refused" flash
- The URL is still printed to the terminal as a fallback if the browser fails to open
- Updated README to reflect the new behaviour

## Test plan

- [ ] macOS: double-click `webui` — browser opens to `http://localhost:8091`
- [ ] macOS: run `./webui` from a different directory — browser still opens
- [ ] Windows: double-click `webui.exe` — browser opens
- [ ] Linux: run `./webui` — browser opens via `xdg-open`
- [ ] When default port 8091 is busy — browser opens to the alternative port printed in the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process startup behavior by forcing `cwd` to the executable directory and auto-launching the system browser, which can affect relative-path file I/O and behavior in headless/server environments.
> 
> **Overview**
> **`webui` now auto-opens the GoLC UI in the default browser** on startup (macOS `open`, Windows `cmd /c start`, Linux `xdg-open`), binding the TCP listener before launching to avoid initial connection failures.
> 
> Adds `utils.ChdirToBinaryDir()` and calls it from both `webui` and `ResultsAll` so `Results/`, `Logs/`, `config.json`, and embedded assets resolve relative to the binary location regardless of how the app is launched.
> 
> README is updated to reflect the new launch flow and to clarify that reports/logs are always written next to the binary, with expanded documentation of the file-tree report outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508de0de2d9891feddcf74ec3db617d9b50ede30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->