### PR TITLE
fix: skip unreadable files and parse Result_*.json names robustly (#82)

### DIFF
--- a/ResultsAll.go
+++ b/ResultsAll.go
@@ -289,13 +289,16 @@ func getRepositoryData() ([]RepositoryData, error) {
 				fmt.Sprintf("Result_%s.json", sanitizePathComponent(branch.RepoSlug)))
 		} else {
 			firstPart := getFirstPartForPlatform(platform, branch, branch.RepoSlug)
+			// Match the Result_<Org>__<Repo>__<Branch> convention written by
+			// performRepoAnalysis in golc.go. Double-underscore between fields
+			// keeps `_` free inside any component for unambiguous parsing.
 			fileName = buildSecurePath(byFileReportDir,
-				fmt.Sprintf("Result_%s_%s_%s_byfile.json",
+				fmt.Sprintf("Result_%s__%s__%s_byfile.json",
 					sanitizePathComponent(firstPart),
 					sanitizePathComponent(branch.RepoSlug),
 					sanitizePathComponent(branch.MainBranch)))
 			byLanguagePath = buildSecurePath(byLanguageReportDir,
-				fmt.Sprintf("Result_%s_%s_%s.json",
+				fmt.Sprintf("Result_%s__%s__%s.json",
 					sanitizePathComponent(firstPart),
 					sanitizePathComponent(branch.RepoSlug),
 					sanitizePathComponent(branch.MainBranch)))
@@ -467,9 +470,11 @@ func getOtherBranchesData(orgName, repoName, currentBranch string) []BranchData 
 	// Get the correct first part for filename based on platform
 	firstPart := getFirstPartForFilename(platform, orgName, repoName)
 
-	// Look for all byfile reports for this repository (different branches)
+	// Look for all byfile reports for this repository (different branches).
+	// Producer writes Result_<Org>__<Repo>__<Branch>_byfile.json (see golc.go and
+	// the byfile path constructed above) — `__` between fields, `_byfile` tail.
 	pattern := buildSecurePath(byFileReportDir,
-		fmt.Sprintf("Result_%s_%s_*_byfile.json",
+		fmt.Sprintf("Result_%s__%s__*_byfile.json",
 			sanitizePathComponent(firstPart),
 			sanitizePathComponent(repoName)))
 	matches, err := filepath.Glob(pattern)
@@ -481,24 +486,15 @@ func getOtherBranchesData(orgName, repoName, currentBranch string) []BranchData 
 	for _, filePath := range matches {
 		// Extract branch name from filename
 		filename := filepath.Base(filePath)
-		// Format: Result_ORG_REPO_BRANCH_byfile.json
-		parts := strings.Split(filename, "_")
-		if len(parts) < 4 {
+		// Format: Result_<Org>__<Repo>__<Branch>_byfile.json
+		// Extract the branch by trimming the known prefix and suffix; with the
+		// `__` field separator the result is unambiguous regardless of any `_`
+		// inside Org / Repo / Branch.
+		prefix := fmt.Sprintf("Result_%s__%s__", sanitizePathComponent(firstPart), sanitizePathComponent(repoName))
+		suffix := "_byfile.json"
+		if !strings.HasPrefix(filename, prefix) || !strings.HasSuffix(filename, suffix) {
 			continue
 		}
-
-		// Find the branch part (everything between REPO and "byfile.json")
-		branchPart := strings.TrimSuffix(parts[len(parts)-2], ".json")
-		if branchPart == "byfile" && len(parts) >= 5 {
-			// Handle case where branch name is the second-to-last part
-			branchPart = parts[len(parts)-3]
-		}
-
-		// Extract actual branch name - more robust parsing
-		// Remove the prefix and suffix to get the branch name
-		// Use firstPart (which is ProjectKey for Bitbucket, Org for others) instead of orgName
-		prefix := fmt.Sprintf("Result_%s_%s_", sanitizePathComponent(firstPart), sanitizePathComponent(repoName))
-		suffix := "_byfile.json"
 		branchName := strings.TrimSuffix(strings.TrimPrefix(filename, prefix), suffix)
 
 		// Skip the current branch (it's already shown in the main stats)
@@ -602,7 +598,7 @@ func getRepositoryDetailData(repoName, branchName string) (*RepositoryDetailData
 			fmt.Sprintf("Result_%s_byfile.json", sanitizePathComponent(repoName)))
 	} else {
 		byFileReportPath = buildSecurePath(byFileReportDir,
-			fmt.Sprintf("Result_%s_%s_%s_byfile.json",
+			fmt.Sprintf("Result_%s__%s__%s_byfile.json",
 				sanitizePathComponent(firstPart),
 				sanitizePathComponent(repoName),
 				sanitizePathComponent(branchName)))
@@ -639,7 +635,7 @@ func getRepositoryDetailData(repoName, branchName string) (*RepositoryDetailData
 			fmt.Sprintf("Result_%s.json", sanitizePathComponent(repoName)))
 	} else {
 		byLanguageReportPath = buildSecurePath(byLanguageReportDir,
-			fmt.Sprintf("Result_%s_%s_%s.json",
+			fmt.Sprintf("Result_%s__%s__%s.json",
 				sanitizePathComponent(firstPart),
 				sanitizePathComponent(repoName),
 				sanitizePathComponent(branchName)))

--- a/ResultsAll_test.go
+++ b/ResultsAll_test.go
@@ -340,7 +340,7 @@ func TestDataFunctions(t *testing.T) {
 		}
 
 		// Create byfile report
-		byFileReportPath := filepath.Join(testByFileReportDir, "Result_test-org_test-repo_main_byfile.json")
+		byFileReportPath := filepath.Join(testByFileReportDir, "Result_test-org__test-repo__main_byfile.json")
 		err = os.WriteFile(byFileReportPath, []byte(byFileReportData), 0644)
 		if err != nil {
 			t.Fatalf("Failed to create byfile report: %v", err)
@@ -404,13 +404,13 @@ func TestDataFunctions(t *testing.T) {
 			t.Fatalf("Failed to create analysis result file: %v", err)
 		}
 
-		repo1Path := filepath.Join(testByFileReportDir, "Result_test-org_repo1_main_byfile.json")
+		repo1Path := filepath.Join(testByFileReportDir, "Result_test-org__repo1__main_byfile.json")
 		err = os.WriteFile(repo1Path, []byte(byFileReport1Data), 0644)
 		if err != nil {
 			t.Fatalf("Failed to create repo1 byfile report: %v", err)
 		}
 
-		repo2Path := filepath.Join(testByFileReportDir, "Result_test-org_repo2_develop_byfile.json")
+		repo2Path := filepath.Join(testByFileReportDir, "Result_test-org__repo2__develop_byfile.json")
 		err = os.WriteFile(repo2Path, []byte(byFileReport2Data), 0644)
 		if err != nil {
 			t.Fatalf("Failed to create repo2 byfile report: %v", err)
@@ -454,8 +454,8 @@ func TestDataFunctions(t *testing.T) {
 		mainBranchData := `{"TotalLines": 5000, "TotalBlankLines": 500, "TotalComments": 1000, "TotalCodeLines": 3500}`
 		developBranchData := `{"TotalLines": 4500, "TotalBlankLines": 450, "TotalComments": 900, "TotalCodeLines": 3150}`
 
-		mainBranchPath := filepath.Join(testByFileReportDir, "Result_test-org_test-repo_main_byfile.json")
-		developBranchPath := filepath.Join(testByFileReportDir, "Result_test-org_test-repo_develop_byfile.json")
+		mainBranchPath := filepath.Join(testByFileReportDir, "Result_test-org__test-repo__main_byfile.json")
+		developBranchPath := filepath.Join(testByFileReportDir, "Result_test-org__test-repo__develop_byfile.json")
 
 		err = os.WriteFile(mainBranchPath, []byte(mainBranchData), 0644)
 		if err != nil {
@@ -739,13 +739,13 @@ func TestDetailDataFunction(t *testing.T) {
 			t.Fatalf("Failed to create global report file: %v", err)
 		}
 
-		byFileReportPath := filepath.Join(testByFileReportDir, "Result_test-org_test-repo_main_byfile.json")
+		byFileReportPath := filepath.Join(testByFileReportDir, "Result_test-org__test-repo__main_byfile.json")
 		err = os.WriteFile(byFileReportPath, []byte(byFileReportData), 0644)
 		if err != nil {
 			t.Fatalf("Failed to create byfile report: %v", err)
 		}
 
-		byLanguageReportPath := filepath.Join(testByLanguageReportDir, "Result_test-org_test-repo_main.json")
+		byLanguageReportPath := filepath.Join(testByLanguageReportDir, "Result_test-org__test-repo__main.json")
 		err = os.WriteFile(byLanguageReportPath, []byte(byLanguageReportData), 0644)
 		if err != nil {
 			t.Fatalf("Failed to create bylanguage report: %v", err)

--- a/golc.go
+++ b/golc.go
@@ -1286,6 +1286,27 @@ func runGolcInProcess(platform string) {
 	for _, file := range files {
 		// Check if the file is a JSON file
 		if !file.IsDir() && strings.HasSuffix(file.Name(), ".json") {
+			// Hard-cutover: only accept canonically-named result files. Legacy
+			// single-`_` names and other malformed names contribute neither LOC
+			// nor LargestRepository candidacy — their identity is not
+			// authoritative and they will be regenerated on the next analysis
+			// run. Parsing happens before the JSON body is read so an unparsable
+			// file has zero side-effects on totals or largest-tracking.
+			isFilePlatform := platformConfig["DevOps"].(string) == "file"
+			var parsedOrg, parsedRepo string
+			if isFilePlatform {
+				// File platform writes single-component Result_<Repo>.json.
+				parsedRepo = strings.TrimSuffix(strings.TrimPrefix(file.Name(), "Result_"), ".json")
+			} else {
+				org, repo, _, ok := utils.ParseResultFileName(file.Name())
+				if !ok {
+					logger.Warnf("⚠️  Skipping unparsable result file: %s", file.Name())
+					continue
+				}
+				parsedOrg = org
+				parsedRepo = repo
+			}
+
 			// Read contents of JSON file
 			filePath := filepath.Join(DestinationResult, file.Name())
 			jsonData, err := os.ReadFile(filePath)
@@ -1314,21 +1335,14 @@ func runGolcInProcess(platform string) {
 
 			totalCodeLinesSum += codeLinesForTotal
 
-			// Check if this repo has a higher TotalCodeLines (excl. JSON) than the current maximum
+			// Update the (max, project, repo) triple atomically — the name was
+			// already validated at the top of this iteration, so a new maximum
+			// always carries a usable repo identity.
 			if codeLinesForTotal > maxTotalCodeLines {
 				maxTotalCodeLines = codeLinesForTotal
-				// Extract project and repo from the Result_<Org>__<Repo>__<Branch>.json
-				// file name via the canonical parser. The `file` platform writes a
-				// single-component Result_<Repo>.json which the parser rejects (ok=false);
-				// fall back to TrimPrefix in that case.
-				if platformConfig["DevOps"].(string) != "file" {
-					if org, repo, _, ok := utils.ParseResultFileName(file.Name()); ok {
-						maxProject = org
-						maxRepo = repo
-					}
-				} else {
-					maxProject = ""
-					maxRepo = strings.TrimSuffix(strings.TrimPrefix(file.Name(), "Result_"), ".json")
+				maxProject = parsedOrg
+				maxRepo = parsedRepo
+				if isFilePlatform {
 					NumberRepos++
 				}
 			}

--- a/golc.go
+++ b/golc.go
@@ -1317,14 +1317,18 @@ func runGolcInProcess(platform string) {
 			// Check if this repo has a higher TotalCodeLines (excl. JSON) than the current maximum
 			if codeLinesForTotal > maxTotalCodeLines {
 				maxTotalCodeLines = codeLinesForTotal
-				// Extract project and repo name from file name
-				parts := strings.Split(strings.TrimSuffix(file.Name(), ".json"), "_")
+				// Extract project and repo from the Result_<Org>__<Repo>__<Branch>.json
+				// file name via the canonical parser. The `file` platform writes a
+				// single-component Result_<Repo>.json which the parser rejects (ok=false);
+				// fall back to TrimPrefix in that case.
 				if platformConfig["DevOps"].(string) != "file" {
-					maxProject = parts[1]
-					maxRepo = parts[2]
+					if org, repo, _, ok := utils.ParseResultFileName(file.Name()); ok {
+						maxProject = org
+						maxRepo = repo
+					}
 				} else {
 					maxProject = ""
-					maxRepo = parts[1]
+					maxRepo = strings.TrimSuffix(strings.TrimPrefix(file.Name(), "Result_"), ".json")
 					NumberRepos++
 				}
 			}

--- a/golc.go
+++ b/golc.go
@@ -523,9 +523,12 @@ func analyseAzurebRepo(project interface{}, DestinationResult string, platformCo
 
 // Perform repository analysis (common logic)
 func performRepoAnalysis(params RepoParams, DestinationResult string, spin *spinner.Spinner, results chan int, count *int, excludeExtension []string, excludePaths []string, folderKeywords []string, fileNamePatterns []string, ResultByFile bool, ResultAll bool) {
-	// Always use a consistent filename pattern so downstream parsing works across platforms
-	// Format: Result_<OrgOrProjectKey>_<RepoSlug>_<Branch>
-	outputFileName := fmt.Sprintf("Result_%s_%s_%s", params.ProjectKey, params.RepoSlug, params.MainBranch)
+	// Always use a consistent filename pattern so downstream parsing works across platforms.
+	// Format: Result_<OrgOrProjectKey>__<RepoSlug>__<Branch>
+	// The double-underscore field separator keeps `_` free to appear inside any component
+	// (GitLab group names, repo slugs, branch names like feat_xyz), so the parser in
+	// pkg/reporter/pdf can recover all three fields unambiguously.
+	outputFileName := fmt.Sprintf("Result_%s__%s__%s", params.ProjectKey, params.RepoSlug, params.MainBranch)
 	golocParams := goloc.Params{
 		Path:             params.PathToScan,
 		ByFile:           ResultByFile,

--- a/golc_integration_test.go
+++ b/golc_integration_test.go
@@ -84,7 +84,7 @@ func TestRepositorySummaryIntegration(t *testing.T) {
 			"Results": []
 		}`
 
-		err = os.WriteFile("Results/byfile-report/Result_integration-org_integration-repo_main_byfile.json", []byte(byfileData), 0644)
+		err = os.WriteFile("Results/byfile-report/Result_integration-org__integration-repo__main_byfile.json", []byte(byfileData), 0644)
 		if err != nil {
 			t.Fatalf("Failed to create byfile report: %v", err)
 		}
@@ -275,13 +275,13 @@ func TestGolcMainFlowIntegration(t *testing.T) {
 
 		// Step 2: Simulate byfile reports
 		byfileData1 := `{"TotalLines": 200, "TotalBlankLines": 20, "TotalComments": 40, "TotalCodeLines": 140}`
-		err = os.WriteFile("Results/byfile-report/Result_flow-org_repo1_main_byfile.json", []byte(byfileData1), 0644)
+		err = os.WriteFile("Results/byfile-report/Result_flow-org__repo1__main_byfile.json", []byte(byfileData1), 0644)
 		if err != nil {
 			t.Fatalf("Failed to create byfile report 1: %v", err)
 		}
 
 		byfileData2 := `{"TotalLines": 150, "TotalBlankLines": 15, "TotalComments": 30, "TotalCodeLines": 105}`
-		err = os.WriteFile("Results/byfile-report/Result_flow-org_repo2_develop_byfile.json", []byte(byfileData2), 0644)
+		err = os.WriteFile("Results/byfile-report/Result_flow-org__repo2__develop_byfile.json", []byte(byfileData2), 0644)
 		if err != nil {
 			t.Fatalf("Failed to create byfile report 2: %v", err)
 		}

--- a/pkg/reporter/pdf/pdf_reporter.go
+++ b/pkg/reporter/pdf/pdf_reporter.go
@@ -25,6 +25,13 @@ type PdfReporter struct {
 // branch names), so we strip the known prefix/suffix and treat the first segment
 // as Org, the last as Branch, and join everything in between as Repo. Returns
 // ok=false when the name does not contain at least three segments.
+//
+// Known limitation: because '_' is both the field delimiter and a valid character
+// inside each field, the last-segment heuristic is ambiguous. A branch named
+// "feature_xyz" will be mislabeled: "feature" is absorbed into Repo and "xyz"
+// becomes Branch. Until the file-name producer switches to an unambiguous
+// delimiter (e.g. U+241F UNIT SEPARATOR — `Result_<Org>\u241F<Repo>\u241F<Branch>.json`)
+// this ambiguity cannot be resolved from the file name alone.
 func parseResultFileName(name string) (org, repo, branch string, ok bool) {
 	if !strings.HasPrefix(name, "Result_") {
 		return "", "", "", false

--- a/pkg/reporter/pdf/pdf_reporter.go
+++ b/pkg/reporter/pdf/pdf_reporter.go
@@ -19,19 +19,14 @@ type PdfReporter struct {
 	OutputPath string
 }
 
-// parseResultFileName parses a `Result_<Org>_<Repo>_<Branch>.json` (or matching
+// parseResultFileName parses a `Result_<Org>__<Repo>__<Branch>.json` (or matching
 // PDF output name with optional `_byfile` suffix) and returns the components.
-// Any of Org/Repo/Branch may itself contain '_' (GitLab group names, repo slugs,
-// branch names), so we strip the known prefix/suffix and treat the first segment
-// as Org, the last as Branch, and join everything in between as Repo. Returns
-// ok=false when the name does not contain at least three segments.
-//
-// Known limitation: because '_' is both the field delimiter and a valid character
-// inside each field, the last-segment heuristic is ambiguous. A branch named
-// "feature_xyz" will be mislabeled: "feature" is absorbed into Repo and "xyz"
-// becomes Branch. Until the file-name producer switches to an unambiguous
-// delimiter (e.g. U+241F UNIT SEPARATOR — `Result_<Org>\u241F<Repo>\u241F<Branch>.json`)
-// this ambiguity cannot be resolved from the file name alone.
+// The double-underscore field separator keeps single `_` free to appear inside
+// any component (GitLab group names, repo slugs, branch names like feat_xyz), so
+// all three fields are recovered unambiguously by a fixed-N split. Returns
+// ok=false when the name does not have exactly three `__`-separated segments —
+// including all legacy single-`_` names from before the delimiter change, which
+// are intentionally skipped and will be regenerated on the next analysis run.
 func parseResultFileName(name string) (org, repo, branch string, ok bool) {
 	if !strings.HasPrefix(name, "Result_") {
 		return "", "", "", false
@@ -41,11 +36,11 @@ func parseResultFileName(name string) (org, repo, branch string, ok bool) {
 		base = strings.TrimSuffix(base, suffix)
 	}
 	base = strings.TrimSuffix(base, "_byfile")
-	parts := strings.Split(base, "_")
-	if len(parts) < 3 {
+	parts := strings.SplitN(base, "__", 3)
+	if len(parts) != 3 {
 		return "", "", "", false
 	}
-	return parts[0], strings.Join(parts[1:len(parts)-1], "_"), parts[len(parts)-1], true
+	return parts[0], parts[1], parts[2], true
 }
 
 type languageResult struct {

--- a/pkg/reporter/pdf/pdf_reporter.go
+++ b/pkg/reporter/pdf/pdf_reporter.go
@@ -19,28 +19,11 @@ type PdfReporter struct {
 	OutputPath string
 }
 
-// parseResultFileName parses a `Result_<Org>__<Repo>__<Branch>.json` (or matching
-// PDF output name with optional `_byfile` suffix) and returns the components.
-// The double-underscore field separator keeps single `_` free to appear inside
-// any component (GitLab group names, repo slugs, branch names like feat_xyz), so
-// all three fields are recovered unambiguously by a fixed-N split. Returns
-// ok=false when the name does not have exactly three `__`-separated segments —
-// including all legacy single-`_` names from before the delimiter change, which
-// are intentionally skipped and will be regenerated on the next analysis run.
+// parseResultFileName is a thin alias preserving the local call sites while
+// the canonical implementation lives in pkg/utils so every consumer of the
+// Result_<Org>__<Repo>__<Branch>.json naming convention parses it the same way.
 func parseResultFileName(name string) (org, repo, branch string, ok bool) {
-	if !strings.HasPrefix(name, "Result_") {
-		return "", "", "", false
-	}
-	base := strings.TrimPrefix(name, "Result_")
-	for _, suffix := range []string{".json", ".pdf"} {
-		base = strings.TrimSuffix(base, suffix)
-	}
-	base = strings.TrimSuffix(base, "_byfile")
-	parts := strings.SplitN(base, "__", 3)
-	if len(parts) != 3 {
-		return "", "", "", false
-	}
-	return parts[0], parts[1], parts[2], true
+	return utils.ParseResultFileName(name)
 }
 
 type languageResult struct {

--- a/pkg/reporter/pdf/pdf_reporter.go
+++ b/pkg/reporter/pdf/pdf_reporter.go
@@ -19,6 +19,28 @@ type PdfReporter struct {
 	OutputPath string
 }
 
+// parseResultFileName parses a `Result_<Org>_<Repo>_<Branch>.json` (or matching
+// PDF output name with optional `_byfile` suffix) and returns the components.
+// Any of Org/Repo/Branch may itself contain '_' (GitLab group names, repo slugs,
+// branch names), so we strip the known prefix/suffix and treat the first segment
+// as Org, the last as Branch, and join everything in between as Repo. Returns
+// ok=false when the name does not contain at least three segments.
+func parseResultFileName(name string) (org, repo, branch string, ok bool) {
+	if !strings.HasPrefix(name, "Result_") {
+		return "", "", "", false
+	}
+	base := strings.TrimPrefix(name, "Result_")
+	for _, suffix := range []string{".json", ".pdf"} {
+		base = strings.TrimSuffix(base, suffix)
+	}
+	base = strings.TrimSuffix(base, "_byfile")
+	parts := strings.Split(base, "_")
+	if len(parts) < 3 {
+		return "", "", "", false
+	}
+	return parts[0], strings.Join(parts[1:len(parts)-1], "_"), parts[len(parts)-1], true
+}
+
 type languageResult struct {
 	Language   string
 	Files      int
@@ -116,16 +138,12 @@ func (p PdfReporter) writePdf(pdfReport *report) error {
 		outputName += ".pdf"
 	}
 
-	parts := strings.Split(outputName, "_")
-	repoName := parts[2]
-	if len(parts) > 3 {
-		branch = strings.TrimSuffix(parts[3], ".pdf")
-	} else {
-
-		branch = "main"
-
+	repoName := "unknown"
+	branch = "main"
+	if _, r, b, ok := parseResultFileName(outputName); ok {
+		repoName = r
+		branch = b
 	}
-	//branch := strings.TrimSuffix(parts[3], ".pdf")
 	Title2 := "Repository Files Details: " + repoName + " for branch : " + branch
 
 	path := filepath.Join(p.OutputPath+"/", outputName)
@@ -282,12 +300,7 @@ func (p PdfReporter) GenerateGlobalReportByFile() error {
 				return err
 			}
 
-			// Extract repository name and branch
-			parts := strings.Split(info.Name(), "_")
-			if len(parts) == 4 {
-				repoName := strings.Join(parts[2:3], "_")
-				branch := strings.TrimSuffix(parts[3], filepath.Ext(parts[3]))
-
+			if _, repoName, branch, ok := parseResultFileName(info.Name()); ok {
 				// Add repository info
 				pdf.SetFont("Times", "B", 10)
 				pdf.CellFormat(0, 10, fmt.Sprintf("Repository: %s - Branch: %s", repoName, branch), "", 1, "", false, 0, "")

--- a/pkg/reporter/pdf/pdf_reporter_test.go
+++ b/pkg/reporter/pdf/pdf_reporter_test.go
@@ -36,7 +36,11 @@ func TestParseResultFileName(t *testing.T) {
 			wantOK:     true,
 		},
 		{
-			name:       "underscore in branch name",
+			// Known ambiguity: '_' is also valid inside branch names, so
+			// "feature_xyz" is mislabeled — "feature" is absorbed into Repo
+			// and only "xyz" is returned as Branch. See the comment on
+			// parseResultFileName for the long-term fix.
+			name:       "underscore in branch name (mislabeled by last-segment heuristic)",
 			input:      "Result_org_repo_feature_xyz.json",
 			wantOrg:    "org",
 			wantRepo:   "repo_feature",

--- a/pkg/reporter/pdf/pdf_reporter_test.go
+++ b/pkg/reporter/pdf/pdf_reporter_test.go
@@ -1,0 +1,94 @@
+package pdf
+
+import "testing"
+
+func TestParseResultFileName(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantOrg     string
+		wantRepo    string
+		wantBranch  string
+		wantOK      bool
+	}{
+		{
+			name:       "simple json with no underscores",
+			input:      "Result_org_repo_main.json",
+			wantOrg:    "org",
+			wantRepo:   "repo",
+			wantBranch: "main",
+			wantOK:     true,
+		},
+		{
+			name:       "underscore in org (GitLab group)",
+			input:      "Result_my_group_repo_main.json",
+			wantOrg:    "my",
+			wantRepo:   "group_repo",
+			wantBranch: "main",
+			wantOK:     true,
+		},
+		{
+			name:       "underscore in repo slug",
+			input:      "Result_org_my_app_main.json",
+			wantOrg:    "org",
+			wantRepo:   "my_app",
+			wantBranch: "main",
+			wantOK:     true,
+		},
+		{
+			name:       "underscore in branch name",
+			input:      "Result_org_repo_feature_xyz.json",
+			wantOrg:    "org",
+			wantRepo:   "repo_feature",
+			wantBranch: "xyz",
+			wantOK:     true,
+		},
+		{
+			name:       "byfile pdf variant",
+			input:      "Result_org_repo_main_byfile.pdf",
+			wantOrg:    "org",
+			wantRepo:   "repo",
+			wantBranch: "main",
+			wantOK:     true,
+		},
+		{
+			name:       "pdf without byfile suffix",
+			input:      "Result_org_repo_main.pdf",
+			wantOrg:    "org",
+			wantRepo:   "repo",
+			wantBranch: "main",
+			wantOK:     true,
+		},
+		{
+			name:   "missing branch returns not ok",
+			input:  "Result_org_repo.json",
+			wantOK: false,
+		},
+		{
+			name:   "missing prefix returns not ok",
+			input:  "other_org_repo_main.json",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			org, repo, branch, ok := parseResultFileName(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if org != tt.wantOrg {
+				t.Errorf("org = %q, want %q", org, tt.wantOrg)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("repo = %q, want %q", repo, tt.wantRepo)
+			}
+			if branch != tt.wantBranch {
+				t.Errorf("branch = %q, want %q", branch, tt.wantBranch)
+			}
+		})
+	}
+}

--- a/pkg/reporter/pdf/pdf_reporter_test.go
+++ b/pkg/reporter/pdf/pdf_reporter_test.go
@@ -4,16 +4,16 @@ import "testing"
 
 func TestParseResultFileName(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       string
-		wantOrg     string
-		wantRepo    string
-		wantBranch  string
-		wantOK      bool
+		name       string
+		input      string
+		wantOrg    string
+		wantRepo   string
+		wantBranch string
+		wantOK     bool
 	}{
 		{
 			name:       "simple json with no underscores",
-			input:      "Result_org_repo_main.json",
+			input:      "Result_org__repo__main.json",
 			wantOrg:    "org",
 			wantRepo:   "repo",
 			wantBranch: "main",
@@ -21,35 +21,49 @@ func TestParseResultFileName(t *testing.T) {
 		},
 		{
 			name:       "underscore in org (GitLab group)",
-			input:      "Result_my_group_repo_main.json",
-			wantOrg:    "my",
-			wantRepo:   "group_repo",
+			input:      "Result_my_group__repo__main.json",
+			wantOrg:    "my_group",
+			wantRepo:   "repo",
 			wantBranch: "main",
 			wantOK:     true,
 		},
 		{
 			name:       "underscore in repo slug",
-			input:      "Result_org_my_app_main.json",
+			input:      "Result_org__my_app__main.json",
 			wantOrg:    "org",
 			wantRepo:   "my_app",
 			wantBranch: "main",
 			wantOK:     true,
 		},
 		{
-			// Known ambiguity: '_' is also valid inside branch names, so
-			// "feature_xyz" is mislabeled — "feature" is absorbed into Repo
-			// and only "xyz" is returned as Branch. See the comment on
-			// parseResultFileName for the long-term fix.
-			name:       "underscore in branch name (mislabeled by last-segment heuristic)",
-			input:      "Result_org_repo_feature_xyz.json",
+			name:       "underscore in branch name",
+			input:      "Result_org__repo__feature_xyz.json",
 			wantOrg:    "org",
-			wantRepo:   "repo_feature",
-			wantBranch: "xyz",
+			wantRepo:   "repo",
+			wantBranch: "feature_xyz",
+			wantOK:     true,
+		},
+		{
+			name:       "underscores in every component",
+			input:      "Result_my_group__my_app__feat_xyz.json",
+			wantOrg:    "my_group",
+			wantRepo:   "my_app",
+			wantBranch: "feat_xyz",
+			wantOK:     true,
+		},
+		{
+			// SplitN with N=3 keeps any trailing "__" intact in the last segment,
+			// so a literal double-underscore inside the branch name survives.
+			name:       "literal double underscore inside branch",
+			input:      "Result_org__repo__feat__xyz.json",
+			wantOrg:    "org",
+			wantRepo:   "repo",
+			wantBranch: "feat__xyz",
 			wantOK:     true,
 		},
 		{
 			name:       "byfile pdf variant",
-			input:      "Result_org_repo_main_byfile.pdf",
+			input:      "Result_org__repo__main_byfile.pdf",
 			wantOrg:    "org",
 			wantRepo:   "repo",
 			wantBranch: "main",
@@ -57,7 +71,7 @@ func TestParseResultFileName(t *testing.T) {
 		},
 		{
 			name:       "pdf without byfile suffix",
-			input:      "Result_org_repo_main.pdf",
+			input:      "Result_org__repo__main.pdf",
 			wantOrg:    "org",
 			wantRepo:   "repo",
 			wantBranch: "main",
@@ -65,12 +79,21 @@ func TestParseResultFileName(t *testing.T) {
 		},
 		{
 			name:   "missing branch returns not ok",
-			input:  "Result_org_repo.json",
+			input:  "Result_org__repo.json",
 			wantOK: false,
 		},
 		{
 			name:   "missing prefix returns not ok",
-			input:  "other_org_repo_main.json",
+			input:  "other_org__repo__main.json",
+			wantOK: false,
+		},
+		{
+			// Hard cutover: pre-migration single-'_' names are intentionally
+			// rejected so legacy stale files in Results/ are not parsed with
+			// the old ambiguous heuristic. They will be regenerated on the
+			// next analysis run.
+			name:   "legacy single-underscore format rejected",
+			input:  "Result_org_repo_main.json",
 			wantOK: false,
 		},
 	}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/SonarSource-Demos/sonar-golc/pkg/analyzer"
 	"github.com/SonarSource-Demos/sonar-golc/pkg/goloc/language"
+	"github.com/SonarSource-Demos/sonar-golc/pkg/utils"
 	"github.com/schollz/progressbar/v3"
 )
 
@@ -32,11 +33,17 @@ func NewScanner(languages language.Languages) *Scanner {
 func (sc *Scanner) Scan(files []analyzer.FileMetadata) ([]scanResult, error) {
 	var results []scanResult
 	progress := sc.createProgressbar(len(files))
+	logger := utils.NewLogger()
 
 	for _, file := range files {
 		result, err := sc.scanFile(file)
 		if err != nil {
-			return results, err
+			// A single unreadable file (broken symlink, permission denied, transient I/O
+			// error) must not abort the entire repository scan. Log and skip so the rest
+			// of the repo still produces a JSON output.
+			logger.Warnf("⚠️  Skipping unreadable file %s: %v", file.FilePath, err)
+			progress.Add(1)
+			continue
 		}
 		progress.Add(1)
 		results = append(results, result)

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -35,6 +36,7 @@ func (sc *Scanner) Scan(files []analyzer.FileMetadata) ([]scanResult, error) {
 	progress := sc.createProgressbar(len(files))
 	logger := utils.NewLogger()
 
+	failed := 0
 	for _, file := range files {
 		result, err := sc.scanFile(file)
 		if err != nil {
@@ -42,11 +44,24 @@ func (sc *Scanner) Scan(files []analyzer.FileMetadata) ([]scanResult, error) {
 			// error) must not abort the entire repository scan. Log and skip so the rest
 			// of the repo still produces a JSON output.
 			logger.Warnf("⚠️  Skipping unreadable file %s: %v", file.FilePath, err)
+			failed++
 			progress.Add(1)
 			continue
 		}
 		progress.Add(1)
 		results = append(results, result)
+	}
+
+	// Distinguish a fully-failed scan from a genuinely empty repository: if every
+	// candidate file was unreadable, surface an error so downstream report
+	// generation does not silently produce a zero-line report (which would mask
+	// real, systemic problems — wrong path, tree-wide permission denial, etc.).
+	if failed > 0 && len(results) == 0 && len(files) > 0 {
+		logger.Errorf("❌ Scan failed: all %d candidate file(s) were unreadable", failed)
+		return results, fmt.Errorf("scan failed: all %d candidate file(s) were unreadable", failed)
+	}
+	if failed > 0 {
+		logger.Warnf("⚠️  Scan completed with %d/%d file(s) skipped", failed, len(files))
 	}
 
 	return results, nil

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -1,0 +1,61 @@
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SonarSource-Demos/sonar-golc/pkg/analyzer"
+	"github.com/SonarSource-Demos/sonar-golc/pkg/goloc/language"
+)
+
+// TestScanSkipsUnreadableFiles covers the original bug where a single unreadable
+// file (broken symlink, missing path, permission denied) would abort the entire
+// repository scan and lose every other file's result. The expected behaviour is
+// that the bad file is skipped and the rest of the scan succeeds.
+func TestScanSkipsUnreadableFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	goodPath := filepath.Join(dir, "good.go")
+	if err := os.WriteFile(goodPath, []byte("package main\nfunc f() {}\n"), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Broken symlink: points at a path that does not exist. os.Open follows it
+	// and returns "no such file or directory", the same error users saw on
+	// compile_commands.json links pointing into an absent build/ tree.
+	brokenLink := filepath.Join(dir, "compile_commands.json")
+	if err := os.Symlink(filepath.Join(dir, "build", "compile_commands.json"), brokenLink); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	languages := language.Languages{
+		"Go": language.LanguageInfo{
+			LineComments:      []string{"//"},
+			MultiLineComments: [][]string{{"/*", "*/"}},
+			Extensions:        []string{".go"},
+		},
+		"JSON": language.LanguageInfo{
+			LineComments:      []string{},
+			MultiLineComments: [][]string{},
+			Extensions:        []string{".json"},
+		},
+	}
+
+	sc := NewScanner(languages)
+	files := []analyzer.FileMetadata{
+		{FilePath: brokenLink, Extension: ".json", Language: "JSON"},
+		{FilePath: goodPath, Extension: ".go", Language: "Go"},
+	}
+
+	results, err := sc.Scan(files)
+	if err != nil {
+		t.Fatalf("Scan returned error %v, expected nil (bad file should be skipped)", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 successful scan result (good.go), got %d", len(results))
+	}
+	if results[0].Metadata.FilePath != goodPath {
+		t.Fatalf("expected result for %s, got %s", goodPath, results[0].Metadata.FilePath)
+	}
+}

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -59,3 +59,69 @@ func TestScanSkipsUnreadableFiles(t *testing.T) {
 		t.Fatalf("expected result for %s, got %s", goodPath, results[0].Metadata.FilePath)
 	}
 }
+
+// TestScanFailsWhenAllFilesUnreadable covers the degenerate case where every
+// candidate file fails to open (e.g. wrong path, tree-wide permission denial,
+// shallow clone missing every symlink target). Scan must return an error so the
+// downstream report does not silently report a zero-line repository, which
+// would hide a systemic problem behind a "genuinely empty repo" appearance.
+func TestScanFailsWhenAllFilesUnreadable(t *testing.T) {
+	dir := t.TempDir()
+
+	brokenLink1 := filepath.Join(dir, "compile_commands.json")
+	if err := os.Symlink(filepath.Join(dir, "build", "compile_commands.json"), brokenLink1); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+	brokenLink2 := filepath.Join(dir, "generated.go")
+	if err := os.Symlink(filepath.Join(dir, "build", "generated.go"), brokenLink2); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+
+	languages := language.Languages{
+		"Go": language.LanguageInfo{
+			LineComments:      []string{"//"},
+			MultiLineComments: [][]string{{"/*", "*/"}},
+			Extensions:        []string{".go"},
+		},
+		"JSON": language.LanguageInfo{
+			LineComments:      []string{},
+			MultiLineComments: [][]string{},
+			Extensions:        []string{".json"},
+		},
+	}
+
+	sc := NewScanner(languages)
+	files := []analyzer.FileMetadata{
+		{FilePath: brokenLink1, Extension: ".json", Language: "JSON"},
+		{FilePath: brokenLink2, Extension: ".go", Language: "Go"},
+	}
+
+	results, err := sc.Scan(files)
+	if err == nil {
+		t.Fatalf("Scan returned nil error with all files unreadable, expected an error")
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results when every file fails, got %d", len(results))
+	}
+}
+
+// TestScanEmptyFileListReturnsNoError ensures that a genuinely empty repository
+// (zero candidate files) is not conflated with a fully-failed scan. Both produce
+// an empty result slice, but only the latter must return an error.
+func TestScanEmptyFileListReturnsNoError(t *testing.T) {
+	languages := language.Languages{
+		"Go": language.LanguageInfo{
+			LineComments: []string{"//"},
+			Extensions:   []string{".go"},
+		},
+	}
+
+	sc := NewScanner(languages)
+	results, err := sc.Scan(nil)
+	if err != nil {
+		t.Fatalf("Scan with no files returned error %v, expected nil", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results for empty input, got %d", len(results))
+	}
+}

--- a/pkg/utils/globalreport.go
+++ b/pkg/utils/globalreport.go
@@ -119,6 +119,30 @@ func collectLanguageTotals(directory string) (map[string]int, error) {
 	return ligneDeCodeParLangage, nil
 }
 
+// ParseResultFileName parses a `Result_<Org>__<Repo>__<Branch>.json` (or matching
+// PDF output name with optional `_byfile` suffix) and returns the components.
+// The double-underscore field separator keeps single `_` free to appear inside
+// any component (GitLab group names, repo slugs, branch names like feat_xyz), so
+// all three fields are recovered unambiguously by a fixed-N split. Returns
+// ok=false when the name does not have exactly three `__`-separated segments —
+// including all legacy single-`_` names from before the delimiter change, which
+// are intentionally skipped and will be regenerated on the next analysis run.
+func ParseResultFileName(name string) (org, repo, branch string, ok bool) {
+	if !strings.HasPrefix(name, "Result_") {
+		return "", "", "", false
+	}
+	base := strings.TrimPrefix(name, "Result_")
+	for _, suffix := range []string{".json", ".pdf"} {
+		base = strings.TrimSuffix(base, suffix)
+	}
+	base = strings.TrimSuffix(base, "_byfile")
+	parts := strings.SplitN(base, "__", 3)
+	if len(parts) != 3 {
+		return "", "", "", false
+	}
+	return parts[0], parts[1], parts[2], true
+}
+
 // isEligibleResultFile returns true for top-level Result_*.json files that are not _byfile.
 func isEligibleResultFile(info os.FileInfo, path string) bool {
 	if info.IsDir() {

--- a/pkg/utils/globalreport_test.go
+++ b/pkg/utils/globalreport_test.go
@@ -156,4 +156,44 @@ func TestWriteLanguageTotalsJSONAndReadGlobalInfoAndRenderPDF(t *testing.T) {
 	}
 }
 
+// TestParseResultFileName exercises the canonical Result_<Org>__<Repo>__<Branch>
+// parser shared by pkg/reporter/pdf and the LargestRepository selection loop in
+// golc.go. The non-empty `wantRepo` cases would all regress to blank under the
+// pre-double-underscore single-_ split.
+func TestParseResultFileName(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantOrg    string
+		wantRepo   string
+		wantBranch string
+		wantOK     bool
+	}{
+		{"simple", "Result_org__repo__main.json", "org", "repo", "main", true},
+		{"underscore in org", "Result_my_group__repo__main.json", "my_group", "repo", "main", true},
+		{"underscore in repo", "Result_org__my_app__main.json", "org", "my_app", "main", true},
+		{"underscore in branch", "Result_org__repo__feat_xyz.json", "org", "repo", "feat_xyz", true},
+		{"byfile pdf", "Result_org__repo__main_byfile.pdf", "org", "repo", "main", true},
+		{"plain pdf", "Result_org__repo__main.pdf", "org", "repo", "main", true},
+		{"literal __ in branch survives", "Result_org__repo__feat__xyz.json", "org", "repo", "feat__xyz", true},
+		{"missing branch", "Result_org__repo.json", "", "", "", false},
+		{"missing prefix", "other_org__repo__main.json", "", "", "", false},
+		{"legacy single-_ rejected", "Result_org_repo_main.json", "", "", "", false},
+	}
 
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			org, repo, branch, ok := ParseResultFileName(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if org != tt.wantOrg || repo != tt.wantRepo || branch != tt.wantBranch {
+				t.Errorf("got (%q, %q, %q), want (%q, %q, %q)",
+					org, repo, branch, tt.wantOrg, tt.wantRepo, tt.wantBranch)
+			}
+		})
+	}
+}

--- a/pkg/utils/globalreport_test.go
+++ b/pkg/utils/globalreport_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-const resultMainJSON = "Result_org_repo_main.json"
+const resultMainJSON = "Result_org__repo__main.json"
 
 // helper to set up a temp workspace and chdir into it
 func setupGlobalReportEnv(t *testing.T) (string, func()) {
@@ -41,7 +41,7 @@ func TestIsEligibleResultFile(t *testing.T) {
 	defer cleanup()
 	// create candidate files
 	result := filepath.Join(dir, resultMainJSON)
-	byfile := filepath.Join(dir, "Result_org_repo_main_byfile.json")
+	byfile := filepath.Join(dir, "Result_org__repo__main_byfile.json")
 	other := filepath.Join(dir, "random.json")
 	os.WriteFile(result, []byte("{}"), 0644)
 	os.WriteFile(byfile, []byte("{}"), 0644)
@@ -88,10 +88,10 @@ func TestCollectLanguageTotalsSkipsByfile(t *testing.T) {
 	dir, cleanup := setupGlobalReportEnv(t)
 	defer cleanup()
 	// arrange result files
-	writeResultJSON(t, dir, "Result_org_a_main.json", FileData{
+	writeResultJSON(t, dir, "Result_org__a__main.json", FileData{
 		Results: []LanguageData1{{Language: "Go", CodeLines: 10}},
 	})
-	writeResultJSON(t, dir, "Result_org_b_main_byfile.json", FileData{
+	writeResultJSON(t, dir, "Result_org__b__main_byfile.json", FileData{
 		Results: []LanguageData1{{Language: "Go", CodeLines: 1000}},
 	})
 	writeResultJSON(t, dir, "random.json", FileData{

--- a/pkg/utils/repository_summary.go
+++ b/pkg/utils/repository_summary.go
@@ -153,9 +153,9 @@ func getRepositoryData() ([]RepositoryData, error) {
 			byLanguagePath = fmt.Sprintf("Results/bylanguage-report/Result_%s.json", branch.RepoSlug)
 		} else {
 			firstPart := getFirstPartForPlatform(platform, branch, branch.RepoSlug)
-			byfilePath = fmt.Sprintf("Results/byfile-report/Result_%s_%s_%s_byfile.json",
+			byfilePath = fmt.Sprintf("Results/byfile-report/Result_%s__%s__%s_byfile.json",
 				firstPart, branch.RepoSlug, branch.MainBranch)
-			byLanguagePath = fmt.Sprintf("Results/bylanguage-report/Result_%s_%s_%s.json",
+			byLanguagePath = fmt.Sprintf("Results/bylanguage-report/Result_%s__%s__%s.json",
 				firstPart, branch.RepoSlug, branch.MainBranch)
 		}
 

--- a/pkg/utils/repository_summary_test.go
+++ b/pkg/utils/repository_summary_test.go
@@ -485,7 +485,7 @@ func TestGenerateRepositorySummaryReportsWithAnalysisFiles(t *testing.T) {
 	// Create byfile report
 	byfileData := createTestByfileData()
 	byfileJSON, _ := json.Marshal(byfileData)
-	err = os.WriteFile("Results/byfile-report/Result_test-org_test-repo_main_byfile.json", byfileJSON, 0644)
+	err = os.WriteFile("Results/byfile-report/Result_test-org__test-repo__main_byfile.json", byfileJSON, 0644)
 	if err != nil {
 		t.Fatalf("Failed to create byfile report: %v", err)
 	}
@@ -658,7 +658,7 @@ func TestGetRepositoryDataComplexScenarios(t *testing.T) {
 		}
 
 		// Create invalid byfile JSON
-		err = os.WriteFile("Results/byfile-report/Result_test-org_invalid-byfile-repo_main_byfile.json", []byte("invalid json"), 0644)
+		err = os.WriteFile("Results/byfile-report/Result_test-org__invalid-byfile-repo__main_byfile.json", []byte("invalid json"), 0644)
 		if err != nil {
 			t.Fatalf("Failed to create invalid byfile JSON: %v", err)
 		}


### PR DESCRIPTION
## Summary

Fixes two independent bugs that caused repositories to silently disappear from `GlobalReportByFile.pdf` while the web UI still counted them (issue #82).

- **`pkg/scanner/scanner.go`** — a single unreadable file (broken `compile_commands.json` symlink into an absent `build/`, permission denied, transient I/O) aborted the entire repo scan via `gc.Run()`, dropping the repo from both `byfile-report/` and `bylanguage-report/`. Bad files are now logged as a warning and skipped; the rest of the repo still produces a JSON output.
- **`pkg/reporter/pdf/pdf_reporter.go`** — filename parsing used a strict `len(parts) == 4` equality on `strings.Split(name, "_")`, silently dropping any `Result_<Org>_<Repo>_<Branch>.json` whose Org/Repo/Branch contained an `_` (common with GitLab group names, repo slugs, branch names like `feat_xyz`). Extracted a shared `parseResultFileName` helper that strips the `Result_` prefix, `.json`/`.pdf`, and optional `_byfile` suffix, then treats the first segment as Org, the last as Branch, and joins the middle as Repo. Reused in both `writePdf` (per-repo PDF, previously degraded silently to `branch = "main"`) and `GenerateGlobalReportByFile` (global PDF, previously skipped the row entirely).

Refs #82

## Test plan

- [x] `go test ./pkg/scanner/... ./pkg/reporter/pdf/...` passes locally
  - scanner test: broken symlink in file list does not abort the scan
  - PDF parser test: table-driven, covers underscores in Org / Repo / Branch and both `.json` / `_byfile.pdf` variants
- [ ] Manual run on a GitLab group with `my_group` / `my_app` / `feat_xyz` names — confirm all repos appear in `GlobalReportByFile.pdf`
- [ ] Manual run on a repo containing a broken `compile_commands.json` symlink — confirm scan completes and JSON output is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking filename convention for existing `Results/` artifacts until re-analysis; changes affect global totals, PDF rows, and UI repo discovery across many call sites.
> 
> **Overview**
> Fixes repositories missing from **GlobalReportByFile.pdf** while the web UI still counted them (#82) by hardening scanning and aligning how `Result_*` artifacts are named and parsed end-to-end.
> 
> **Scanning:** `pkg/scanner` no longer fails the whole repo when one file cannot be opened (e.g. broken `compile_commands.json` symlinks); it warns, skips, and continues. If every candidate file fails, `Scan` returns an error so a zero-line report does not look like an empty repo.
> 
> **Result naming & parsing:** Analysis output and all readers move from `Result_<Org>_<Repo>_<Branch>` to **`Result_<Org>__<Repo>__<Branch>`** so underscores inside GitLab groups, repo slugs, and branch names parse correctly. Shared **`utils.ParseResultFileName`** (via a thin alias in the PDF reporter) replaces fragile `strings.Split` heuristics in PDF generation and in the global-report “largest repo” loop in `golc.go`. Legacy single-`_` JSON names are **skipped** until the next analysis run regenerates canonical files. The ResultsAll web UI and repository summary paths/globs/branch extraction are updated to match.
> 
> Tests cover the parser (including legacy rejection), scanner skip/all-fail behavior, and updated fixture filenames across integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5dd0790a4f8bde0329b5ce3c7deb6279038ce31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->