### PR TITLE
fix: resolve owner for personal-account GitHub analysis

### DIFF
--- a/pkg/devops/getgithub/getgithub.go
+++ b/pkg/devops/getgithub/getgithub.go
@@ -1186,6 +1186,7 @@ func GetGithubLanguages(parms ParamsReposGithub, ctx context.Context, client *gi
 	cptarchiv := 0        // Counter archiv repos
 	notAnalyzedCount := 0 // Counter Number of repositories excluded
 	emptyRepo := 0        // Counter Number of repositories empty
+	loggers := utils.SharedLogger()
 	parms.Spin.Stop()
 	spin1 := spinner.New(spinner.CharSets[35], 100*time.Millisecond)
 	spin1.Color("green", "bold")
@@ -1214,8 +1215,8 @@ func GetGithubLanguages(parms ParamsReposGithub, ctx context.Context, client *gi
 		// Next Step : Test is Repository is empty
 		isEmpty, err := reposIfEmpty(ctx, client, repoName, parms.Organization)
 		if err != nil {
-			loggers := utils.SharedLogger()
 			loggers.Errorf("❌ repo %s: skipped — empty-check failed: %v", repoName, err)
+			notAnalyzedCount++
 			continue
 
 		}

--- a/pkg/devops/getgithub/getgithub.go
+++ b/pkg/devops/getgithub/getgithub.go
@@ -300,7 +300,8 @@ func GetReposGithub(parms ParamsReposGithub, ctx context.Context, client *github
 		}
 		isEmpty, err := reposIfEmpty(ctx, client, repoName, parms.Organization)
 		if err != nil {
-			fmt.Print(err.Error())
+			loggers.Errorf("❌ repo %s: skipped — empty-check failed: %v", repoName, err)
+			notAnalyzedCount++
 			continue
 		}
 		if isEmpty {
@@ -840,6 +841,19 @@ func GetRepoGithubList(platformConfig map[string]interface{}, exclusionfile stri
 			repositories, err1 = fetchAllRepositories(ctx, client, platformConfig["Organization"].(string), opt)
 		} else {
 			repositories, err1 = fetchUserRepositories(ctx, client, opt1)
+			// Personal account: the per-repo API calls (ListCommits, ListBranches,
+			// ListRepositoryEvents) need an owner. If the user did not fill the
+			// Organization field (it does not apply to personal accounts), resolve
+			// it from the authenticated user so downstream calls don't 404.
+			if err1 == nil && strings.TrimSpace(platformConfig["Organization"].(string)) == "" {
+				user, _, uerr := client.Users.Get(ctx, "")
+				if uerr != nil {
+					loggers.Errorf("❌ Failed to resolve authenticated user for personal-account analysis: %v", uerr)
+					return importantBranches, uerr
+				}
+				platformConfig["Organization"] = user.GetLogin()
+				loggers.Infof("👤 Personal account detected — using authenticated user '%s' as repository owner", user.GetLogin())
+			}
 		}
 	} else {
 		repositories, err1 = fetchSingleRepository(ctx, client, platformConfig)
@@ -1200,7 +1214,8 @@ func GetGithubLanguages(parms ParamsReposGithub, ctx context.Context, client *gi
 		// Next Step : Test is Repository is empty
 		isEmpty, err := reposIfEmpty(ctx, client, repoName, parms.Organization)
 		if err != nil {
-			fmt.Print(err.Error())
+			loggers := utils.SharedLogger()
+			loggers.Errorf("❌ repo %s: skipped — empty-check failed: %v", repoName, err)
 			continue
 
 		}

--- a/pkg/devops/getgithub/getgithub_test.go
+++ b/pkg/devops/getgithub/getgithub_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -1536,4 +1538,73 @@ func TestMainAnalysisWorkflow(t *testing.T) {
 		}()
 		analyzeRepoBranches(params, context.Background(), nil, nil, 1, nil)
 	})
+}
+
+// TestGetRepoGithubList_PersonalAccountUserGetError covers the failure path
+// introduced by the personal-account owner-resolution block: when Org=false
+// and Organization is empty, GetRepoGithubList must surface an error from
+// client.Users.Get instead of silently proceeding with an empty owner (which
+// would 404 every per-repo call downstream).
+func TestGetRepoGithubList_PersonalAccountUserGetError(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "test_github_personal_user_get_*")
+	if err != nil {
+		t.Fatalf(errFailedToCreateTempDir, err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to chdir to temp dir: %v", err)
+	}
+	if err := os.MkdirAll("Logs", 0755); err != nil {
+		t.Fatalf(errFailedToCreateLogsDir, err)
+	}
+
+	// Fake GHES server: /user/repos returns an empty list (so fetchUserRepositories
+	// succeeds), /user returns 500 (so client.Users.Get fails and we hit the new
+	// error path). Any other request is an unexpected call.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/user/repos", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	})
+	mux.HandleFunc("/api/v3/user", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"Internal Server Error"}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected GitHub API call: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	platformConfig := map[string]interface{}{
+		"Url":           server.URL + "/",
+		"AccessToken":   testToken,
+		"Organization":  "",
+		"Org":           false,
+		"Repos":         "",
+		"Branch":        "",
+		"Period":        float64(-1),
+		"Stats":         false,
+		"DefaultBranch": false,
+		"Baseapi":       "",
+		"Apiver":        testAPIVersion,
+	}
+
+	branches, err := GetRepoGithubList(platformConfig, "0", false)
+	if err == nil {
+		t.Fatalf("expected error from GetRepoGithubList when Users.Get fails, got nil (branches=%v)", branches)
+	}
+	if len(branches) != 0 {
+		t.Errorf("expected no branches when Users.Get fails, got %d", len(branches))
+	}
+	// Organization must remain unchanged on the failure path.
+	if got := platformConfig["Organization"].(string); got != "" {
+		t.Errorf("expected Organization to remain empty on Users.Get failure, got %q", got)
+	}
 }


### PR DESCRIPTION
## Summary
- Personal-account GitHub analysis (toggle **Analyze as organization** OFF, empty Organization field) was failing with `No Analysis performed...` because per-repo calls (`ListCommits`, `ListBranches`, `ListRepositoryEvents`) were issued with an empty owner and GitHub returned 404 for every repo.
- The `reposIfEmpty` error was printed via `fmt.Print` to stdout, bypassing the logger, so the UI debug log only showed the final "No Analysis performed..." line with no actionable cause.

## Fix
- In `GetRepoGithubList`, when `Org=false` and `Organization` is blank, resolve the authenticated user's login via `client.Users.Get(ctx, "")` and use it as the effective owner for downstream per-repo calls. Logs `👤 Personal account detected — using authenticated user '<login>' as repository owner` for visibility.
- Route the previously-silent `reposIfEmpty` error through `loggers.Errorf` in both call sites (regular path and `FastAnalys`), so any future GitHub failure surfaces in the debug log instead of being swallowed.

## Repro (before fix)
1. Run GoLC web UI against GitHub Cloud with a personal account token.
2. Toggle **Analyze as organization** OFF and leave Organization empty.
3. Observed: repos discovered correctly, but `Total Branches that will be analyzed: 0` followed by `No Analysis performed...`. Summary shows `in the organization <>`.

## After fix
- Personal-account analysis proceeds end-to-end.
- If anything else fails the per-repo empty check, the actual error is now visible in the debug log.