### PR TITLE
fix: resolve owner for personal-account GitHub analysis

### DIFF
--- a/pkg/devops/getgithub/getgithub.go
+++ b/pkg/devops/getgithub/getgithub.go
@@ -300,7 +300,8 @@ func GetReposGithub(parms ParamsReposGithub, ctx context.Context, client *github
 		}
 		isEmpty, err := reposIfEmpty(ctx, client, repoName, parms.Organization)
 		if err != nil {
-			fmt.Print(err.Error())
+			loggers.Errorf("❌ repo %s: skipped — empty-check failed: %v", repoName, err)
+			notAnalyzedCount++
 			continue
 		}
 		if isEmpty {
@@ -840,6 +841,19 @@ func GetRepoGithubList(platformConfig map[string]interface{}, exclusionfile stri
 			repositories, err1 = fetchAllRepositories(ctx, client, platformConfig["Organization"].(string), opt)
 		} else {
 			repositories, err1 = fetchUserRepositories(ctx, client, opt1)
+			// Personal account: the per-repo API calls (ListCommits, ListBranches,
+			// ListRepositoryEvents) need an owner. If the user did not fill the
+			// Organization field (it does not apply to personal accounts), resolve
+			// it from the authenticated user so downstream calls don't 404.
+			if err1 == nil && strings.TrimSpace(platformConfig["Organization"].(string)) == "" {
+				user, _, uerr := client.Users.Get(ctx, "")
+				if uerr != nil {
+					loggers.Errorf("❌ Failed to resolve authenticated user for personal-account analysis: %v", uerr)
+					return importantBranches, uerr
+				}
+				platformConfig["Organization"] = user.GetLogin()
+				loggers.Infof("👤 Personal account detected — using authenticated user '%s' as repository owner", user.GetLogin())
+			}
 		}
 	} else {
 		repositories, err1 = fetchSingleRepository(ctx, client, platformConfig)
@@ -1200,7 +1214,8 @@ func GetGithubLanguages(parms ParamsReposGithub, ctx context.Context, client *gi
 		// Next Step : Test is Repository is empty
 		isEmpty, err := reposIfEmpty(ctx, client, repoName, parms.Organization)
 		if err != nil {
-			fmt.Print(err.Error())
+			loggers := utils.SharedLogger()
+			loggers.Errorf("❌ repo %s: skipped — empty-check failed: %v", repoName, err)
 			continue
 
 		}


### PR DESCRIPTION
## Summary
- Personal-account GitHub analysis (toggle **Analyze as organization** OFF, empty Organization field) was failing with `No Analysis performed...` because per-repo calls (`ListCommits`, `ListBranches`, `ListRepositoryEvents`) were issued with an empty owner and GitHub returned 404 for every repo.
- The `reposIfEmpty` error was printed via `fmt.Print` to stdout, bypassing the logger, so the UI debug log only showed the final "No Analysis performed..." line with no actionable cause.

## Fix
- In `GetRepoGithubList`, when `Org=false` and `Organization` is blank, resolve the authenticated user's login via `client.Users.Get(ctx, "")` and use it as the effective owner for downstream per-repo calls. Logs `👤 Personal account detected — using authenticated user '<login>' as repository owner` for visibility.
- Route the previously-silent `reposIfEmpty` error through `loggers.Errorf` in both call sites (regular path and `FastAnalys`), so any future GitHub failure surfaces in the debug log instead of being swallowed.

## Repro (before fix)
1. Run GoLC web UI against GitHub Cloud with a personal account token.
2. Toggle **Analyze as organization** OFF and leave Organization empty.
3. Observed: repos discovered correctly, but `Total Branches that will be analyzed: 0` followed by `No Analysis performed...`. Summary shows `in the organization <>`.

## After fix
- Personal-account analysis proceeds end-to-end.
- If anything else fails the per-repo empty check, the actual error is now visible in the debug log.

## Test plan
- [ ] Verify a personal account analysis completes with Organization left blank.
- [ ] Verify org analysis still works unchanged (Org=true path is untouched).
- [ ] Verify single-repo analysis still works (Repos non-empty path is untouched).
- [ ] Verify that an intentional bad token / revoked permission now surfaces a logger error line for the failing repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted changes to GitHub repo discovery/analysis flow that mainly improve owner resolution for personal accounts and surface errors via the shared logger.
> 
> **Overview**
> Fixes personal-account GitHub analysis by auto-resolving the repository owner from the authenticated user when `Org=false` and `Organization` is blank, preventing downstream per-repo API calls from 404ing.
> 
> Improves diagnosability by routing `reposIfEmpty` failures through `loggers.Errorf` (and counting the repo as not analyzed in the main path) instead of printing to stdout, so skipped repos show an actionable error in logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc487514bc7d2610d6ca88b232b14a37f142d1ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->