### PR TITLE
feat(reports): count archived repos on ADO (#74) + cross-platform scan summary

### DIFF
--- a/ResultsAll.go
+++ b/ResultsAll.go
@@ -186,12 +186,25 @@ type RepositoryDetailData struct {
 }
 
 type PageData struct {
-	Languages        []LanguageData
-	GlobalReport     Globalinfo
-	Repositories     []RepositoryData
-	SkippedRepos     []utils.SkippedRepo // repos the analysis phase could not complete (clone timeout/failure, analysis error)
-	NoteLOCExcluded  string              // Note that JSON is excluded from total (SonarQube behavior)
-	Platform         string
+	Languages       []LanguageData
+	GlobalReport    Globalinfo
+	Repositories    []RepositoryData
+	SkippedRepos    []utils.SkippedRepo // repos the analysis phase could not complete (clone timeout/failure, analysis error)
+	ScanSummary     *ScanSummaryView    // per-run repository breakdown; nil on older result sets
+	NoteLOCExcluded string              // Note that JSON is excluded from total (SonarQube behavior)
+	Platform        string
+}
+
+// ScanSummaryView is the template-facing view of utils.ScanSummary. Analyzed is
+// adjusted for repos that failed during the analysis phase, and Skipped is that
+// failure count, so the row reconciles: Scanned = Analyzed + Archived + Empty + Excluded + Skipped.
+type ScanSummaryView struct {
+	Scanned  int
+	Analyzed int
+	Archived int
+	Empty    int
+	Excluded int
+	Skipped  int
 }
 
 var globalInfo Globalinfo       // Variable pour stocker les infos globales
@@ -916,16 +929,42 @@ func loadApplicationData() (PageData, error) {
 	// error). Missing file (older result sets) => empty list, so the page still renders.
 	skippedRepos := utils.LoadSkippedRepos("Results")
 
+	// Per-run repository breakdown for the Scan Summary card. Missing file (older
+	// result sets) => nil, so the card is omitted and the page still renders.
+	scanSummary := buildScanSummaryView(utils.LoadScanSummary("Results"), len(skippedRepos))
+
 	pageData = PageData{
 		Languages:       languages,
 		GlobalReport:    globalInfo,
 		Repositories:    repositoryData,
 		SkippedRepos:    skippedRepos,
+		ScanSummary:     scanSummary,
 		NoteLOCExcluded: utils.NoteExcludedFromTotal,
 		Platform:        detectedPlatform,
 	}
 
 	return pageData, nil
+}
+
+// buildScanSummaryView adapts a persisted utils.ScanSummary into the template view,
+// subtracting repos that failed during analysis from the analyzed count and
+// exposing that failure count as Skipped. Returns nil when no summary was persisted.
+func buildScanSummaryView(summary *utils.ScanSummary, skippedCount int) *ScanSummaryView {
+	if summary == nil {
+		return nil
+	}
+	analyzed := summary.Analyzed - skippedCount
+	if analyzed < 0 {
+		analyzed = 0
+	}
+	return &ScanSummaryView{
+		Scanned:  summary.Scanned,
+		Analyzed: analyzed,
+		Archived: summary.Archived,
+		Empty:    summary.Empty,
+		Excluded: summary.Excluded,
+		Skipped:  skippedCount,
+	}
 }
 
 // setupHTTPHandlers configures all HTTP route handlers
@@ -1000,6 +1039,13 @@ func setupHTTPHandlers(pageData PageData) {
 			skipped = []utils.SkippedRepo{}
 		}
 		json.NewEncoder(w).Encode(skipped)
+	})
+
+	// API Endpoint for the per-run repository breakdown (scanned/analyzed/archived/
+	// empty/excluded/skipped). Returns null when no summary was persisted.
+	http.HandleFunc("/api/scan-summary", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(contentTypeHeader, applicationJSONType)
+		json.NewEncoder(w).Encode(pageData.ScanSummary)
 	})
 
 	// Repository Detail Page Handler
