### PR TITLE
fix: exclude archived repositories from LOC calculation on Bitbucket

### DIFF
--- a/pkg/devops/getbitbucket/getbitbucket.go
+++ b/pkg/devops/getbitbucket/getbitbucket.go
@@ -663,7 +663,7 @@ func getRepoAnalyse(params ParamsProjectBitbucket) ([]ProjectBranch, int, int, i
 		spin1.Stop()
 		NBRrepo = len(repos) + emptyOrArchivedCount + archivedCount
 		if emptyOrArchivedCount > 0 || archivedCount > 0 {
-			loggers.Infof("\t  ✅ The number of %s found is: %d - Find empty %d:", message4, NBRrepo, emptyOrArchivedCount)
+			loggers.Infof("\t  ✅ The number of %s found is: %d - Find empty: %d, archived: %d", message4, NBRrepo, emptyOrArchivedCount, archivedCount)
 		} else {
 			loggers.Infof("\t  ✅ The number of %s found is: %d", message4, NBRrepo)
 		}

--- a/pkg/devops/getbitbucket/getbitbucket.go
+++ b/pkg/devops/getbitbucket/getbitbucket.go
@@ -661,11 +661,10 @@ func getRepoAnalyse(params ParamsProjectBitbucket) ([]ProjectBranch, int, int, i
 		totalexclude = totalexclude + excludedCount
 
 		spin1.Stop()
-		if emptyOrArchivedCount > 0 {
-			NBRrepo = len(repos) + emptyOrArchivedCount
+		NBRrepo = len(repos) + emptyOrArchivedCount + archivedCount
+		if emptyOrArchivedCount > 0 || archivedCount > 0 {
 			loggers.Infof("\t  ✅ The number of %s found is: %d - Find empty %d:", message4, NBRrepo, emptyOrArchivedCount)
 		} else {
-			NBRrepo = len(repos)
 			loggers.Infof("\t  ✅ The number of %s found is: %d", message4, NBRrepo)
 		}
 
@@ -768,6 +767,9 @@ func listReposForProject(parms ParamsProjectBitbucket, projectKey string) (int, 
 			if repo.IsArchived {
 				loggers.Debugf("→ repo %s/%s: skipped (archived)", projectKey, repo.Slug)
 				archivedCount++
+				if parms.SingleRepos == repo.Slug {
+					return archivedCount, 0, 0, nil, nil
+				}
 				continue
 			}
 			bbRepo := bitbucket.Repository{

--- a/pkg/devops/getbitbucket/getbitbucket.go
+++ b/pkg/devops/getbitbucket/getbitbucket.go
@@ -644,7 +644,7 @@ func getRepoAnalyse(params ParamsProjectBitbucket) ([]ProjectBranch, int, int, i
 		fmt.Print("\n")
 		loggers.Infof("\t🟢  Analyse Project: %s ", project.Name)
 
-		emptyOrArchivedCount, excludedCount, repos, err := listReposForProject(params, project.Key)
+		archivedCount, emptyOrArchivedCount, excludedCount, repos, err := listReposForProject(params, project.Key)
 		if err != nil {
 			if len(params.SingleRepos) == 0 {
 				loggers.Errorf("❌ Get Repos for each Project:%v", err)
@@ -657,6 +657,7 @@ func getRepoAnalyse(params ParamsProjectBitbucket) ([]ProjectBranch, int, int, i
 			}
 		}
 		emptyRepos = emptyRepos + emptyOrArchivedCount
+		cptarchiv = cptarchiv + archivedCount
 		totalexclude = totalexclude + excludedCount
 
 		spin1.Stop()
@@ -697,9 +698,10 @@ func getRepoAnalyse(params ParamsProjectBitbucket) ([]ProjectBranch, int, int, i
 	return importantBranches, emptyRepos, NBRrepos, TotalBranches, totalexclude, cptarchiv, nil
 
 }
-func listReposForProject(parms ParamsProjectBitbucket, projectKey string) (int, int, []*bitbucket.Repository, error) {
+func listReposForProject(parms ParamsProjectBitbucket, projectKey string) (int, int, int, []*bitbucket.Repository, error) {
 	var allRepos []*bitbucket.Repository
-	var excludedCount, emptyOrArchivedCount int
+	var archivedCount, excludedCount, emptyOrArchivedCount int
+	loggers := utils.SharedLogger()
 
 	// Use direct HTTP calls with Basic Auth support
 	url := fmt.Sprintf("%srepositories/%s?q=project.key=\"%s\"&pagelen=100", parms.BitbucketURLBase, parms.Workspace, projectKey)
@@ -707,32 +709,32 @@ func listReposForProject(parms ParamsProjectBitbucket, projectKey string) (int, 
 	for url != "" {
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
-			return 0, 0, nil, err
+			return 0, 0, 0, nil, err
 		}
 		req.Header.Set("Authorization", getAuthHeader(parms.Users, parms.AccessToken))
 
 		resp, err := utils.HTTPClient.Do(req)
 		if err != nil {
-			return 0, 0, nil, err
+			return 0, 0, 0, nil, err
 		}
 
 		if resp.StatusCode != http.StatusOK {
 			body, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			return 0, 0, nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+			return 0, 0, 0, nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
 		}
 
 		body, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
-			return 0, 0, nil, err
+			return 0, 0, 0, nil, err
 		}
 
 		var reposResponse struct {
 			Values []struct {
-				Type     string `json:"type"`
-				FullName string `json:"full_name"`
-				Links    struct {
+				Type       string `json:"type"`
+				FullName   string `json:"full_name"`
+				Links      struct {
 					Self struct {
 						Href string `json:"href"`
 					} `json:"self"`
@@ -741,6 +743,7 @@ func listReposForProject(parms ParamsProjectBitbucket, projectKey string) (int, 
 				Slug       string `json:"slug"`
 				UUID       string `json:"uuid"`
 				IsPrivate  bool   `json:"is_private"`
+				IsArchived bool   `json:"is_archived"`
 				Mainbranch struct {
 					Name string `json:"name"`
 				} `json:"mainbranch"`
@@ -756,12 +759,17 @@ func listReposForProject(parms ParamsProjectBitbucket, projectKey string) (int, 
 
 		err = json.Unmarshal(body, &reposResponse)
 		if err != nil {
-			return 0, 0, nil, err
+			return 0, 0, 0, nil, err
 		}
 
 		// Convert to bitbucket.Repository format
 		var reposResItems []bitbucket.Repository
 		for _, repo := range reposResponse.Values {
+			if repo.IsArchived {
+				loggers.Debugf("→ repo %s/%s: skipped (archived)", projectKey, repo.Slug)
+				archivedCount++
+				continue
+			}
 			bbRepo := bitbucket.Repository{
 				Full_name:  repo.FullName,
 				Slug:       repo.Slug,
@@ -786,7 +794,7 @@ func listReposForProject(parms ParamsProjectBitbucket, projectKey string) (int, 
 
 		eoc, exc, repos, err := listRepos(parms, projectKey, reposRes)
 		if err != nil {
-			return 0, 0, nil, err
+			return 0, 0, 0, nil, err
 		}
 		emptyOrArchivedCount += eoc
 		excludedCount += exc
@@ -795,7 +803,7 @@ func listReposForProject(parms ParamsProjectBitbucket, projectKey string) (int, 
 		url = reposResponse.Next
 	}
 
-	return emptyOrArchivedCount, excludedCount, allRepos, nil
+	return archivedCount, emptyOrArchivedCount, excludedCount, allRepos, nil
 }
 
 func listRepos(parms ParamsProjectBitbucket, projectKey string, reposRes *bitbucket.RepositoriesRes) (int, int, []*bitbucket.Repository, error) {

--- a/pkg/devops/getbitbucket/getbitbucket_test.go
+++ b/pkg/devops/getbitbucket/getbitbucket_test.go
@@ -311,3 +311,109 @@ func TestGetSpecificProjectsWithAuth_ExcludedProject(t *testing.T) {
 		t.Errorf("expected 1 excluded, got %d", excluded)
 	}
 }
+
+func TestListReposForProject_ArchivedFiltered(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repositories/ws":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{
+						"slug":        "repo-archived",
+						"full_name":   "ws/repo-archived",
+						"is_archived": true,
+						"mainbranch":  map[string]string{"name": "main"},
+						"project":     map[string]string{"key": "PROJ"},
+					},
+					{
+						"slug":        "repo-active",
+						"full_name":   "ws/repo-active",
+						"is_archived": false,
+						"mainbranch":  map[string]string{"name": "main"},
+						"project":     map[string]string{"key": "PROJ"},
+					},
+				},
+				"next": "",
+			})
+		case "/repositories/ws/repo-active/src/main/":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values":  []map[string]interface{}{{"path": "README.md", "type": "commit_file"}},
+				"pagelen": 100,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	parms := ParamsProjectBitbucket{
+		Workspace:        "ws",
+		AccessToken:      "token",
+		BitbucketURLBase: ts.URL + "/",
+		Exclusionlist:    utils.NewExclusionList(nil, nil),
+	}
+
+	archivedCount, emptyOrArchived, excluded, repos, err := listReposForProject(parms, "PROJ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if archivedCount != 1 {
+		t.Errorf("expected archivedCount=1, got %d", archivedCount)
+	}
+	if emptyOrArchived != 0 {
+		t.Errorf("expected emptyOrArchived=0, got %d", emptyOrArchived)
+	}
+	if excluded != 0 {
+		t.Errorf("expected excluded=0, got %d", excluded)
+	}
+	if len(repos) != 1 {
+		t.Errorf("expected 1 repo, got %d", len(repos))
+	}
+}
+
+func TestListReposForProject_SingleReposArchived(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repositories/ws" {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{
+						"slug":        "repo-archived",
+						"full_name":   "ws/repo-archived",
+						"is_archived": true,
+						"mainbranch":  map[string]string{"name": "main"},
+						"project":     map[string]string{"key": "PROJ"},
+					},
+				},
+				"next": "",
+			})
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	parms := ParamsProjectBitbucket{
+		Workspace:        "ws",
+		AccessToken:      "token",
+		BitbucketURLBase: ts.URL + "/",
+		Exclusionlist:    utils.NewExclusionList(nil, nil),
+		SingleRepos:      "repo-archived",
+	}
+
+	archivedCount, emptyOrArchived, excluded, repos, err := listReposForProject(parms, "PROJ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if archivedCount != 1 {
+		t.Errorf("expected archivedCount=1, got %d", archivedCount)
+	}
+	if emptyOrArchived != 0 {
+		t.Errorf("expected emptyOrArchived=0, got %d", emptyOrArchived)
+	}
+	if excluded != 0 {
+		t.Errorf("expected excluded=0, got %d", excluded)
+	}
+	if len(repos) != 0 {
+		t.Errorf("expected 0 repos, got %d", len(repos))
+	}
+}

--- a/pkg/devops/getbitbucketdc/getbitbucketdc.go
+++ b/pkg/devops/getbitbucketdc/getbitbucketdc.go
@@ -76,9 +76,10 @@ type RepoResponse struct {
 }
 
 type Repo struct {
-	Slug    string `json:"slug"`
-	Name    string `json:"name"`
-	Project struct {
+	Slug     string `json:"slug"`
+	Name     string `json:"name"`
+	Archived bool   `json:"archived"`
+	Project  struct {
 		Key string `json:"key"`
 	} `json:"project"`
 	Links struct {
@@ -797,6 +798,11 @@ func fetchOneRepos(url string, accessToken string, exclusionList *utils.Exclusio
 		os.Exit(1)
 	}
 
+	if repo.Archived {
+		loggers.Infof("⏭️  Skipping <%s>: archived", repo.Name)
+		return allRepos, nil
+	}
+
 	KEYTEST := repo.Project.Key + "/" + repo.Slug
 
 	if len(exclusionList.Projects) == 0 && len(exclusionList.Repos) == 0 {
@@ -880,6 +886,11 @@ func fetchAllRepos(baseURL string, accessToken string, exclusionList *utils.Excl
 		ReposResponse := reposResp.(*RepoResponse)
 		for _, repo := range ReposResponse.Values {
 			KEYTEST := repo.Project.Key + "/" + repo.Slug
+
+			if repo.Archived {
+				loggers.Debugf("→ repo %s: skipped (archived)", KEYTEST)
+				continue
+			}
 
 			if len(exclusionList.Projects) == 0 && len(exclusionList.Repos) == 0 {
 				allRepos = append(allRepos, repo)


### PR DESCRIPTION
## Summary

- **Bitbucket DC**: Added `Archived bool` to the `Repo` struct. `fetchAllRepos` and `fetchOneRepos` now skip repos where `archived=true`, which is already returned by the Bitbucket DC REST API but was previously ignored.
- **Bitbucket Cloud**: Added `is_archived` field to the HTTP response struct in `listReposForProject`. Archived repos are filtered before being passed to `listRepos`, and a separate `archivedCount` is returned so the summary line correctly reports `Archived: N`.

## Context

Reported by an user against a Bitbucket Data Center instance: archived/decommissioned repositories were being included in the LOC estimate, inflating the count relative to the repos they actually plan to analyse in SonarQube.