### PR TITLE
fix(logger): use SharedLogger() on per-repo hot paths to stop FD churn (#84)

### DIFF
--- a/pkg/gogit/gogit.go
+++ b/pkg/gogit/gogit.go
@@ -20,7 +20,7 @@ import (
 
 func Getrepos(src, branch, token, workDir string) (string, error) {
 
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	suffix, err := randomSuffix()
 	if err != nil {
 		return "", err

--- a/pkg/goloc/goloc.go
+++ b/pkg/goloc/goloc.go
@@ -60,7 +60,7 @@ type GCloc struct {
 /* func NewGCloc(params Params, languages language.Languages) (*GCloc, error) {
 	var path string
 	var err error
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 
 	if !params.Cloned {
 		// The repository is not cloned, clone it
@@ -156,7 +156,7 @@ func NewGCloc(params Params, languages language.Languages) (*GCloc, error) {
 		if lastPart := filepath.Base(path); lastPart != "" {
 			params.OutputName = fmt.Sprintf("%s%s", params.OutputName, lastPart)
 		} else {
-			utils.NewLogger().Errorf("❌ Failed to create OutputName")
+			utils.SharedLogger().Errorf("❌ Failed to create OutputName")
 		}
 	}
 
@@ -333,7 +333,7 @@ func getReporters(reportFormats []string, outputName, outputPath string, byfile 
 		case "prompt":
 			reporters = append(reporters, prompt.PromptReporter{})
 		case "json":
-			//loggers := utils.NewLogger()
+			//loggers := utils.SharedLogger()
 
 			if byfile {
 

--- a/pkg/reporter/csv/csv_reporter.go
+++ b/pkg/reporter/csv/csv_reporter.go
@@ -90,7 +90,7 @@ func (c CsvReporter) GenerateReportByFile(summary *sorter.SortedSummary) error {
 }
 
 func (c CsvReporter) writeCsv(csvReport *report) error {
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	outputName := strings.Replace(c.OutputName, "/", "_", -1)
 	if !strings.HasSuffix(outputName, ".csv") {
 		outputName += ".csv"

--- a/pkg/reporter/json/json_reporter.go
+++ b/pkg/reporter/json/json_reporter.go
@@ -89,7 +89,7 @@ func (j JsonReporter) GenerateReportByFile(summary *sorter.SortedSummary) error 
 }
 
 func (j JsonReporter) writeJson(jsonReport *report) error {
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	file, err := json.MarshalIndent(jsonReport, "", "  ")
 	if err != nil {
 		return err

--- a/pkg/reporter/pdf/pdf_reporter.go
+++ b/pkg/reporter/pdf/pdf_reporter.go
@@ -117,7 +117,7 @@ func (p PdfReporter) GenerateReportByFile(summary *sorter.SortedSummary) error {
 
 func (p PdfReporter) writePdf(pdfReport *report) error {
 	var branch string
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	outputName := strings.Replace(p.OutputName, "/", "_", -1)
 	if !strings.HasSuffix(outputName, ".pdf") {
 		outputName += ".pdf"
@@ -238,7 +238,7 @@ func (p PdfReporter) writePdf(pdfReport *report) error {
 }
 
 func (p PdfReporter) GenerateGlobalReportByFile() error {
-	loggers := utils.NewLogger()
+	loggers := utils.SharedLogger()
 	dir := "./Results/byfile-report/"
 	/*	pwd, err1 := os.Getwd()
 		if err1 != nil {

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -34,7 +34,7 @@ func NewScanner(languages language.Languages) *Scanner {
 func (sc *Scanner) Scan(files []analyzer.FileMetadata) ([]scanResult, error) {
 	var results []scanResult
 	progress := sc.createProgressbar(len(files))
-	logger := utils.NewLogger()
+	logger := utils.SharedLogger()
 
 	failed := 0
 	for _, file := range files {

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -104,6 +104,11 @@ var allLevels = []logrus.Level{
 // NewLogger returns a logger that:
 //   - writes Info+ (coloured) to stdout and Logs/Logs.log  — visible in the UI SSE stream
 //   - writes Debug+ (plain text) to Logs/debug.log         — downloadable from the UI
+//
+// Each call opens two file handles (Logs.log + debug.log) that are only closed
+// when the GC finalizes the returned logger, so it is NOT safe to call per-repo
+// on hot paths. Production code MUST use SharedLogger() instead; NewLogger is
+// intended for test fixtures that want an isolated logger instance.
 func NewLogger() *logrus.Logger {
 	logger := logrus.New()
 	logger.SetLevel(logrus.DebugLevel)


### PR DESCRIPTION
## What

Replaces `utils.NewLogger()` with the existing process-wide singleton `utils.SharedLogger()` at the **7 live production call sites** that run once per repository, and documents `NewLogger()` as test-fixture-only.

Closes the FD-churn problem described in #84.

## Why

`utils.NewLogger()` opens two file handles (`Logs/Logs.log` + `Logs/debug.log`) on **every call**, captured by `io.MultiWriter` / `writerHook` closures inside the returned logger. There is no `Close()` — the handles are released only when the GC finalizes the orphaned `*os.File`. Seven hot-path sites called it once per repo, so a multi-repo scan accumulates FDs faster than finalizers reclaim them.

### Measured (local, this codebase)

| Scenario | Open FDs |
|---|---|
| 1000 sequential `NewLogger()`, no GC | **~2000** (2 per call) |
| after `runtime.GC()` | ~95 (lazy finalizer reclaim) |
| 550-repo worker-model simulation, peak | **~1400** concurrently open |

On a **default macOS box (`ulimit -n` = 256)** that peak trips `too many open files` from `os.OpenFile`, `git clone`, or socket allocation. A raised `ulimit` hides it entirely — which is why large scans can still pass on some machines. Using the singleton removes the environment-dependency.

## Changes

- Swap `NewLogger()` → `SharedLogger()` at 7 sites:
  - `pkg/gogit/gogit.go` (clone)
  - `pkg/scanner/scanner.go` (`Scan`)
  - `pkg/goloc/goloc.go` (`NewGCloc` error path)
  - `pkg/reporter/pdf/pdf_reporter.go` (×2)
  - `pkg/reporter/json/json_reporter.go`
  - `pkg/reporter/csv/csv_reporter.go`
- Add a godoc note marking `NewLogger()` as test-fixture-only.
- Test fixtures in `getgithub_test.go` intentionally keep `NewLogger()` (isolated instances) — left untouched.

`SharedLogger()` is already initialised early in `runGolcInProcess` and is the pattern every `get*` adapter already uses, so no init-ordering change is needed.

## Verification

- ✅ `grep -rn 'utils\.NewLogger(' pkg/ | grep -v _test.go` → zero matches
- ✅ `go build ./...`
- ✅ `go vet` on touched packages
- ✅ `go test ./...` (all pass)

Refs #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)