### PR TITLE
fix: correct pagination URL corruption in Bitbucket DC fetch

### DIFF
--- a/pkg/devops/getbitbucketdc/getbitbucketdc.go
+++ b/pkg/devops/getbitbucketdc/getbitbucketdc.go
@@ -193,7 +193,6 @@ type FetchParams struct {
 }
 
 const tokenOpt = "Bearer "
-const Startopt = "%s?start=%d"
 
 var ErrEmptyRepo = errors.New("repository is empty")
 
@@ -729,8 +728,9 @@ func ifExistBranches(repoURL, accessToken string) ([]Branch, error) {
 	return branchesResp.Values, nil
 }
 
-func fetchAllProjects(url string, accessToken string, exclusionList *utils.ExclusionList) ([]Project, error) {
+func fetchAllProjects(baseURL string, accessToken string, exclusionList *utils.ExclusionList) ([]Project, error) {
 	var allProjects []Project
+	url := baseURL
 	for {
 		projectsResp, err := fetchProjects(url, accessToken, true)
 		if err != nil {
@@ -752,7 +752,7 @@ func fetchAllProjects(url string, accessToken string, exclusionList *utils.Exclu
 		if projectResponse.IsLastPage {
 			break
 		}
-		url = fmt.Sprintf(Startopt, url, projectResponse.NextPageStart)
+		url = fmt.Sprintf("%s?start=%d", baseURL, projectResponse.NextPageStart)
 	}
 	return allProjects, nil
 }
@@ -868,9 +868,10 @@ func isRepoExcluded(exclusionList *utils.ExclusionList, repo string) bool {
 	return excluded
 }
 
-func fetchAllRepos(url string, accessToken string, exclusionList *utils.ExclusionList) ([]Repo, error) {
+func fetchAllRepos(baseURL string, accessToken string, exclusionList *utils.ExclusionList) ([]Repo, error) {
 	var allRepos []Repo
 	loggers := utils.SharedLogger()
+	url := baseURL
 	for {
 		reposResp, err := fetchRepos(url, accessToken, true)
 		if err != nil {
@@ -895,7 +896,7 @@ func fetchAllRepos(url string, accessToken string, exclusionList *utils.Exclusio
 		if ReposResponse.IsLastPage {
 			break
 		}
-		url = fmt.Sprintf(Startopt, url, ReposResponse.NextPageStart)
+		url = fmt.Sprintf("%s?start=%d", baseURL, ReposResponse.NextPageStart)
 	}
 	return allRepos, nil
 }
@@ -935,8 +936,9 @@ func fetchRepos(url string, accessToken string, isProjectResponse bool) (interfa
 
 }
 
-func fetchAllBranches(url string, accessToken string) ([]Branch, error) {
+func fetchAllBranches(baseURL string, accessToken string) ([]Branch, error) {
 	var allBranches []Branch
+	url := baseURL
 	for {
 		branchesResp, err := fetchBranches(url, accessToken)
 		if err != nil {
@@ -946,7 +948,7 @@ func fetchAllBranches(url string, accessToken string) ([]Branch, error) {
 		if branchesResp.IsLastPage {
 			break
 		}
-		url = fmt.Sprintf(Startopt, url, branchesResp.NextPageStart)
+		url = fmt.Sprintf("%s?start=%d", baseURL, branchesResp.NextPageStart)
 	}
 	return allBranches, nil
 }

--- a/pkg/devops/getbitbucketdc/getbitbucketdc_test.go
+++ b/pkg/devops/getbitbucketdc/getbitbucketdc_test.go
@@ -313,3 +313,77 @@ func TestIfExistBranches_APIError(t *testing.T) {
 		t.Error("expected error for API error response")
 	}
 }
+
+func TestFetchAllRepos_Pagination(t *testing.T) {
+	// Verifies that multi-page repo fetches build each next-page URL from the
+	// base URL, not by appending ?start=N to the already-paginated URL.
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		start := r.URL.Query().Get("start")
+		// Any call beyond page 1 must carry exactly one start= param.
+		if callCount > 1 && start == "" {
+			t.Errorf("call %d: expected start query param, got none (url: %s)", callCount, r.URL.String())
+		}
+		if r.URL.RawQuery != "" && r.URL.RawQuery != fmt.Sprintf("start=%s", start) {
+			t.Errorf("call %d: malformed query string %q — likely appended ?start= to prior paginated URL", callCount, r.URL.RawQuery)
+		}
+		if start == "1" {
+			json.NewEncoder(w).Encode(RepoResponse{
+				IsLastPage: true,
+				Values:     []Repo{{Slug: "repo-b", Name: "repo-b", Project: struct{ Key string `json:"key"` }{Key: "PROJ"}}},
+			})
+		} else {
+			json.NewEncoder(w).Encode(RepoResponse{
+				IsLastPage:    false,
+				NextPageStart: 1,
+				Values:        []Repo{{Slug: "repo-a", Name: "repo-a", Project: struct{ Key string `json:"key"` }{Key: "PROJ"}}},
+			})
+		}
+	}))
+	defer ts.Close()
+
+	el := &utils.ExclusionList{Projects: map[string]bool{}, Repos: map[string]bool{}}
+	repos, err := fetchAllRepos(ts.URL+"/repos", "token", el)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Errorf("expected 2 repos across 2 pages, got %d", len(repos))
+	}
+}
+
+func TestFetchAllProjects_Pagination(t *testing.T) {
+	// Verifies that multi-page project fetches build each next-page URL from the
+	// base URL, not by appending ?start=N to the already-paginated URL.
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		start := r.URL.Query().Get("start")
+		if r.URL.RawQuery != "" && r.URL.RawQuery != fmt.Sprintf("start=%s", start) {
+			t.Errorf("call %d: malformed query string %q — likely appended ?start= to prior paginated URL", callCount, r.URL.RawQuery)
+		}
+		if start == "1" {
+			json.NewEncoder(w).Encode(ProjectResponse{
+				IsLastPage: true,
+				Values:     []Project{{Key: "PROJ-B", Name: "Project B"}},
+			})
+		} else {
+			json.NewEncoder(w).Encode(ProjectResponse{
+				IsLastPage:    false,
+				NextPageStart: 1,
+				Values:        []Project{{Key: "PROJ-A", Name: "Project A"}},
+			})
+		}
+	}))
+	defer ts.Close()
+
+	el := &utils.ExclusionList{Projects: map[string]bool{}, Repos: map[string]bool{}}
+	projects, err := fetchAllProjects(ts.URL+"/projects", "token", el)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(projects) != 2 {
+		t.Errorf("expected 2 projects across 2 pages, got %d", len(projects))
+	}
+}


### PR DESCRIPTION
## Summary

- `fetchAllRepos`, `fetchAllBranches`, and `fetchAllProjects` were building next-page URLs by appending `?start=N` to the *accumulated* URL from the previous iteration
- By the third page the URL contained two `?` separators (e.g. `.../repos?start=25?start=50`), which is invalid
- Depending on the server's tolerance: either an HTML error page was returned (causing `invalid character '<' looking for beginning of value`) or the server silently returned `NextPageStart=0` with `IsLastPage=false`, creating an infinite pagination loop that ended in a network timeout after several minutes
- Fix: keep the original `baseURL` immutable and always build the next-page URL as `baseURL + "?start=N"` — matching the correct pattern already used by `getDefaultBranch`
- Removes the now-unused `Startopt` constant

## Test plan

- [ ] All existing tests in `pkg/devops/getbitbucketdc` pass (`go test ./pkg/devops/getbitbucketdc/...`)
- [ ] Verify against a Bitbucket DC instance with a project containing more than one page of repos (>25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Bitbucket DC pagination for projects/repos/branches; mistakes could still break discovery or cause incomplete/infinite fetch loops, though changes are small and covered by new tests.
> 
> **Overview**
> Fixes Bitbucket DC pagination URL construction in `fetchAllProjects`, `fetchAllRepos`, and `fetchAllBranches` by keeping an immutable `baseURL` and rebuilding each `?start=` page URL from that base (preventing corrupted URLs like `...?start=25?start=50`).
> 
> Removes the unused `Startopt` constant and adds HTTP tests that assert multi-page project/repo pagination generates a single well-formed `start` query parameter per request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2d65eef6b2b6a9e0e75e07e1cb2d5b540cf907a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->