@@ -1438,6 +1484,54 @@ const htmlTemplate = `
           </div>
         </div>
       </section>
+
+      {{if .ScanSummary}}
+      <!-- Scan Summary Section -->
+      <section id="scan-summary-section" style="background-color: #f8f9fa; padding: 2rem 0 1rem 0;">
+        <div class="container">
+          <div class="row">
+            <div class="col-12">
+              <div class="card shadow-lg">
+                <h5 class="card-header text-white" style="background-color:#0073ba;">
+                  <i class="fas fa-clipboard-list"></i> Scan Summary
+                </h5>
+                <div class="card-body">
+                  <p class="text-muted mb-3" style="font-size:0.9rem;">
+                    Repository breakdown for this run. <strong>Scanned</strong> is the total discovered; it splits into <strong>Analyzed</strong> plus the repositories filtered out (<strong>Archived</strong>/disabled, <strong>Empty</strong>, <strong>Excluded</strong>) and those that could not be completed (<strong>Skipped</strong>).
+                  </p>
+                  <div class="row text-center">
+                    <div class="col">
+                      <div class="h3 mb-0">{{.ScanSummary.Scanned}}</div>
+                      <div class="text-muted small">Scanned</div>
+                    </div>
+                    <div class="col">
+                      <div class="h3 mb-0 text-success">{{.ScanSummary.Analyzed}}</div>
+                      <div class="text-muted small">Analyzed</div>
+                    </div>
+                    <div class="col">
+                      <div class="h3 mb-0">{{.ScanSummary.Archived}}</div>
+                      <div class="text-muted small">Archived</div>
+                    </div>
+                    <div class="col">
+                      <div class="h3 mb-0">{{.ScanSummary.Empty}}</div>
+                      <div class="text-muted small">Empty</div>
+                    </div>
+                    <div class="col">
+                      <div class="h3 mb-0">{{.ScanSummary.Excluded}}</div>
+                      <div class="text-muted small">Excluded</div>
+                    </div>
+                    <div class="col">
+                      <div class="h3 mb-0" style="color:#d68910;">{{.ScanSummary.Skipped}}</div>
+                      <div class="text-muted small">Skipped</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      {{end}}
 
       {{if .SkippedRepos}}
       <!-- Skipped Repositories Section -->

--- a/ResultsAll.go
+++ b/ResultsAll.go
@@ -946,9 +946,12 @@ func loadApplicationData() (PageData, error) {
 	return pageData, nil
 }
 
-// buildScanSummaryView adapts a persisted utils.ScanSummary into the template view,
-// subtracting repos that failed during analysis from the analyzed count and
-// exposing that failure count as Skipped. Returns nil when no summary was persisted.
+// buildScanSummaryView adapts a persisted utils.ScanSummary into the template view.
+// Analysis-phase failures (skippedCount, from analysis_skipped.json) are subtracted
+// from the analyzed count and folded together with the summary's discovery-phase
+// Skipped total, so the displayed row reconciles:
+// Scanned = Analyzed + Archived + Empty + Excluded + Skipped. Returns nil when no
+// summary was persisted.
 func buildScanSummaryView(summary *utils.ScanSummary, skippedCount int) *ScanSummaryView {
 	if summary == nil {
 		return nil
@@ -963,7 +966,7 @@ func buildScanSummaryView(summary *utils.ScanSummary, skippedCount int) *ScanSum
 		Archived: summary.Archived,
 		Empty:    summary.Empty,
 		Excluded: summary.Excluded,
-		Skipped:  skippedCount,
+		Skipped:  summary.Skipped + skippedCount,
 	}
 }
 

--- a/pkg/devops/getazure/getazure.go
+++ b/pkg/devops/getazure/getazure.go
@@ -335,15 +335,13 @@ func GetRepoAzureList(platformConfig map[string]interface{}, exclusionFile strin
 	// Persist the per-run repository breakdown for the ResultsAll page and the
 	// global PDF report. Analyzed is the number of repos that will actually be
 	// analyzed (one important branch per repo); Scanned is derived from the sum.
-	if err := utils.SaveScanSummary("Results", utils.ScanSummary{
-		Platform: "azure",
-		Analyzed: len(importantBranches),
-		Archived: totalArchiv,
-		Empty:    emptyRepo,
-		Excluded: totalExclude,
-	}); err != nil {
-		loggers.Errorf("❌ Error saving scan summary: %v", err)
-	}
+	//
+	// nbRepos is the true count of discovered repos (analyzed + filtered), so any
+	// repo discovered but dropped inside the analysis loop (no usable default
+	// branch, or filtered out by single-branch selection) without landing in a
+	// category is surfaced as Skipped, keeping Scanned equal to the real total.
+	discoverySkipped := azureDiscoverySkipped(nbRepos, emptyRepo, totalExclude, totalArchiv, len(importantBranches))
+	utils.PersistScanSummary("Results", utils.NewScanSummary("azure", len(importantBranches), totalArchiv, emptyRepo, totalExclude, discoverySkipped))
 
 	printSummary(platformConfig["Organization"].(string), stats)
 
@@ -548,8 +546,14 @@ func fetchDisabledRepoIDs(parms ParamsProjectAzure, projectKey string) map[strin
 		loggers.Warnf("⚠️  Skipping disabled-repo detection for project %s: "+reason, append([]interface{}{projectKey}, args...)...)
 	}
 
+	// Bound the call: the shared HTTP client has no request timeout, so a server
+	// that accepts the connection but never responds would otherwise hang the
+	// whole scan instead of degrading gracefully.
+	ctx, cancel := context.WithTimeout(parms.Context, 30*time.Second)
+	defer cancel()
+
 	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories?api-version=6.0", parms.ApiURL, url.PathEscape(projectKey))
-	req, err := http.NewRequestWithContext(parms.Context, http.MethodGet, endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		warn("%v", err)
 		return disabled
@@ -580,6 +584,19 @@ func fetchDisabledRepoIDs(parms ParamsProjectAzure, projectKey string) map[strin
 		}
 	}
 	return disabled
+}
+
+// azureDiscoverySkipped returns the number of repositories that were discovered
+// (nbRepos includes analyzed + all filtered categories) but dropped inside the
+// analysis loop without being analyzed or filed under archived/empty/excluded —
+// e.g. no usable default branch, or filtered out by a single-branch selection.
+// Surfacing this keeps the scan summary's Scanned total equal to the real count.
+func azureDiscoverySkipped(nbRepos, empty, excluded, archived, analyzed int) int {
+	skipped := nbRepos - empty - excluded - archived - analyzed
+	if skipped < 0 {
+		return 0
+	}
+	return skipped
 }
 
 func listReposForProject(parms ParamsProjectAzure, projectKey string, gitClient git.Client) (int, int, int, []git.GitRepository, error) {

--- a/pkg/devops/getazure/getazure.go
+++ b/pkg/devops/getazure/getazure.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -330,6 +332,19 @@ func GetRepoAzureList(platformConfig map[string]interface{}, exclusionFile strin
 		TotalBranches:     TotalBranches,
 	}
 
+	// Persist the per-run repository breakdown for the ResultsAll page and the
+	// global PDF report. Analyzed is the number of repos that will actually be
+	// analyzed (one important branch per repo); Scanned is derived from the sum.
+	if err := utils.SaveScanSummary("Results", utils.ScanSummary{
+		Platform: "azure",
+		Analyzed: len(importantBranches),
+		Archived: totalArchiv,
+		Empty:    emptyRepo,
+		Excluded: totalExclude,
+	}); err != nil {
+		loggers.Errorf("❌ Error saving scan summary: %v", err)
+	}
+
 	printSummary(platformConfig["Organization"].(string), stats)
 
 	return importantBranches, nil
@@ -416,7 +431,7 @@ func getRepoAnalyse(params ParamsProjectAzure, gitClient git.Client) ([]ProjectB
 
 		loggers.Infof("\t🟢  Analyse Project: %s \n", *project.Name)
 
-		emptyOrArchivedCount, emptyRepos, excludedCount, repos, err := listReposForProject(params, *project.Name, gitClient)
+		archivedCount, emptyCount, excludedCount, repos, err := listReposForProject(params, *project.Name, gitClient)
 
 		if err != nil {
 			if len(params.SingleRepos) == 0 {
@@ -430,14 +445,19 @@ func getRepoAnalyse(params ParamsProjectAzure, gitClient git.Client) ([]ProjectB
 			}
 		}
 
-		totalexclude = totalexclude + excludedCount
+		// Accumulate into the function-level counters. Using distinct local names
+		// above avoids shadowing these accumulators inside the loop body.
+		totalexclude += excludedCount
+		emptyRepos += emptyCount
+		cptarchiv += archivedCount
 
 		spin1.Stop()
-		if emptyOrArchivedCount > 0 {
-			NBRrepo = len(repos) + emptyOrArchivedCount
-			loggers.Infof("\t  ✅ The number of %s found is: %d - Find empty %d:\n", message4, NBRrepo, emptyOrArchivedCount)
+		// NBRrepo counts every repo discovered for the project (analyzed + filtered)
+		// so the summary total reconciles with the per-category counts.
+		NBRrepo = len(repos) + emptyCount + archivedCount + excludedCount
+		if emptyCount+archivedCount+excludedCount > 0 {
+			loggers.Infof("\t  ✅ The number of %s found is: %d - Empty: %d, Archived: %d, Excluded: %d\n", message4, NBRrepo, emptyCount, archivedCount, excludedCount)
 		} else {
-			NBRrepo = len(repos)
 			loggers.Infof("\t  ✅ The number of %s found is: %d\n", message4, NBRrepo)
 		}
 
@@ -503,10 +523,73 @@ func parseSingleRepos(singleRepos string) []string {
 	return list
 }
 
+// azureRepoList mirrors the subset of the Azure DevOps "list repositories" REST
+// response we need. The pinned SDK (v1.0.0-b5) drops isDisabled from its
+// git.GitRepository struct, so disabled repositories — the ADO equivalent of an
+// "archived" repo: no default branch, cannot be cloned — can only be detected
+// through a raw REST call.
+type azureRepoList struct {
+	Value []struct {
+		Id         string `json:"id"`
+		IsDisabled bool   `json:"isDisabled"`
+	} `json:"value"`
+}
+
+// fetchDisabledRepoIDs returns the set of disabled repository IDs for a project,
+// keyed by lowercased UUID. Disabled repos must be excluded from the analysis the
+// same way archived repositories are on the other platforms. On any error
+// (insufficient permissions, older server, network) it logs a warning and returns
+// an empty set so the scan proceeds rather than failing.
+func fetchDisabledRepoIDs(parms ParamsProjectAzure, projectKey string) map[string]bool {
+	loggers := utils.SharedLogger()
+	disabled := make(map[string]bool)
+
+	warn := func(reason string, args ...interface{}) {
+		loggers.Warnf("⚠️  Skipping disabled-repo detection for project %s: "+reason, append([]interface{}{projectKey}, args...)...)
+	}
+
+	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories?api-version=6.0", parms.ApiURL, url.PathEscape(projectKey))
+	req, err := http.NewRequestWithContext(parms.Context, http.MethodGet, endpoint, nil)
+	if err != nil {
+		warn("%v", err)
+		return disabled
+	}
+	req.SetBasicAuth("", parms.AccessToken)
+
+	resp, err := utils.HTTPClient.Do(req)
+	if err != nil {
+		warn("%v", err)
+		return disabled
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		warn("API returned %s", resp.Status)
+		return disabled
+	}
+
+	var list azureRepoList
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		warn("%v", err)
+		return disabled
+	}
+
+	for _, repo := range list.Value {
+		if repo.IsDisabled {
+			disabled[strings.ToLower(repo.Id)] = true
+		}
+	}
+	return disabled
+}
+
 func listReposForProject(parms ParamsProjectAzure, projectKey string, gitClient git.Client) (int, int, int, []git.GitRepository, error) {
 	var allRepos []git.GitRepository
 	var archivedCount, emptyCount, excludedCount int
 	loggers := utils.SharedLogger()
+
+	// Disabled (archived-equivalent) repos are detected via a raw REST call
+	// because the pinned SDK does not expose the isDisabled flag.
+	disabledRepos := fetchDisabledRepoIDs(parms, projectKey)
 
 	// Convert SingleRepos (comma-separated) to a clean slice, ignoring blank
 	// entries and surrounding whitespace (e.g. "repo1, repo2 ,repo3").
@@ -539,6 +622,14 @@ func listReposForProject(parms ParamsProjectAzure, projectKey string, gitClient 
 			continue
 		}
 		repoID := repo.Id.String()
+
+		// Skip disabled repos (ADO equivalent of archived): they have no default
+		// branch and cannot be cloned, so they must not inflate the analyzed count.
+		if disabledRepos[strings.ToLower(repoID)] {
+			loggers.Debugf("→ repo %s/%s: skipped (disabled/archived)", projectKey, repoName)
+			archivedCount++
+			continue
+		}
 
 		isEmpty, err := isRepoEmpty(parms.Context, gitClient, projectKey, repoID)
 

--- a/pkg/devops/getazure/getazure_disabled_test.go
+++ b/pkg/devops/getazure/getazure_disabled_test.go
@@ -1,0 +1,62 @@
+package getazure
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newDisabledReposParams builds the minimal params fetchDisabledRepoIDs needs,
+// pointing ApiURL at the given test server.
+func newDisabledReposParams(apiURL string) ParamsProjectAzure {
+	return ParamsProjectAzure{
+		Context:     context.Background(),
+		ApiURL:      apiURL,
+		AccessToken: "token",
+	}
+}
+
+func TestFetchDisabledRepoIDs_ParsesDisabledFlag(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"value":[
+			{"id":"AAAAAAAA-1111-2222-3333-444444444444","isDisabled":true},
+			{"id":"BBBBBBBB-1111-2222-3333-444444444444","isDisabled":false},
+			{"id":"CCCCCCCC-1111-2222-3333-444444444444"}
+		]}`))
+	}))
+	defer ts.Close()
+
+	disabled := fetchDisabledRepoIDs(newDisabledReposParams(ts.URL), "PROJ")
+
+	if len(disabled) != 1 {
+		t.Fatalf("expected exactly 1 disabled repo, got %d: %v", len(disabled), disabled)
+	}
+	// IDs are keyed lowercase so lookups from git.GitRepository UUIDs match.
+	if !disabled["aaaaaaaa-1111-2222-3333-444444444444"] {
+		t.Errorf("disabled repo id not found (case-insensitive): %v", disabled)
+	}
+}
+
+func TestFetchDisabledRepoIDs_Non200IsEmpty(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	if disabled := fetchDisabledRepoIDs(newDisabledReposParams(ts.URL), "PROJ"); len(disabled) != 0 {
+		t.Errorf("expected empty set on non-200 response, got %v", disabled)
+	}
+}
+
+func TestFetchDisabledRepoIDs_BadJSONIsEmpty(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("{not json"))
+	}))
+	defer ts.Close()
+
+	if disabled := fetchDisabledRepoIDs(newDisabledReposParams(ts.URL), "PROJ"); len(disabled) != 0 {
+		t.Errorf("expected empty set on malformed JSON, got %v", disabled)
+	}
+}

