### PR TITLE
feat(devops): support comma-separated repo selection across platforms

### DIFF
--- a/pkg/devops/getazure/getazure.go
+++ b/pkg/devops/getazure/getazure.go
@@ -479,6 +479,22 @@ func getRepoAnalyse(params ParamsProjectAzure, gitClient git.Client) ([]ProjectB
 
 }
 
+// parseSingleRepos splits the comma-separated "Repos" configuration field into
+// a clean slice of repository names, ignoring blank entries and surrounding
+// whitespace (e.g. "repo1, repo2 ,repo3").
+func parseSingleRepos(singleRepos string) []string {
+	var list []string
+	if singleRepos == "" {
+		return list
+	}
+	for _, r := range strings.Split(singleRepos, ",") {
+		if name := strings.TrimSpace(r); name != "" {
+			list = append(list, name)
+		}
+	}
+	return list
+}
+
 func listReposForProject(parms ParamsProjectAzure, projectKey string, gitClient git.Client) (int, int, int, []git.GitRepository, error) {
 	var allRepos []git.GitRepository
 	var archivedCount, emptyCount, excludedCount int
@@ -486,14 +502,7 @@ func listReposForProject(parms ParamsProjectAzure, projectKey string, gitClient 
 
 	// Convert SingleRepos (comma-separated) to a clean slice, ignoring blank
 	// entries and surrounding whitespace (e.g. "repo1, repo2 ,repo3").
-	var singleReposList []string
-	if parms.SingleRepos != "" {
-		for _, r := range strings.Split(parms.SingleRepos, ",") {
-			if name := strings.TrimSpace(r); name != "" {
-				singleReposList = append(singleReposList, name)
-			}
-		}
-	}
+	singleReposList := parseSingleRepos(parms.SingleRepos)
 
 	// Get repositories
 	loggers.Debugf("→ project %s: fetching repos from API", projectKey)

--- a/pkg/devops/getazure/getazure.go
+++ b/pkg/devops/getazure/getazure.go
@@ -484,10 +484,15 @@ func listReposForProject(parms ParamsProjectAzure, projectKey string, gitClient 
 	var archivedCount, emptyCount, excludedCount int
 	loggers := utils.SharedLogger()
 
-	// Convert SingleRepos to a slice if it's not empty
+	// Convert SingleRepos (comma-separated) to a clean slice, ignoring blank
+	// entries and surrounding whitespace (e.g. "repo1, repo2 ,repo3").
 	var singleReposList []string
 	if parms.SingleRepos != "" {
-		singleReposList = strings.Split(parms.SingleRepos, ",")
+		for _, r := range strings.Split(parms.SingleRepos, ",") {
+			if name := strings.TrimSpace(r); name != "" {
+				singleReposList = append(singleReposList, name)
+			}
+		}
 	}
 
 	// Get repositories

--- a/pkg/devops/getazure/getazure_test.go
+++ b/pkg/devops/getazure/getazure_test.go
@@ -135,3 +135,31 @@ func TestLoadExclusionFileOrCreateNew_MissingFile(t *testing.T) {
 		t.Error("expected error for missing file")
 	}
 }
+
+func TestParseSingleRepos(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"empty", "", nil},
+		{"single", "repo1", []string{"repo1"}},
+		{"multiple", "repo1,repo2,repo3", []string{"repo1", "repo2", "repo3"}},
+		{"whitespace trimmed", "repo1, repo2 ,  repo3", []string{"repo1", "repo2", "repo3"}},
+		{"blanks skipped", "repo1,,repo2,   ,repo3", []string{"repo1", "repo2", "repo3"}},
+		{"only blanks", " , , ", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSingleRepos(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseSingleRepos(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseSingleRepos(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/devops/getbitbucket/getbitbucket.go
+++ b/pkg/devops/getbitbucket/getbitbucket.go
@@ -84,6 +84,18 @@ type ParamsProjectBitbucket struct {
 	SingleBranch     string
 }
 
+// matchesSingleRepos reports whether repoSlug is one of the repositories named
+// in the (comma-separated) SingleRepos field. Surrounding whitespace and blank
+// entries are ignored (e.g. "repo1, repo2 ,repo3").
+func matchesSingleRepos(singleRepos, repoSlug string) bool {
+	for _, name := range strings.Split(singleRepos, ",") {
+		if strings.TrimSpace(name) == repoSlug {
+			return true
+		}
+	}
+	return false
+}
+
 type Response1 struct {
 	Values  []FileInfo `json:"values"`
 	Pagelen int        `json:"pagelen"`
@@ -767,9 +779,6 @@ func listReposForProject(parms ParamsProjectBitbucket, projectKey string) (int, 
 			if repo.IsArchived {
 				loggers.Debugf("→ repo %s/%s: skipped (archived)", projectKey, repo.Slug)
 				archivedCount++
-				if parms.SingleRepos == repo.Slug {
-					return archivedCount, 0, 0, nil, nil
-				}
 				continue
 			}
 			bbRepo := bitbucket.Repository{
@@ -837,38 +846,33 @@ func listRepos(parms ParamsProjectBitbucket, projectKey string, reposRes *bitbuc
 		}
 	} else {
 
-		var repoFound bool
+		// One or more specific repositories were requested (comma-separated).
+		// Collect every matching repo in this page; skip (don't abort) any that
+		// are excluded or empty so the remaining requested repos still analyze.
 		for _, repo := range reposRes.Items {
 
-			if repo.Slug == parms.SingleRepos {
-				repoFound = true
-				repoCopy := repo
-
-				if isRepoExcluded(parms.Exclusionlist, projectKey, repo.Slug) {
-					excludedCount++
-					errmessage := fmt.Sprintf(" - Skipping analysis for Repo %s , it is excluded", repo.Slug)
-					err := fmt.Errorf("%s", errmessage)
-					return 0, excludedCount, allRepos, err
-				}
-
-				isEmpty, err := isRepositoryEmpty(parms.Workspace, repo.Slug, repo.Mainbranch.Name, parms.AccessToken, parms.Users, parms.BitbucketURLBase)
-				if err != nil {
-					loggers.Errorf("❌ Error when Testing if repo is empty %s: %v\n", repo.Slug, err)
-				}
-				if isEmpty {
-					emptyOrArchivedCount++
-					errmessage := fmt.Sprintf(" - Skipping analysis for Repo %s , it is empty", repo.Slug)
-					err := fmt.Errorf("%s", errmessage)
-					return emptyOrArchivedCount, excludedCount, allRepos, err
-				}
-
-				allRepos = append(allRepos, &repoCopy)
-				break
+			if !matchesSingleRepos(parms.SingleRepos, repo.Slug) {
+				continue
 			}
-		}
+			repoCopy := repo
 
-		if !repoFound {
-			excludedCount++
+			if isRepoExcluded(parms.Exclusionlist, projectKey, repo.Slug) {
+				loggers.Infof(" - Skipping analysis for Repo %s , it is excluded", repo.Slug)
+				excludedCount++
+				continue
+			}
+
+			isEmpty, err := isRepositoryEmpty(parms.Workspace, repo.Slug, repo.Mainbranch.Name, parms.AccessToken, parms.Users, parms.BitbucketURLBase)
+			if err != nil {
+				loggers.Errorf("❌ Error when Testing if repo is empty %s: %v\n", repo.Slug, err)
+			}
+			if isEmpty {
+				loggers.Infof(" - Skipping analysis for Repo %s , it is empty", repo.Slug)
+				emptyOrArchivedCount++
+				continue
+			}
+
+			allRepos = append(allRepos, &repoCopy)
 		}
 	}
 	return emptyOrArchivedCount, excludedCount, allRepos, nil

--- a/pkg/devops/getbitbucket/getbitbucket_test.go
+++ b/pkg/devops/getbitbucket/getbitbucket_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/SonarSource-Demos/sonar-golc/pkg/utils"
+	"github.com/ktrysmt/go-bitbucket"
 )
 
 func TestIsRepoExcluded(t *testing.T) {
@@ -30,6 +31,96 @@ func TestIsRepoExcluded(t *testing.T) {
 			t.Errorf("isRepoExcluded(%q, %q) = %v, want %v", tc.projectKey, tc.repoKey, got, tc.want)
 		}
 	}
+}
+
+func TestMatchesSingleRepos(t *testing.T) {
+	tests := []struct {
+		name        string
+		singleRepos string
+		repoSlug    string
+		want        bool
+	}{
+		{"single match", "repo1", "repo1", true},
+		{"single no match", "repo1", "repo2", false},
+		{"multiple first", "repo1,repo2,repo3", "repo1", true},
+		{"multiple middle", "repo1,repo2,repo3", "repo2", true},
+		{"multiple last", "repo1,repo2,repo3", "repo3", true},
+		{"multiple no match", "repo1,repo2,repo3", "repo4", false},
+		{"whitespace tolerated", "repo1, repo2 ,  repo3", "repo2", true},
+		{"empty filter", "", "repo1", false},
+		{"no partial match", "repo10", "repo1", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := matchesSingleRepos(tc.singleRepos, tc.repoSlug); got != tc.want {
+				t.Errorf("matchesSingleRepos(%q, %q) = %v, want %v", tc.singleRepos, tc.repoSlug, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestListRepos_SingleReposFilter(t *testing.T) {
+	// Mock the "is repo empty" file listing so matched repos are treated as
+	// non-empty (one file present).
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(Response1{
+			Values:  []FileInfo{{Path: "README.md"}},
+			Pagelen: 100,
+			Page:    1,
+		})
+	}))
+	defer ts.Close()
+
+	reposRes := &bitbucket.RepositoriesRes{
+		Items: []bitbucket.Repository{
+			{Slug: "repo1", Mainbranch: bitbucket.RepositoryBranch{Name: "main"}},
+			{Slug: "repo2", Mainbranch: bitbucket.RepositoryBranch{Name: "main"}},
+			{Slug: "repo3", Mainbranch: bitbucket.RepositoryBranch{Name: "main"}},
+		},
+	}
+
+	t.Run("collects all matching repos from a comma list", func(t *testing.T) {
+		parms := ParamsProjectBitbucket{
+			SingleRepos:      "repo1,repo3",
+			Workspace:        "ws",
+			AccessToken:      "token",
+			BitbucketURLBase: ts.URL + "/",
+			Exclusionlist:    utils.NewExclusionList(nil, nil),
+		}
+		empty, excluded, repos, err := listRepos(parms, "PROJ", reposRes)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if empty != 0 || excluded != 0 {
+			t.Errorf("expected no empty/excluded, got empty=%d excluded=%d", empty, excluded)
+		}
+		if len(repos) != 2 {
+			t.Fatalf("expected repo1 and repo3, got %d", len(repos))
+		}
+		if repos[0].Slug != "repo1" || repos[1].Slug != "repo3" {
+			t.Errorf("expected [repo1 repo3], got [%s %s]", repos[0].Slug, repos[1].Slug)
+		}
+	})
+
+	t.Run("excluded matched repo is skipped not analyzed", func(t *testing.T) {
+		parms := ParamsProjectBitbucket{
+			SingleRepos:      "repo1,repo2",
+			Workspace:        "ws",
+			AccessToken:      "token",
+			BitbucketURLBase: ts.URL + "/",
+			Exclusionlist:    utils.NewExclusionList(nil, []string{"PROJ/repo1"}),
+		}
+		_, excluded, repos, err := listRepos(parms, "PROJ", reposRes)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if excluded != 1 {
+			t.Errorf("expected excluded=1, got %d", excluded)
+		}
+		if len(repos) != 1 || repos[0].Slug != "repo2" {
+			t.Fatalf("expected only repo2, got %+v", repos)
+		}
+	})
 }
 
 func TestIsProjectExcluded(t *testing.T) {

--- a/pkg/devops/getbitbucketdc/getbitbucketdc.go
+++ b/pkg/devops/getbitbucketdc/getbitbucketdc.go
@@ -652,11 +652,15 @@ func determineProjectsAndRepos(platformConfig map[string]interface{}, exclusionL
 		// Fetch each in turn; skip (don't abort) any that are excluded or fail
 		// so the remaining requested repos still analyze.
 		spin.Start()
+		requested := 0
+		seen := make(map[string]bool)
 		for _, r := range strings.Split(repo, ",") {
 			repoName := strings.TrimSpace(r)
-			if repoName == "" {
+			if repoName == "" || seen[repoName] {
 				continue
 			}
+			seen[repoName] = true
+			requested++
 			Texclude := project + "/" + repoName
 			if isProjectAndRepoExcluded(Texclude, *exclusionList) {
 				loggers.Infof("⏭️  Skipping <%s/%s>: excluded from the analysis", project, repoName)
@@ -670,6 +674,12 @@ func determineProjectsAndRepos(platformConfig map[string]interface{}, exclusionL
 			repos = append(repos, oneRepo...)
 		}
 		spin.Stop()
+		// At least one repo was requested but none could be resolved (all
+		// excluded, archived, missing, or unreachable). Fail loudly rather than
+		// silently falling through to an empty all-projects scan.
+		if requested > 0 && len(repos) == 0 {
+			return nil, nil, fmt.Errorf("none of the requested repositories in project %s could be analyzed: %s", project, repo)
+		}
 	} else {
 		return nil, nil, fmt.Errorf("project name is empty")
 	}

--- a/pkg/devops/getbitbucketdc/getbitbucketdc.go
+++ b/pkg/devops/getbitbucketdc/getbitbucketdc.go
@@ -631,6 +631,7 @@ func determineProjectsAndRepos(platformConfig map[string]interface{}, exclusionL
 	var projects []Project
 	var repos []Repo
 	var err error
+	loggers := utils.SharedLogger()
 
 	project := platformConfig["Project"].(string)
 	repo := platformConfig["Repos"].(string)
@@ -647,12 +648,27 @@ func determineProjectsAndRepos(platformConfig map[string]interface{}, exclusionL
 		projects, err = fetchOnelProjects(fmt.Sprintf("%s/%s", bitbucketURL, project), platformConfig["AccessToken"].(string), exclusionList)
 		spin.Stop()
 	} else if project != "" && repo != "" {
-		Texclude := project + "/" + repo
-		if isProjectAndRepoExcluded(Texclude, *exclusionList) {
-			return nil, nil, fmt.Errorf("project %s and repository %s are excluded from the analysis", project, repo)
-		}
+		// One or more specific repositories were requested (comma-separated).
+		// Fetch each in turn; skip (don't abort) any that are excluded or fail
+		// so the remaining requested repos still analyze.
 		spin.Start()
-		repos, err = fetchOneRepos(fmt.Sprintf("%s/%s/repos/%s", bitbucketURL, project, repo), platformConfig["AccessToken"].(string), exclusionList)
+		for _, r := range strings.Split(repo, ",") {
+			repoName := strings.TrimSpace(r)
+			if repoName == "" {
+				continue
+			}
+			Texclude := project + "/" + repoName
+			if isProjectAndRepoExcluded(Texclude, *exclusionList) {
+				loggers.Infof("⏭️  Skipping <%s/%s>: excluded from the analysis", project, repoName)
+				continue
+			}
+			oneRepo, ferr := fetchOneRepos(fmt.Sprintf("%s/%s/repos/%s", bitbucketURL, project, repoName), platformConfig["AccessToken"].(string), exclusionList)
+			if ferr != nil {
+				loggers.Errorf("❌ Error fetching repository <%s/%s>: %v — skipping", project, repoName, ferr)
+				continue
+			}
+			repos = append(repos, oneRepo...)
+		}
 		spin.Stop()
 	} else {
 		return nil, nil, fmt.Errorf("project name is empty")
@@ -794,8 +810,7 @@ func fetchOneRepos(url string, accessToken string, exclusionList *utils.Exclusio
 	repo := reposResp.(*Repo)
 
 	if len(repo.Name) == 0 {
-		loggers.Errorf("❌ Error Repo or Project not exist")
-		os.Exit(1)
+		return nil, fmt.Errorf("repository or project does not exist")
 	}
 
 	if repo.Archived {

--- a/pkg/devops/getbitbucketdc/getbitbucketdc_test.go
+++ b/pkg/devops/getbitbucketdc/getbitbucketdc_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/SonarSource-Demos/sonar-golc/pkg/utils"
+	"github.com/briandowns/spinner"
 )
 
 // --- Pure logic tests ---
@@ -385,5 +387,103 @@ func TestFetchAllProjects_Pagination(t *testing.T) {
 	}
 	if len(projects) != 2 {
 		t.Errorf("expected 2 projects across 2 pages, got %d", len(projects))
+	}
+}
+
+// newTestSpinner returns a spinner suitable for tests (never started visibly).
+func newTestSpinner() *spinner.Spinner {
+	return spinner.New(spinner.CharSets[35], 100*time.Millisecond)
+}
+
+func TestDetermineProjectsAndRepos_CommaSeparatedDedup(t *testing.T) {
+	// Count how many times each repo slug is fetched so we can assert that a
+	// duplicate name ("repo1,repo1") is only requested once.
+	hits := map[string]int{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// URL shape: /{project}/repos/{repo}
+		slug := r.URL.Path[len("/PROJ/repos/"):]
+		hits[slug]++
+		json.NewEncoder(w).Encode(Repo{
+			Slug: slug, Name: slug,
+			Project: struct {
+				Key string `json:"key"`
+			}{Key: "PROJ"},
+		})
+	}))
+	defer ts.Close()
+
+	platformConfig := map[string]interface{}{
+		"Project":     "PROJ",
+		"Repos":       "repo1, repo1 ,repo2",
+		"AccessToken": "token",
+	}
+	el := &utils.ExclusionList{Projects: map[string]bool{}, Repos: map[string]bool{}}
+
+	_, repos, err := determineProjectsAndRepos(platformConfig, el, ts.URL, newTestSpinner())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 unique repos, got %d", len(repos))
+	}
+	if hits["repo1"] != 1 {
+		t.Errorf("expected repo1 to be fetched exactly once (dedup), got %d", hits["repo1"])
+	}
+	if hits["repo2"] != 1 {
+		t.Errorf("expected repo2 to be fetched once, got %d", hits["repo2"])
+	}
+}
+
+func TestDetermineProjectsAndRepos_AllUnresolvedErrors(t *testing.T) {
+	// Server returns an empty object for every repo → empty Name → fetchOneRepos
+	// errors → every requested repo is skipped. determineProjectsAndRepos must
+	// then fail loudly rather than silently returning nothing.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	platformConfig := map[string]interface{}{
+		"Project":     "PROJ",
+		"Repos":       "ghost1,ghost2",
+		"AccessToken": "token",
+	}
+	el := &utils.ExclusionList{Projects: map[string]bool{}, Repos: map[string]bool{}}
+
+	_, repos, err := determineProjectsAndRepos(platformConfig, el, ts.URL, newTestSpinner())
+	if err == nil {
+		t.Fatalf("expected an error when no requested repos resolve, got nil (repos=%v)", repos)
+	}
+	if len(repos) != 0 {
+		t.Errorf("expected no repos, got %d", len(repos))
+	}
+}
+
+func TestDetermineProjectsAndRepos_ExcludedRepoSkipped(t *testing.T) {
+	// repo1 is excluded; repo2 resolves. Result: only repo2, no error.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		slug := r.URL.Path[len("/PROJ/repos/"):]
+		json.NewEncoder(w).Encode(Repo{
+			Slug: slug, Name: slug,
+			Project: struct {
+				Key string `json:"key"`
+			}{Key: "PROJ"},
+		})
+	}))
+	defer ts.Close()
+
+	platformConfig := map[string]interface{}{
+		"Project":     "PROJ",
+		"Repos":       "repo1,repo2",
+		"AccessToken": "token",
+	}
+	el := &utils.ExclusionList{Projects: map[string]bool{}, Repos: map[string]bool{"PROJ/repo1": true}}
+
+	_, repos, err := determineProjectsAndRepos(platformConfig, el, ts.URL, newTestSpinner())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repos) != 1 || repos[0].Slug != "repo2" {
+		t.Fatalf("expected only repo2, got %+v", repos)
 	}
 }

--- a/pkg/devops/getgithub/getgithub.go
+++ b/pkg/devops/getgithub/getgithub.go
@@ -856,7 +856,7 @@ func GetRepoGithubList(platformConfig map[string]interface{}, exclusionfile stri
 			}
 		}
 	} else {
-		repositories, err1 = fetchSingleRepository(ctx, client, platformConfig)
+		repositories, err1 = fetchSpecificRepositories(ctx, client, platformConfig)
 	}
 
 	if err1 != nil {
@@ -1003,14 +1003,46 @@ func fetchAllRepositories(ctx context.Context, client *github.Client, organizati
 	return repositories, nil
 }
 
-func fetchSingleRepository(ctx context.Context, client *github.Client, platformConfig map[string]interface{}) ([]*github.Repository, error) {
-	repos, _, err := client.Repositories.Get(ctx, platformConfig["Organization"].(string), platformConfig["Repos"].(string))
-	loggers := utils.SharedLogger()
-	if err != nil {
-		loggers.Errorf("❌ Error fetching repository: %v\n", err)
-		return nil, err
+// parseRepoList splits the comma-separated "Repos" configuration field into a
+// clean, de-duplicated list of repository names, ignoring blank entries and
+// surrounding whitespace (e.g. "repo1, repo2 ,repo3").
+func parseRepoList(repos string) []string {
+	var list []string
+	seen := make(map[string]bool)
+	for _, r := range strings.Split(repos, ",") {
+		name := strings.TrimSpace(r)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		list = append(list, name)
 	}
-	return []*github.Repository{repos}, nil
+	return list
+}
+
+// fetchSpecificRepositories fetches the explicit repositories named in the
+// (comma-separated) "Repos" configuration field. Repositories that cannot be
+// fetched (e.g. typo, missing access) are logged and skipped so that one bad
+// name does not abort the whole analysis.
+func fetchSpecificRepositories(ctx context.Context, client *github.Client, platformConfig map[string]interface{}) ([]*github.Repository, error) {
+	loggers := utils.SharedLogger()
+	organization := platformConfig["Organization"].(string)
+	names := parseRepoList(platformConfig["Repos"].(string))
+
+	var repositories []*github.Repository
+	for _, name := range names {
+		repos, _, err := client.Repositories.Get(ctx, organization, name)
+		if err != nil {
+			loggers.Errorf("❌ Error fetching repository <%s>: %v\n", name, err)
+			continue
+		}
+		repositories = append(repositories, repos)
+	}
+
+	if len(repositories) == 0 {
+		return nil, fmt.Errorf("none of the requested repositories could be fetched: %s", platformConfig["Repos"].(string))
+	}
+	return repositories, nil
 }
 
 func getCommonParams(platformConfig map[string]interface{}, repositories []*github.Repository, exclusionList ExclusionRepos, spin *spinner.Spinner) ParamsReposGithub {
@@ -1145,16 +1177,13 @@ func FastAnalys(platformConfig map[string]interface{}, exlusionfile string) erro
 
 	} else {
 
-		var reposSlice []*github.Repository
 		ctx, client := initializeGithubClient(platformConfig)
 
-		repos1, _, err := client.Repositories.Get(ctx, platformConfig["Organization"].(string), platformConfig["Repos"].(string))
+		reposSlice, err := fetchSpecificRepositories(ctx, client, platformConfig)
 		if err != nil {
 			loggers.Errorf("❌ Error fetching repository: %v\n", err)
-
 		}
 
-		reposSlice = append(reposSlice, repos1)
 		parms := ParamsReposGithub{
 			Repos:         reposSlice,
 			URL:           platformConfig["Url"].(string),
@@ -1162,7 +1191,7 @@ func FastAnalys(platformConfig map[string]interface{}, exlusionfile string) erro
 			Apiver:        platformConfig["Apiver"].(string),
 			AccessToken:   platformConfig["AccessToken"].(string),
 			Organization:  platformConfig["Organization"].(string),
-			NBRepos:       len(repositories),
+			NBRepos:       len(reposSlice),
 			ExclusionList: exclusionList,
 			Spin:          spin,
 			Branch:        platformConfig["Branch"].(string),

--- a/pkg/devops/getgithub/getgithub_test.go
+++ b/pkg/devops/getgithub/getgithub_test.go
@@ -1140,12 +1140,12 @@ func TestEdgeCasesAndErrorPaths(t *testing.T) {
 			}
 		}()
 
-		// Test fetchSingleRepository with nil client
+		// Test fetchSpecificRepositories with nil client
 		func() {
 			panicked := false
 			defer func() {
 				if r := recover(); r != nil {
-					t.Logf("fetchSingleRepository properly handled nil client: %v", r)
+					t.Logf("fetchSpecificRepositories properly handled nil client: %v", r)
 					panicked = true
 				}
 			}()
@@ -1153,9 +1153,9 @@ func TestEdgeCasesAndErrorPaths(t *testing.T) {
 				"Organization": testOrgName,
 				"Repos":        testRepoName,
 			}
-			fetchSingleRepository(context.Background(), nil, config)
+			fetchSpecificRepositories(context.Background(), nil, config)
 			if !panicked {
-				t.Error("fetchSingleRepository should panic with nil client")
+				t.Error("fetchSpecificRepositories should panic with nil client")
 			}
 		}()
 	})

--- a/pkg/devops/getgithub/getgithub_test.go
+++ b/pkg/devops/getgithub/getgithub_test.go
@@ -1608,3 +1608,87 @@ func TestGetRepoGithubList_PersonalAccountUserGetError(t *testing.T) {
 		t.Errorf("expected Organization to remain empty on Users.Get failure, got %q", got)
 	}
 }
+
+func TestParseRepoList(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"empty", "", nil},
+		{"single", "repo1", []string{"repo1"}},
+		{"multiple", "repo1,repo2,repo3", []string{"repo1", "repo2", "repo3"}},
+		{"whitespace trimmed", "repo1, repo2 ,  repo3", []string{"repo1", "repo2", "repo3"}},
+		{"blanks skipped", "repo1,,repo2,   ,repo3", []string{"repo1", "repo2", "repo3"}},
+		{"duplicates dropped", "repo1,repo2,repo1,repo2", []string{"repo1", "repo2"}},
+		{"only blanks", " , , ", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseRepoList(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseRepoList(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseRepoList(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFetchSpecificRepositories(t *testing.T) {
+	// Fake GHES server: repos r1 and r3 exist, r2 returns 404. The repo Get
+	// path on the enterprise client is /api/v3/repos/{org}/{repo}.
+	mux := http.NewServeMux()
+	for _, name := range []string{"r1", "r3"} {
+		repoName := name
+		mux.HandleFunc("/api/v3/repos/"+testOrgName+"/"+repoName, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"name":%q}`, repoName)))
+		})
+	}
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Unknown repo (e.g. r2) → 404.
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	makeConfig := func(repos string) map[string]interface{} {
+		return map[string]interface{}{
+			"Url":          server.URL + "/",
+			"AccessToken":  testToken,
+			"Organization": testOrgName,
+			"Repos":        repos,
+		}
+	}
+	ctx, client := initializeGithubClient(makeConfig(""))
+
+	t.Run("skips unreachable repos and keeps the rest", func(t *testing.T) {
+		repos, err := fetchSpecificRepositories(ctx, client, makeConfig("r1, r2 ,r3"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(repos) != 2 {
+			t.Fatalf("expected 2 reachable repos (r1, r3), got %d", len(repos))
+		}
+		if repos[0].GetName() != "r1" || repos[1].GetName() != "r3" {
+			t.Errorf("expected [r1 r3], got [%s %s]", repos[0].GetName(), repos[1].GetName())
+		}
+	})
+
+	t.Run("errors when none resolve", func(t *testing.T) {
+		repos, err := fetchSpecificRepositories(ctx, client, makeConfig("nope1,nope2"))
+		if err == nil {
+			t.Fatalf("expected error when no repositories resolve, got nil (repos=%v)", repos)
+		}
+		if len(repos) != 0 {
+			t.Errorf("expected no repos, got %d", len(repos))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

The `Repos` configuration field is documented (README line 83) as accepting a **comma-separated** list of repositories, but only **Azure DevOps** actually honored it. On **GitHub/GHES**, **Bitbucket Cloud**, and **Bitbucket DC**, the entire string was treated as a single repository name — so an entry like `repo1,repo2` silently matched nothing. On GitHub the resulting 404 was even swallowed, so the scan just returned zero repos with no error. This was reported as "scanning specific repositories with comma-separated names doesn't work."

This PR makes the comma-separated behavior work consistently on every platform where it applies.

## Changes

- **GitHub / GHES** (`getgithub.go`): added `parseRepoList` (split on comma, trim whitespace, drop blanks/dupes) and replaced `fetchSingleRepository` with `fetchSpecificRepositories`, which loops `Repositories.Get` over each name. Inaccessible/typo'd names are logged and skipped; only errors if *none* resolve. Applied to both the standard and `FastAnalys` paths. Also fixed a latent bug in `FastAnalys` where `NBRepos` was derived from an always-empty slice.
- **Bitbucket Cloud** (`getbitbucket.go`): added `matchesSingleRepos` (membership over the comma list) and switched the exact-match filter to collect *all* matching repos instead of breaking after the first. Excluded/empty requested repos are now skipped-with-log rather than aborting the whole scan.
- **Bitbucket DC** (`getbitbucketdc.go`): the `project + repo` branch now splits the repo field and fetches each repo with a per-repo exclusion check. Hardened `fetchOneRepos` to return an error instead of `os.Exit(1)` when a repo doesn't exist, so a bad name skips gracefully like the other platforms.
- **Azure DevOps** (`getazure.go`): already split on comma; added whitespace-trimming / skip-empty so `repo1, repo2` (with spaces) works.

## Behavior notes

- **GitLab** is unchanged — it scopes by Group URL, not `Repos` (N/A).
- **Bitbucket Cloud** still requires a `Project` alongside `Repos` (pre-existing routing); multi-repo now works within that project.
- A requested repo that is missing/excluded/empty is now skipped with a log line on all platforms, rather than aborting the run.

## Testing

- `go build ./...` — passes
- `go test ./pkg/devops/...` — passes (updated the one test referencing the renamed GitHub function)
- `go vet` on all changed packages — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)