### PR TITLE
fix(deps): exclude goldmark v1.4.13 to clear CVE-2026-5160

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,6 @@ require (
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/yuin/goldmark v1.8.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
@@ -118,6 +117,11 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
+
+// goldmark v1.4.13 (pulled only via golang.org/x/tools in the module graph, never
+// built — MVS selects v1.8.2) carries CVE-2026-5160. Exclude it so it drops out of
+// the graph entirely and is not reported as a transitive risk.
+exclude github.com/yuin/goldmark v1.4.13
 
 replace golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a => golang.org/x/image v0.30.0
 

--- a/go.sum
+++ b/go.sum
@@ -259,9 +259,6 @@ github.com/xanzy/go-gitlab v0.105.0 h1:3nyLq0ESez0crcaM19o5S//SvezOQguuIHZ3wgX64
 github.com/xanzy/go-gitlab v0.105.0/go.mod h1:ETg8tcj4OhrB84UEgeE8dSuV/0h4BBL1uOV/qK0vlyI=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
-github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
-github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0 h1:kWRNZMsfBHZ+uHjiH4y7Etn2FK26LAGkNFw7RHv1DhE=


### PR DESCRIPTION
## Summary

Clears the SonarQube quality-gate failure for **CVE-2026-5160** (XSS / CWE-79, CVSS 5.1) in `github.com/yuin/goldmark`.

The direct requirement was already upgraded to `v1.8.2`, and Go's minimal version selection (MVS) was already building `v1.8.2` — never the vulnerable `v1.4.13`. But SonarQube's SCA scans the full module graph, where `v1.4.13` still appeared as a transitive edge via `golang.org/x/tools` (a module the build doesn't actually need). That graph edge alone kept the finding open.

## Fix

- Added an `exclude github.com/yuin/goldmark v1.4.13` directive (matching the project's existing `replace`-directive convention) and ran `go mod tidy`.
- Because no package in the repo imports goldmark, `go mod tidy` pruned it **entirely** from `go.mod` and `go.sum`. The package is no longer a dependency, so the CVE can no longer be reported.

## Breaking-change assessment: none

No project code imports goldmark — verified via `grep` and `go mod why`. There is no API surface to break.

## Verification

- `go build ./...` → OK
- `go vet ./...` → clean
- `go mod verify` → all modules verified
- SonarQube Agentic Analysis (DEEP) → No issues found
- `go.sum` no longer contains any goldmark entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)