--- a/pkg/devops/getazure/getazure_disabled_test.go
+++ b/pkg/devops/getazure/getazure_disabled_test.go
@@ -2,9 +2,14 @@ package getazure
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/SonarSource-Demos/sonar-golc/pkg/utils"
+	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
 )
 
 // newDisabledReposParams builds the minimal params fetchDisabledRepoIDs needs,
@@ -39,6 +44,14 @@ func TestFetchDisabledRepoIDs_ParsesDisabledFlag(t *testing.T) {
 	}
 }
 
+func TestFetchDisabledRepoIDs_BadEndpointIsEmpty(t *testing.T) {
+	// A control character in the URL makes request construction fail, exercising
+	// the early-return warning path without any network call.
+	if disabled := fetchDisabledRepoIDs(newDisabledReposParams("http://\x7f-bad"), "PROJ"); len(disabled) != 0 {
+		t.Errorf("expected empty set when the request cannot be built, got %v", disabled)
+	}
+}
+
 func TestFetchDisabledRepoIDs_Non200IsEmpty(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
@@ -58,5 +71,104 @@ func TestFetchDisabledRepoIDs_BadJSONIsEmpty(t *testing.T) {
 
 	if disabled := fetchDisabledRepoIDs(newDisabledReposParams(ts.URL), "PROJ"); len(disabled) != 0 {
 		t.Errorf("expected empty set on malformed JSON, got %v", disabled)
+	}
+}
+
+func TestAzureDiscoverySkipped(t *testing.T) {
+	// 20 discovered, 2 empty, 3 excluded, 1 archived, 10 analyzed -> 4 dropped mid-loop.
+	if got := azureDiscoverySkipped(20, 2, 3, 1, 10); got != 4 {
+		t.Errorf("azureDiscoverySkipped = %d, want 4", got)
+	}
+	// Never negative, even if the counts somehow over-subtract.
+	if got := azureDiscoverySkipped(5, 2, 3, 1, 10); got != 0 {
+		t.Errorf("azureDiscoverySkipped should floor at 0, got %d", got)
+	}
+}
+
+// TestListReposForProject_CountsDisabled is the core #74 assertion: a disabled
+// (archived-equivalent) repo is counted as archived and dropped from the analyzed
+// set, while a normal repo is returned.
+func TestListReposForProject_CountsDisabled(t *testing.T) {
+	disabledID := uuid.New()
+	enabledID := uuid.New()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"value":[{"id":"%s","isDisabled":true},{"id":"%s","isDisabled":false}]}`, disabledID, enabledID)
+	}))
+	defer ts.Close()
+
+	disabledName, enabledName := "disabled-repo", "live-repo"
+	fc := &fakeGitClient{
+		repos: &[]git.GitRepository{
+			{Id: &disabledID, Name: &disabledName},
+			{Id: &enabledID, Name: &enabledName},
+		},
+		items:    &[]git.GitItem{{}},        // non-empty content
+		branches: &[]git.GitBranchStats{{}}, // at least one branch
+	}
+
+	parms := ParamsProjectAzure{
+		Context:       context.Background(),
+		ApiURL:        ts.URL,
+		AccessToken:   "token",
+		Exclusionlist: &utils.ExclusionList{Projects: map[string]bool{}, Repos: map[string]bool{}},
+	}
+
+	archived, empty, excluded, repos, err := listReposForProject(parms, "PROJ", fc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if archived != 1 {
+		t.Errorf("archived = %d, want 1 (the disabled repo)", archived)
+	}
+	if empty != 0 || excluded != 0 {
+		t.Errorf("empty=%d excluded=%d, want 0 and 0", empty, excluded)
+	}
+	if len(repos) != 1 || *repos[0].Name != enabledName {
+		t.Errorf("expected only the live repo returned, got %d repos", len(repos))
+	}
+}
+
+// TestListReposForProject_ExcludedAndEmpty covers the exclusion and empty-repo
+// filter branches alongside the archived one.
+func TestListReposForProject_ExcludedAndEmpty(t *testing.T) {
+	excludedID := uuid.New()
+	emptyID := uuid.New()
+
+	// No repos are disabled here; the REST endpoint returns an empty set.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"value":[]}`))
+	}))
+	defer ts.Close()
+
+	excludedName, emptyName := "excluded-repo", "empty-repo"
+	fc := &fakeGitClient{
+		repos: &[]git.GitRepository{
+			{Id: &excludedID, Name: &excludedName},
+			{Id: &emptyID, Name: &emptyName},
+		},
+		items:    &[]git.GitItem{},        // empty content -> repo counts as empty
+		branches: &[]git.GitBranchStats{}, // no branches
+	}
+
+	parms := ParamsProjectAzure{
+		Context:     context.Background(),
+		ApiURL:      ts.URL,
+		AccessToken: "token",
+		Exclusionlist: &utils.ExclusionList{
+			Projects: map[string]bool{},
+			Repos:    map[string]bool{"PROJ/" + excludedName: true},
+		},
+	}
+
+	archived, empty, excluded, repos, err := listReposForProject(parms, "PROJ", fc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if archived != 0 || excluded != 1 || empty != 1 {
+		t.Errorf("archived=%d excluded=%d empty=%d, want 0/1/1", archived, excluded, empty)
+	}
+	if len(repos) != 0 {
+		t.Errorf("expected no analyzable repos, got %d", len(repos))
 	}
 }

--- a/pkg/devops/getazure/getazure_test.go
+++ b/pkg/devops/getazure/getazure_test.go
@@ -234,6 +234,40 @@ func TestGetRepoAnalyse_Fallback(t *testing.T) {
 	}
 }
 
+// TestGetRepoAnalyse_EmptyRepos drives getRepoAnalyse with a repo that has no
+// content so it is counted as empty and excluded from the analyzed set, covering
+// the empty-counting branch and the "found … empty/archived/excluded" log path.
+func TestGetRepoAnalyse_EmptyRepos(t *testing.T) {
+	id := uuid.New()
+	fc := &fakeGitClient{
+		repos:    &[]git.GitRepository{{Id: &id, Name: strPtr("emptyrepo")}},
+		items:    &[]git.GitItem{},        // no items -> repo is empty
+		branches: &[]git.GitBranchStats{}, // no branches
+	}
+
+	spin := spinner.New(spinner.CharSets[35], 100*time.Millisecond)
+	spin.Writer = io.Discard
+	params := ParamsProjectAzure{
+		Context:       context.Background(),
+		Projects:      []core.TeamProjectReference{{Name: strPtr("proj1")}},
+		Organization:  "org",
+		Exclusionlist: utils.NewExclusionList(nil, nil),
+		Spin:          spin,
+		Period:        -1,
+	}
+
+	branches, empty, nbRepos, _, excluded, archived, err := getRepoAnalyse(params, fc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if empty != 1 || nbRepos != 1 || len(branches) != 0 {
+		t.Errorf("empty=%d nbRepos=%d analyzed=%d, want 1/1/0", empty, nbRepos, len(branches))
+	}
+	if excluded != 0 || archived != 0 {
+		t.Errorf("excluded=%d archived=%d, want 0/0", excluded, archived)
+	}
+}
+
 func TestDefaultBranchName(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/devops/getbitbucket/getbitbucket.go
+++ b/pkg/devops/getbitbucket/getbitbucket.go
@@ -232,15 +232,7 @@ func GetProjectBitbucketListCloud(platformConfig map[string]interface{}, exclusi
 	// Persist the per-run repository breakdown for the ResultsAll page and the
 	// global PDF report. Analyzed is the remainder after removing empty/excluded/
 	// archived (matches the printed summary line); Scanned is derived from the sum.
-	if err := utils.SaveScanSummary("Results", utils.ScanSummary{
-		Platform: "bitbucket",
-		Analyzed: nbRepos - emptyRepo - totalExclude - totalArchiv,
-		Archived: totalArchiv,
-		Empty:    emptyRepo,
-		Excluded: totalExclude,
-	}); err != nil {
-		loggers.Errorf("❌ Error saving scan summary: %v", err)
-	}
+	utils.PersistScanSummary("Results", utils.NewScanSummary("bitbucket", nbRepos-emptyRepo-totalExclude-totalArchiv, totalArchiv, emptyRepo, totalExclude, 0))
 
 	printSummary(params.Organization, stats)
 

--- a/pkg/devops/getbitbucket/getbitbucket.go
+++ b/pkg/devops/getbitbucket/getbitbucket.go
@@ -229,6 +229,19 @@ func GetProjectBitbucketListCloud(platformConfig map[string]interface{}, exclusi
 		TotalBranches:     TotalBranches,
 	}
 
+	// Persist the per-run repository breakdown for the ResultsAll page and the
+	// global PDF report. Analyzed is the remainder after removing empty/excluded/
+	// archived (matches the printed summary line); Scanned is derived from the sum.
+	if err := utils.SaveScanSummary("Results", utils.ScanSummary{
+		Platform: "bitbucket",
+		Analyzed: nbRepos - emptyRepo - totalExclude - totalArchiv,
+		Archived: totalArchiv,
+		Empty:    emptyRepo,
+		Excluded: totalExclude,
+	}); err != nil {
+		loggers.Errorf("❌ Error saving scan summary: %v", err)
+	}
+
 	printSummary(params.Organization, stats)
 
 	return importantBranches, nil

--- a/pkg/devops/getbitbucketdc/getbitbucketdc.go
+++ b/pkg/devops/getbitbucketdc/getbitbucketdc.go
@@ -200,6 +200,8 @@ var ErrEmptyRepo = errors.New("repository is empty")
 func GetReposProject(projects []Project, parms ParamsReposProjectDC, bitbucketURLBase string, nbRepos int, exclusionList *utils.ExclusionList) ([]ProjectBranch, int, int) {
 	var importantBranches []ProjectBranch
 	emptyRepo := 0
+	archivedRepo := 0
+	excludedRepo := 0
 	result := AnalysisResult{}
 	loggers := utils.SharedLogger()
 
@@ -216,11 +218,13 @@ func GetReposProject(projects []Project, parms ParamsReposProjectDC, bitbucketUR
 		loggers.Infof("\t🟢  Analyse Project: %s ", project.Name)
 		urlrepos := fmt.Sprintf("%s%s%s/projects/%s/repos", parms.URL, parms.BaseAPI, parms.APIVersion, project.Key)
 
-		repos, err := fetchAllRepos(urlrepos, parms.AccessToken, exclusionList)
+		repos, archivedCount, excludedCount, err := fetchAllRepos(urlrepos, parms.AccessToken, exclusionList)
 		if err != nil {
 			loggers.Errorf("\r❌ Get Repos for each Project:%v", err)
 			continue
 		}
+		archivedRepo += archivedCount
+		excludedRepo += excludedCount
 
 		nbRepos += len(repos)
 		loggers.Infof("\t  ✅ The number of Repo(s) found is: %d", len(repos))
@@ -244,6 +248,19 @@ func GetReposProject(projects []Project, parms ParamsReposProjectDC, bitbucketUR
 	if err := saveAnalysisResult1("Results/config/analysis_result_bitbucket_dc.json", result); err != nil {
 		loggers.Errorf("❌ Error creating Analysis file:%v", err)
 		return importantBranches, nbRepos, emptyRepo
+	}
+
+	// Persist the per-run repository breakdown for the ResultsAll page and the
+	// global PDF report. nbRepos counts the non-archived, non-excluded repos found,
+	// so the analyzed count is that minus the empty ones.
+	if err := utils.SaveScanSummary("Results", utils.ScanSummary{
+		Platform: "bitbucketdc",
+		Analyzed: nbRepos - emptyRepo,
+		Archived: archivedRepo,
+		Empty:    emptyRepo,
+		Excluded: excludedRepo,
+	}); err != nil {
+		loggers.Errorf("❌ Error saving scan summary: %v", err)
 	}
 
 	return importantBranches, nbRepos, emptyRepo
@@ -400,6 +417,17 @@ func GetRepos(project string, repos []Repo, parms ParamsReposDC, bitbucketURLBas
 
 	if err := saveAnalysisResult(result); err != nil {
 		logAndExit(fmt.Sprintf("❌ Error creating Analysis file: %v\n", err), parms.Spin)
+	}
+
+	// Persist the scan summary for the explicitly-requested repos. Archived and
+	// excluded repos are filtered out before this point, so only the analyzed and
+	// empty counts are meaningful here.
+	if err := utils.SaveScanSummary("Results", utils.ScanSummary{
+		Platform: "bitbucketdc",
+		Analyzed: len(importantBranches),
+		Empty:    emptyRepo,
+	}); err != nil {
+		loggers.Errorf("❌ Error saving scan summary: %v", err)
 	}
 
 	return importantBranches, nbRepos, emptyRepo
@@ -899,14 +927,18 @@ func isRepoExcluded(exclusionList *utils.ExclusionList, repo string) bool {
 	return excluded
 }
 
-func fetchAllRepos(baseURL string, accessToken string, exclusionList *utils.ExclusionList) ([]Repo, error) {
+// fetchAllRepos returns the analyzable repositories for a project along with the
+// number skipped because they are archived or excluded, so the scan summary can
+// report the full breakdown.
+func fetchAllRepos(baseURL string, accessToken string, exclusionList *utils.ExclusionList) ([]Repo, int, int, error) {
 	var allRepos []Repo
+	var archivedCount, excludedCount int
 	loggers := utils.SharedLogger()
 	url := baseURL
 	for {
 		reposResp, err := fetchRepos(url, accessToken, true)
 		if err != nil {
-			return nil, err
+			return nil, 0, 0, err
 		}
 		ReposResponse := reposResp.(*RepoResponse)
 		for _, repo := range ReposResponse.Values {
@@ -914,6 +946,7 @@ func fetchAllRepos(baseURL string, accessToken string, exclusionList *utils.Excl
 
 			if repo.Archived {
 				loggers.Debugf("→ repo %s: skipped (archived)", KEYTEST)
+				archivedCount++
 				continue
 			}
 
@@ -922,6 +955,7 @@ func fetchAllRepos(baseURL string, accessToken string, exclusionList *utils.Excl
 			} else {
 				if isRepoExcluded(exclusionList, KEYTEST) {
 					loggers.Debugf("→ repo %s: skipped (excluded)", KEYTEST)
+					excludedCount++
 				} else {
 					allRepos = append(allRepos, repo)
 				}
@@ -934,7 +968,7 @@ func fetchAllRepos(baseURL string, accessToken string, exclusionList *utils.Excl
 		}
 		url = fmt.Sprintf("%s?start=%d", baseURL, ReposResponse.NextPageStart)
 	}
-	return allRepos, nil
+	return allRepos, archivedCount, excludedCount, nil
 }
 
 func fetchRepos(url string, accessToken string, isProjectResponse bool) (interface{}, error) {

--- a/pkg/devops/getbitbucketdc/getbitbucketdc.go
+++ b/pkg/devops/getbitbucketdc/getbitbucketdc.go
@@ -253,15 +253,7 @@ func GetReposProject(projects []Project, parms ParamsReposProjectDC, bitbucketUR
 	// Persist the per-run repository breakdown for the ResultsAll page and the
 	// global PDF report. nbRepos counts the non-archived, non-excluded repos found,
 	// so the analyzed count is that minus the empty ones.
-	if err := utils.SaveScanSummary("Results", utils.ScanSummary{
-		Platform: "bitbucketdc",
-		Analyzed: nbRepos - emptyRepo,
-		Archived: archivedRepo,
-		Empty:    emptyRepo,
-		Excluded: excludedRepo,
-	}); err != nil {
-		loggers.Errorf("❌ Error saving scan summary: %v", err)
-	}
+	utils.PersistScanSummary("Results", utils.NewScanSummary("bitbucketdc", nbRepos-emptyRepo, archivedRepo, emptyRepo, excludedRepo, 0))
 
 	return importantBranches, nbRepos, emptyRepo
 }
@@ -422,13 +414,7 @@ func GetRepos(project string, repos []Repo, parms ParamsReposDC, bitbucketURLBas
 	// Persist the scan summary for the explicitly-requested repos. Archived and
 	// excluded repos are filtered out before this point, so only the analyzed and
 	// empty counts are meaningful here.
-	if err := utils.SaveScanSummary("Results", utils.ScanSummary{
-		Platform: "bitbucketdc",
-		Analyzed: len(importantBranches),
-		Empty:    emptyRepo,
-	}); err != nil {
-		loggers.Errorf("❌ Error saving scan summary: %v", err)
-	}
+	utils.PersistScanSummary("Results", utils.NewScanSummary("bitbucketdc", len(importantBranches), 0, emptyRepo, 0, 0))
 
 	return importantBranches, nbRepos, emptyRepo
 }

--- a/pkg/devops/getbitbucketdc/getbitbucketdc_test.go
+++ b/pkg/devops/getbitbucketdc/getbitbucketdc_test.go
@@ -346,12 +346,15 @@ func TestFetchAllRepos_Pagination(t *testing.T) {
 	defer ts.Close()
 
 	el := &utils.ExclusionList{Projects: map[string]bool{}, Repos: map[string]bool{}}
-	repos, err := fetchAllRepos(ts.URL+"/repos", "token", el)
+	repos, archived, excluded, err := fetchAllRepos(ts.URL+"/repos", "token", el)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(repos) != 2 {
 		t.Errorf("expected 2 repos across 2 pages, got %d", len(repos))
+	}
+	if archived != 0 || excluded != 0 {
+		t.Errorf("expected no archived/excluded repos, got archived=%d excluded=%d", archived, excluded)
 	}
 }
 

--- a/pkg/devops/getbitbucketdc/getbitbucketdc_test.go
+++ b/pkg/devops/getbitbucketdc/getbitbucketdc_test.go
@@ -358,6 +358,53 @@ func TestFetchAllRepos_Pagination(t *testing.T) {
 	}
 }
 
+func TestFetchAllRepos_CountsArchivedAndExcluded(t *testing.T) {
+	// One archived repo (skipped + counted), one excluded repo (skipped + counted),
+	// and one analyzable repo returned.
+	proj := func(k string) struct {
+		Key string `json:"key"`
+	} {
+		return struct {
+			Key string `json:"key"`
+		}{Key: k}
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(RepoResponse{
+			IsLastPage: true,
+			Values: []Repo{
+				{Slug: "archived-repo", Name: "archived-repo", Archived: true, Project: proj("PROJ")},
+				{Slug: "excluded-repo", Name: "excluded-repo", Project: proj("PROJ")},
+				{Slug: "live-repo", Name: "live-repo", Project: proj("PROJ")},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	el := &utils.ExclusionList{
+		Projects: map[string]bool{},
+		Repos:    map[string]bool{"PROJ/excluded-repo": true},
+	}
+	repos, archived, excluded, err := fetchAllRepos(ts.URL+"/repos", "token", el)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if archived != 1 || excluded != 1 {
+		t.Errorf("archived=%d excluded=%d, want 1 and 1", archived, excluded)
+	}
+	if len(repos) != 1 || repos[0].Slug != "live-repo" {
+		t.Errorf("expected only the live repo returned, got %d repos", len(repos))
+	}
+}
+
+func TestFetchAllRepos_FetchError(t *testing.T) {
+	// An unreachable endpoint must surface the fetch error rather than silently
+	// returning an empty repo list.
+	el := &utils.ExclusionList{Projects: map[string]bool{}, Repos: map[string]bool{}}
+	if _, _, _, err := fetchAllRepos("http://127.0.0.1:0/repos", "token", el); err == nil {
+		t.Error("expected an error from an unreachable server, got nil")
+	}
+}
+
 func TestFetchAllProjects_Pagination(t *testing.T) {
 	// Verifies that multi-page project fetches build each next-page URL from the
 	// base URL, not by appending ?start=N to the already-paginated URL.

--- a/pkg/devops/getgithub/getgithub.go
+++ b/pkg/devops/getgithub/getgithub.go
@@ -700,6 +700,10 @@ func GetRepoGithubListAllBranches(platformConfig map[string]interface{}, exclusi
 		TotalBranches:     stats.TotalBranches,
 	}
 
+	// In all-branches mode NbRepos is incremented once per analyzed repo, so it is
+	// already the analyzed count (empty/archived/excluded are tracked separately).
+	saveGithubScanSummary(stats.NbRepos, stats.TotalArchiv, stats.EmptyRepo, stats.TotalExclude)
+
 	loggers.Infof("✅ Analysis completed:")
 	loggers.Infof("   - Repositories analyzed: %d", stats.NbRepos)
 	loggers.Infof("   - Total branches found: %d", stats.TotalBranches)
@@ -803,6 +807,10 @@ func GetRepoGithubList(platformConfig map[string]interface{}, exclusionfile stri
 		TotalArchiv:       totalArchiv,
 		TotalBranches:     TotalBranches,
 	}
+
+	// Here NbRepos is the total discovered, so the analyzed count is the remainder
+	// after removing empty/excluded/archived (matches the printed summary line).
+	saveGithubScanSummary(nbRepos-emptyRepo-totalExclude-totalArchiv, totalArchiv, emptyRepo, totalExclude)
 
 	printSummary(config, stats)
 
@@ -992,6 +1000,21 @@ func findLargestRepository(importantBranches []ProjectBranch, totalSize *int64) 
 	}
 	//return largestRepoSize, largestRepoBranch, largesRepo
 	return largestRepoBranch, largesRepo
+}
+
+// saveGithubScanSummary persists the per-run repository breakdown for the
+// ResultsAll page and the global PDF report. Analyzed is the number of repos that
+// will actually be analyzed; Scanned is derived from the sum of all categories.
+func saveGithubScanSummary(analyzed, archived, empty, excluded int) {
+	if err := utils.SaveScanSummary("Results", utils.ScanSummary{
+		Platform: "github",
+		Analyzed: analyzed,
+		Archived: archived,
+		Empty:    empty,
+		Excluded: excluded,
+	}); err != nil {
+		utils.SharedLogger().Errorf("❌ Error saving scan summary: %v", err)
+	}
 }
 
 func printSummary(config PlatformConfig, stats SummaryStats) {

--- a/pkg/devops/getgithub/getgithub.go
+++ b/pkg/devops/getgithub/getgithub.go
@@ -1006,15 +1006,7 @@ func findLargestRepository(importantBranches []ProjectBranch, totalSize *int64) 
 // ResultsAll page and the global PDF report. Analyzed is the number of repos that
 // will actually be analyzed; Scanned is derived from the sum of all categories.
 func saveGithubScanSummary(analyzed, archived, empty, excluded int) {
-	if err := utils.SaveScanSummary("Results", utils.ScanSummary{
-		Platform: "github",
-		Analyzed: analyzed,
-		Archived: archived,
-		Empty:    empty,
-		Excluded: excluded,
-	}); err != nil {
-		utils.SharedLogger().Errorf("❌ Error saving scan summary: %v", err)
-	}
+	utils.PersistScanSummary("Results", utils.NewScanSummary("github", analyzed, archived, empty, excluded, 0))
 }
 
 func printSummary(config PlatformConfig, stats SummaryStats) {

--- a/pkg/devops/getgitlab/getgitlab.go
+++ b/pkg/devops/getgitlab/getgitlab.go
@@ -904,6 +904,19 @@ func GetRepoGitLabList(platformConfig map[string]interface{}, exclusionfile stri
 	//fmt.Printf("\r✅ TotalProject(s) that will be analyzed: %d - Find empty : %d - Excluded : %d - Archived : %d\n", len(projectBranches), emptyRepos, excludedProjects, archivedRepos)
 	//fmt.Printf("\r✅ Total Branches that will be analyzed: %d\n", TotalBranches)
 
+	// Persist the per-run repository breakdown for the ResultsAll page and the
+	// global PDF report. Analyzed is the number of projects that will actually be
+	// analyzed; Scanned is derived from the sum of all categories.
+	if err := utils.SaveScanSummary("Results", utils.ScanSummary{
+		Platform: "gitlab",
+		Analyzed: len(projectBranches),
+		Archived: archivedRepos,
+		Empty:    emptyRepos,
+		Excluded: excludedProjects,
+	}); err != nil {
+		loggers.Errorf("❌ Error saving scan summary: %v", err)
+	}
+
 	fmt.Print("\n")
 	loggers.Infof("✅ The largest Repository is <%s> with the branch <%s>", largesRepo, largestRepoBranch)
 	loggers.Infof("✅ TotalProject(s) that will be analyzed: %d - Find empty : %d - Excluded : %d - Archived : %d", len(projectBranches), emptyRepos, excludedProjects, archivedRepos)

--- a/pkg/devops/getgitlab/getgitlab.go
+++ b/pkg/devops/getgitlab/getgitlab.go
@@ -907,15 +907,7 @@ func GetRepoGitLabList(platformConfig map[string]interface{}, exclusionfile stri
 	// Persist the per-run repository breakdown for the ResultsAll page and the
 	// global PDF report. Analyzed is the number of projects that will actually be
 	// analyzed; Scanned is derived from the sum of all categories.
-	if err := utils.SaveScanSummary("Results", utils.ScanSummary{
-		Platform: "gitlab",
-		Analyzed: len(projectBranches),
-		Archived: archivedRepos,
-		Empty:    emptyRepos,
-		Excluded: excludedProjects,
-	}); err != nil {
-		loggers.Errorf("❌ Error saving scan summary: %v", err)
-	}
+	utils.PersistScanSummary("Results", utils.NewScanSummary("gitlab", len(projectBranches), archivedRepos, emptyRepos, excludedProjects, 0))
 
 	fmt.Print("\n")
 	loggers.Infof("✅ The largest Repository is <%s> with the branch <%s>", largesRepo, largestRepoBranch)

--- a/pkg/utils/globalreport.go
+++ b/pkg/utils/globalreport.go
@@ -97,8 +97,12 @@ func CreateGlobalReport(directory string) error {
 	// repos does not silently undercount. Missing file => empty list.
 	skippedRepos := LoadSkippedRepos(directory)
 
+	// Per-run repository breakdown (scanned/analyzed/archived/empty). Missing file
+	// (older result sets) => nil, and the summary section renders nothing.
+	scanSummary := LoadScanSummary(directory)
+
 	// Create a PDF
-	if err := renderGlobalPDF(languages, ginfo, skippedRepos); err != nil {
+	if err := renderGlobalPDF(languages, ginfo, skippedRepos, scanSummary); err != nil {
 		return err
 	}
 
@@ -318,6 +322,57 @@ func renderLanguageRow(pdf *gofpdf.Fpdf, lang LanguageData, i, maxLOC int, barCo
 	pdf.SetXY(marginL, rowY+rowH)
 }
 
+// renderScanSummarySection appends a "Scan Summary" section to the global PDF,
+// showing how many repositories were scanned versus analyzed and how many were
+// filtered out (archived/disabled, empty) or could not be completed (skipped).
+// When no summary was persisted (older result sets) it renders nothing.
+func renderScanSummarySection(pdf *gofpdf.Fpdf, summary *ScanSummary, skippedCount int, marginL, contentW float64) {
+	if summary == nil {
+		return
+	}
+
+	// Repos that failed during the analysis phase were part of the projected
+	// analyzed set, so subtract them for the displayed analyzed count.
+	analyzed := summary.Analyzed - skippedCount
+	if analyzed < 0 {
+		analyzed = 0
+	}
+
+	pdf.Ln(8)
+
+	// Section header bar (blue, matching the language-breakdown style).
+	pdf.SetFillColor(0, 115, 186)
+	pdf.Rect(marginL, pdf.GetY(), contentW, 8, "F")
+	pdf.SetFont("Helvetica", "B", 10)
+	pdf.SetTextColor(255, 255, 255)
+	pdf.SetX(marginL + 2)
+	pdf.CellFormat(contentW-2, 8, "Scan Summary", "", 1, "L", false, 0, "")
+	pdf.Ln(2)
+
+	labels := []string{"Scanned", "Analyzed", "Archived", "Empty", "Excluded", "Skipped"}
+	values := []int{summary.Scanned, analyzed, summary.Archived, summary.Empty, summary.Excluded, skippedCount}
+	colW := contentW / float64(len(labels))
+
+	// Value row
+	pdf.SetFont("Helvetica", "B", 12)
+	pdf.SetTextColor(30, 30, 40)
+	pdf.SetX(marginL)
+	for _, v := range values {
+		pdf.CellFormat(colW, 8, fmt.Sprintf("%d", v), "1", 0, "C", false, 0, "")
+	}
+	pdf.Ln(-1)
+
+	// Label row
+	pdf.SetFont("Helvetica", "", 8)
+	pdf.SetTextColor(110, 110, 120)
+	pdf.SetX(marginL)
+	for _, l := range labels {
+		pdf.CellFormat(colW, 6, l, "1", 0, "C", false, 0, "")
+	}
+	pdf.Ln(-1)
+	pdf.SetTextColor(0, 0, 0)
+}
+
 // renderSkippedReposSection appends a "Skipped Repositories" section to the global
 // PDF. When no repositories were skipped it renders a short confirmation line; when
 // some were, it lists each with its branch and the reason it was skipped (clone
@@ -399,7 +454,7 @@ func renderSkippedReposSection(pdf *gofpdf.Fpdf, skippedRepos []SkippedRepo, mar
 }
 
 // renderGlobalPDF generates the GlobalReport.pdf from languages and global info.
-func renderGlobalPDF(languages []LanguageData, ginfo Globalinfo, skippedRepos []SkippedRepo) error {
+func renderGlobalPDF(languages []LanguageData, ginfo Globalinfo, skippedRepos []SkippedRepo, summary *ScanSummary) error {
 	loggers := NewLogger()
 
 	languages, maxLOC := prepareLanguagesForPDF(languages)
@@ -547,6 +602,9 @@ func renderGlobalPDF(languages []LanguageData, ginfo Globalinfo, skippedRepos []
 
 	rowH := 7.0
 	renderLanguageRows(pdf, languages, maxLOC, drawColHeaders, marginL, pageH, marginB, colNum, colLang, colLOC, colPct, colBar, rowH, barColors)
+
+	// ── Scan summary section ─────────────────────────────────────────
+	renderScanSummarySection(pdf, summary, len(skippedRepos), marginL, contentW)
 
 	// ── Skipped repositories section ─────────────────────────────────
 	renderSkippedReposSection(pdf, skippedRepos, marginL, contentW)

--- a/pkg/utils/globalreport.go
+++ b/pkg/utils/globalreport.go
@@ -332,11 +332,13 @@ func renderScanSummarySection(pdf *gofpdf.Fpdf, summary *ScanSummary, skippedCou
 	}
 
 	// Repos that failed during the analysis phase were part of the projected
-	// analyzed set, so subtract them for the displayed analyzed count.
+	// analyzed set, so subtract them for the displayed analyzed count and fold them
+	// together with the discovery-phase skips so the row reconciles.
 	analyzed := summary.Analyzed - skippedCount
 	if analyzed < 0 {
 		analyzed = 0
 	}
+	totalSkipped := summary.Skipped + skippedCount
 
 	pdf.Ln(8)
 
@@ -350,7 +352,7 @@ func renderScanSummarySection(pdf *gofpdf.Fpdf, summary *ScanSummary, skippedCou
 	pdf.Ln(2)
 
 	labels := []string{"Scanned", "Analyzed", "Archived", "Empty", "Excluded", "Skipped"}
-	values := []int{summary.Scanned, analyzed, summary.Archived, summary.Empty, summary.Excluded, skippedCount}
+	values := []int{summary.Scanned, analyzed, summary.Archived, summary.Empty, summary.Excluded, totalSkipped}
 	colW := contentW / float64(len(labels))
 
 	// Value row

--- a/pkg/utils/summary.go
+++ b/pkg/utils/summary.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// ScanSummary records the per-run repository breakdown produced during the
+// analysis-discovery phase of a platform scan (Azure, GitHub, GitLab, Bitbucket
+// Cloud/DC). It is surfaced in the ResultsAll web page and the global PDF report
+// so a large org-wide scan makes clear how many repositories were analyzed versus
+// filtered out (archived/disabled, empty, or excluded).
+//
+// By construction Scanned == Analyzed + Archived + Empty + Excluded, so the
+// breakdown always reconciles regardless of each platform's internal counting.
+// Repositories that could not be completed during the analysis phase (clone
+// timeout/failure) are tracked separately in SkippedRepo and rendered alongside
+// this summary.
+type ScanSummary struct {
+	Platform string `json:"Platform"`
+	Scanned  int    `json:"Scanned"`
+	Analyzed int    `json:"Analyzed"`
+	Archived int    `json:"Archived"`
+	Empty    int    `json:"Empty"`
+	Excluded int    `json:"Excluded"`
+}
+
+// ScanSummaryPath returns the canonical location of the scan-summary file for a
+// given base Results directory.
+func ScanSummaryPath(baseResultsDir string) string {
+	return filepath.Join(baseResultsDir, "config", "analysis_summary.json")
+}
+
+// SaveScanSummary writes the scan summary under <baseResultsDir>/config. The
+// Scanned total is (re)derived from the category counts so the persisted
+// breakdown always reconciles. The file is always overwritten so a clean re-run
+// clears any stale summary from a previous analysis.
+func SaveScanSummary(baseResultsDir string, summary ScanSummary) error {
+	summary.Scanned = summary.Analyzed + summary.Archived + summary.Empty + summary.Excluded
+
+	path := ScanSummaryPath(baseResultsDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(summary, "", "    ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// LoadScanSummary reads the scan summary for a base Results directory. A missing
+// or unreadable file yields nil (not an error): reports should render fine on
+// older result sets that predate this feature.
+func LoadScanSummary(baseResultsDir string) *ScanSummary {
+	data, err := os.ReadFile(ScanSummaryPath(baseResultsDir))
+	if err != nil {
+		return nil
+	}
+	var summary ScanSummary
+	if err := json.Unmarshal(data, &summary); err != nil {
+		return nil
+	}
+	return &summary
+}

--- a/pkg/utils/summary.go
+++ b/pkg/utils/summary.go
@@ -12,11 +12,14 @@ import (
 // so a large org-wide scan makes clear how many repositories were analyzed versus
 // filtered out (archived/disabled, empty, or excluded).
 //
-// By construction Scanned == Analyzed + Archived + Empty + Excluded, so the
-// breakdown always reconciles regardless of each platform's internal counting.
-// Repositories that could not be completed during the analysis phase (clone
-// timeout/failure) are tracked separately in SkippedRepo and rendered alongside
-// this summary.
+// By construction Scanned == Analyzed + Archived + Empty + Excluded + Skipped, so
+// the breakdown always reconciles regardless of each platform's internal counting.
+//
+// Skipped here counts repositories discovered during the analysis-discovery phase
+// that were neither analyzed nor filtered into a category — e.g. a repo with no
+// usable default branch, or one dropped by a single-branch selection. Repositories
+// that fail later during the analysis phase (clone timeout/failure) are tracked
+// separately in SkippedRepo; the reports add those two skip sources together.
 type ScanSummary struct {
 	Platform string `json:"Platform"`
 	Scanned  int    `json:"Scanned"`
@@ -24,6 +27,21 @@ type ScanSummary struct {
 	Archived int    `json:"Archived"`
 	Empty    int    `json:"Empty"`
 	Excluded int    `json:"Excluded"`
+	Skipped  int    `json:"Skipped"`
+}
+
+// NewScanSummary builds a ScanSummary from a platform's per-run counts. It exists
+// so every platform shares one field mapping instead of repeating the struct
+// literal; Scanned is left to SaveScanSummary to derive.
+func NewScanSummary(platform string, analyzed, archived, empty, excluded, skipped int) ScanSummary {
+	return ScanSummary{
+		Platform: platform,
+		Analyzed: analyzed,
+		Archived: archived,
+		Empty:    empty,
+		Excluded: excluded,
+		Skipped:  skipped,
+	}
 }
 
 // ScanSummaryPath returns the canonical location of the scan-summary file for a
@@ -37,7 +55,7 @@ func ScanSummaryPath(baseResultsDir string) string {
 // breakdown always reconciles. The file is always overwritten so a clean re-run
 // clears any stale summary from a previous analysis.
 func SaveScanSummary(baseResultsDir string, summary ScanSummary) error {
-	summary.Scanned = summary.Analyzed + summary.Archived + summary.Empty + summary.Excluded
+	summary.Scanned = summary.Analyzed + summary.Archived + summary.Empty + summary.Excluded + summary.Skipped
 
 	path := ScanSummaryPath(baseResultsDir)
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
@@ -48,6 +66,16 @@ func SaveScanSummary(baseResultsDir string, summary ScanSummary) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0644)
+}
+
+// PersistScanSummary saves the scan summary and logs (rather than propagates) any
+// error. A failed summary write must never abort an otherwise-successful scan, so
+// every platform funnels through this helper instead of repeating the same
+// save-and-log boilerplate.
+func PersistScanSummary(baseResultsDir string, summary ScanSummary) {
+	if err := SaveScanSummary(baseResultsDir, summary); err != nil {
+		NewLogger().Errorf("❌ Error saving scan summary: %v", err)
+	}
 }
 
 // LoadScanSummary reads the scan summary for a base Results directory. A missing

--- a/pkg/utils/summary_test.go
+++ b/pkg/utils/summary_test.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jung-kurt/gofpdf"
+)
+
+// TestRenderScanSummarySection exercises the PDF section renderer for the nil
+// (older result set), zero-count, and populated cases — it must not panic.
+func TestRenderScanSummarySection(t *testing.T) {
+	cases := map[string]*ScanSummary{
+		"nil":       nil,
+		"zero":      {Platform: "azure"},
+		"populated": {Platform: "azure", Scanned: 20, Analyzed: 10, Archived: 2, Empty: 3, Excluded: 5},
+	}
+	for name, summary := range cases {
+		t.Run(name, func(t *testing.T) {
+			pdf := gofpdf.New("P", "mm", "A4", "")
+			pdf.SetFont("Helvetica", "", 8)
+			pdf.AddPage()
+			renderScanSummarySection(pdf, summary, 4, 15.0, 180.0)
+			if err := pdf.OutputFileAndClose(filepath.Join(t.TempDir(), "out.pdf")); err != nil {
+				t.Fatalf("render/output failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestSaveAndLoadScanSummary(t *testing.T) {
+	base := t.TempDir()
+
+	// Scanned is intentionally left 0 to prove SaveScanSummary derives it from
+	// the category counts.
+	in := ScanSummary{
+		Platform: "azure",
+		Analyzed: 10,
+		Archived: 2,
+		Empty:    3,
+		Excluded: 5,
+	}
+	if err := SaveScanSummary(base, in); err != nil {
+		t.Fatalf("SaveScanSummary: %v", err)
+	}
+
+	got := LoadScanSummary(base)
+	if got == nil {
+		t.Fatal("LoadScanSummary returned nil for a summary that was just saved")
+	}
+	if want := 20; got.Scanned != want {
+		t.Errorf("Scanned = %d, want %d (Analyzed+Archived+Empty+Excluded)", got.Scanned, want)
+	}
+	if got.Platform != "azure" || got.Analyzed != 10 || got.Archived != 2 || got.Empty != 3 || got.Excluded != 5 {
+		t.Errorf("round-trip mismatch: %+v", *got)
+	}
+}
+
+func TestLoadScanSummaryMissingFile(t *testing.T) {
+	if got := LoadScanSummary(t.TempDir()); got != nil {
+		t.Errorf("LoadScanSummary on missing file = %+v, want nil", got)
+	}
+}
+
+func TestLoadScanSummaryInvalidJSON(t *testing.T) {
+	base := t.TempDir()
+	path := ScanSummaryPath(base)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if got := LoadScanSummary(base); got != nil {
+		t.Errorf("LoadScanSummary on invalid JSON = %+v, want nil", got)
+	}
+}

--- a/pkg/utils/summary_test.go
+++ b/pkg/utils/summary_test.go
@@ -14,7 +14,7 @@ func TestRenderScanSummarySection(t *testing.T) {
 	cases := map[string]*ScanSummary{
 		"nil":       nil,
 		"zero":      {Platform: "azure"},
-		"populated": {Platform: "azure", Scanned: 20, Analyzed: 10, Archived: 2, Empty: 3, Excluded: 5},
+		"populated": {Platform: "azure", Scanned: 22, Analyzed: 10, Archived: 2, Empty: 3, Excluded: 5, Skipped: 2},
 	}
 	for name, summary := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -40,6 +40,7 @@ func TestSaveAndLoadScanSummary(t *testing.T) {
 		Archived: 2,
 		Empty:    3,
 		Excluded: 5,
+		Skipped:  1,
 	}
 	if err := SaveScanSummary(base, in); err != nil {
 		t.Fatalf("SaveScanSummary: %v", err)
@@ -49,12 +50,50 @@ func TestSaveAndLoadScanSummary(t *testing.T) {
 	if got == nil {
 		t.Fatal("LoadScanSummary returned nil for a summary that was just saved")
 	}
-	if want := 20; got.Scanned != want {
-		t.Errorf("Scanned = %d, want %d (Analyzed+Archived+Empty+Excluded)", got.Scanned, want)
+	if want := 21; got.Scanned != want {
+		t.Errorf("Scanned = %d, want %d (Analyzed+Archived+Empty+Excluded+Skipped)", got.Scanned, want)
 	}
-	if got.Platform != "azure" || got.Analyzed != 10 || got.Archived != 2 || got.Empty != 3 || got.Excluded != 5 {
+	if got.Platform != "azure" || got.Analyzed != 10 || got.Archived != 2 || got.Empty != 3 || got.Excluded != 5 || got.Skipped != 1 {
 		t.Errorf("round-trip mismatch: %+v", *got)
 	}
+}
+
+func TestNewScanSummary(t *testing.T) {
+	s := NewScanSummary("gitlab", 10, 2, 3, 4, 1)
+	if s.Platform != "gitlab" || s.Analyzed != 10 || s.Archived != 2 || s.Empty != 3 || s.Excluded != 4 || s.Skipped != 1 {
+		t.Errorf("unexpected mapping: %+v", s)
+	}
+	// Scanned is left for SaveScanSummary to derive, not set by the constructor.
+	if s.Scanned != 0 {
+		t.Errorf("Scanned should be 0 until persisted, got %d", s.Scanned)
+	}
+}
+
+func TestPersistScanSummary(t *testing.T) {
+	base := t.TempDir()
+	PersistScanSummary(base, ScanSummary{Platform: "gitlab", Analyzed: 4, Archived: 1})
+
+	got := LoadScanSummary(base)
+	if got == nil {
+		t.Fatal("PersistScanSummary did not write a loadable summary")
+	}
+	if got.Scanned != 5 || got.Analyzed != 4 || got.Archived != 1 {
+		t.Errorf("unexpected persisted summary: %+v", *got)
+	}
+}
+
+func TestSaveScanSummaryErrorPath(t *testing.T) {
+	// Use a regular file as the base dir so MkdirAll(<file>/config) fails,
+	// exercising SaveScanSummary's error return.
+	base := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(base, []byte("x"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := SaveScanSummary(base, ScanSummary{Platform: "x"}); err == nil {
+		t.Error("expected an error when the base path is a file, got nil")
+	}
+	// PersistScanSummary must swallow (log) the error, not panic or propagate.
+	PersistScanSummary(base, ScanSummary{Platform: "x"})
 }
 
 func TestLoadScanSummaryMissingFile(t *testing.T) {

--- a/scan_summary_test.go
+++ b/scan_summary_test.go
@@ -17,18 +17,24 @@ func TestBuildScanSummaryView(t *testing.T) {
 		t.Errorf("nil summary should produce nil view, got %+v", got)
 	}
 
-	// Analyzed subtracts the repos that failed during analysis (Skipped).
+	// Analyzed subtracts the analysis-phase failures (skippedCount); the displayed
+	// Skipped folds the persisted discovery-phase Skipped together with them.
+	// Persisted Scanned = 10+2+3+5+1 = 21.
 	v := buildScanSummaryView(&utils.ScanSummary{
-		Scanned: 20, Analyzed: 10, Archived: 2, Empty: 3, Excluded: 5,
+		Scanned: 21, Analyzed: 10, Archived: 2, Empty: 3, Excluded: 5, Skipped: 1,
 	}, 4)
 	if v == nil {
 		t.Fatal("expected non-nil view")
 	}
-	if v.Analyzed != 6 || v.Skipped != 4 {
-		t.Errorf("Analyzed=%d Skipped=%d, want 6 and 4", v.Analyzed, v.Skipped)
+	if v.Analyzed != 6 || v.Skipped != 5 {
+		t.Errorf("Analyzed=%d Skipped=%d, want 6 and 5 (1 discovery + 4 analysis)", v.Analyzed, v.Skipped)
 	}
-	if v.Scanned != 20 || v.Archived != 2 || v.Empty != 3 || v.Excluded != 5 {
+	if v.Scanned != 21 || v.Archived != 2 || v.Empty != 3 || v.Excluded != 5 {
 		t.Errorf("unexpected passthrough values: %+v", *v)
+	}
+	// The displayed row must reconcile: Scanned == Analyzed+Archived+Empty+Excluded+Skipped.
+	if sum := v.Analyzed + v.Archived + v.Empty + v.Excluded + v.Skipped; sum != v.Scanned {
+		t.Errorf("row does not reconcile: parts sum to %d, Scanned is %d", sum, v.Scanned)
 	}
 
 	// Analyzed must floor at 0 when more repos were skipped than projected.

--- a/scan_summary_test.go
+++ b/scan_summary_test.go
@@ -1,0 +1,71 @@
+//go:build resultsall
+// +build resultsall
+
+package main
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/SonarSource-Demos/sonar-golc/pkg/utils"
+)
+
+func TestBuildScanSummaryView(t *testing.T) {
+	if got := buildScanSummaryView(nil, 3); got != nil {
+		t.Errorf("nil summary should produce nil view, got %+v", got)
+	}
+
+	// Analyzed subtracts the repos that failed during analysis (Skipped).
+	v := buildScanSummaryView(&utils.ScanSummary{
+		Scanned: 20, Analyzed: 10, Archived: 2, Empty: 3, Excluded: 5,
+	}, 4)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.Analyzed != 6 || v.Skipped != 4 {
+		t.Errorf("Analyzed=%d Skipped=%d, want 6 and 4", v.Analyzed, v.Skipped)
+	}
+	if v.Scanned != 20 || v.Archived != 2 || v.Empty != 3 || v.Excluded != 5 {
+		t.Errorf("unexpected passthrough values: %+v", *v)
+	}
+
+	// Analyzed must floor at 0 when more repos were skipped than projected.
+	if v2 := buildScanSummaryView(&utils.ScanSummary{Analyzed: 2}, 5); v2.Analyzed != 0 {
+		t.Errorf("Analyzed should floor at 0, got %d", v2.Analyzed)
+	}
+}
+
+func renderTemplate(t *testing.T, pd PageData) string {
+	t.Helper()
+	tmpl := template.Must(template.New("index").Funcs(template.FuncMap{
+		"add": func(a, b int) int { return a + b },
+	}).Parse(htmlTemplate))
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, pd); err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+	return buf.String()
+}
+
+func TestScanSummaryTemplateRenders(t *testing.T) {
+	out := renderTemplate(t, PageData{
+		ScanSummary: &ScanSummaryView{Scanned: 20, Analyzed: 6, Archived: 2, Empty: 3, Excluded: 5, Skipped: 4},
+	})
+	if !strings.Contains(out, "Scan Summary") {
+		t.Error("rendered page should contain the Scan Summary heading")
+	}
+	for _, label := range []string{"Scanned", "Analyzed", "Archived", "Empty", "Excluded", "Skipped"} {
+		if !strings.Contains(out, label) {
+			t.Errorf("rendered page missing %q tile", label)
+		}
+	}
+}
+
+func TestScanSummaryTemplateOmittedWhenNil(t *testing.T) {
+	out := renderTemplate(t, PageData{})
+	if strings.Contains(out, "Scan Summary") {
+		t.Error("Scan Summary section should be omitted when no summary is present")
+	}
+}


### PR DESCRIPTION
Closes #74.

## ADO archived repos (#74)
The archived-repo handling in `getazure` was inert:
- `listReposForProject` never detected archived/disabled repos (`archivedCount` was declared but never incremented).
- A **variable-shadowing bug** in `getRepoAnalyse` (a loop-scoped `:=` re-declaring `emptyRepos`) meant **both the empty and archived counts were silently lost** and always returned 0; `emptyOrArchivedCount` was misnamed dead code.

Azure DevOps has no "archived" repo state — the equivalent is a **disabled** repo (no default branch, uncloneable) — and the pinned SDK (`azure-devops-go-api v1.0.0-b5`) drops `isDisabled` from `GitRepository`. So disabled repos are now detected via a raw REST call (`GET …/git/repositories?api-version=6.0`, PAT basic auth, shared `utils.HTTPClient`) that degrades gracefully (logs a warning, treats none as disabled) on permission/network errors so a scan never fails. Disabled repos are counted and skipped, and the empty/archived accounting is corrected.

## Other platforms
GitHub, Bitbucket Cloud, and GitLab already detected + counted archived correctly. **Bitbucket DC** skipped archived repos without counting them — added an archived/excluded counter to `fetchAllRepos` to close that reporting gap.

## Cross-platform Scan Summary
Per-run repository breakdown — **Scanned / Analyzed / Archived / Empty / Excluded / Skipped** — surfaced in the ResultsAll web page and the global PDF report, for all platforms.
- New `pkg/utils/summary.go` mirrors the existing `skipped.go` persistence pattern: `ScanSummary` → `Results/config/analysis_summary.json`, with `Scanned` derived so the breakdown always reconciles (`Scanned = Analyzed + Archived + Empty + Excluded + Skipped`).
- Missing file → `nil`, so older result sets still render.
- `/api/scan-summary` endpoint added alongside the existing API handlers.
- `Analyzed` is adjusted down by analysis-phase failures, which surface as `Skipped`.

## Tests
- `pkg/utils/summary_test.go`: save/load round-trip, `Scanned` derivation, missing/invalid file, PDF section render (nil/zero/populated).
- `pkg/devops/getazure/getazure_disabled_test.go`: `isDisabled` parse + graceful non-200/bad-JSON fallback.
- `pkg/devops/getbitbucketdc`: `fetchAllRepos` archived/excluded counts.
- `scan_summary_test.go`: `buildScanSummaryView` logic + template renders/omits.

All builds (`./...`, `-tags webui`, `-tags resultsall`) and the full test suite pass. A live ADO scan against a real disabled repo was not run (needs org credentials); the REST parse, counting, and rendering are covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)