### PR TITLE
refactor: one description of the result-file layout

### DIFF
--- a/ResultsAll.go
+++ b/ResultsAll.go
@@ -97,52 +97,16 @@ type LanguageData struct {
 	RelativePct float64 `json:"-"`
 }
 
-type RepositoryData struct {
-	Number int `json:"Number"`
-	// Key identifies the repository across page and reports — the stem of its
-	// result file — and is what the deselection checkboxes submit.
-	Key         string `json:"Key"`
-	Repository  string `json:"Repository"`
-	Org         string `json:"Org"`
-	Branch      string `json:"Branch"`
-	Lines       int    `json:"Lines"`
-	BlankLines  int    `json:"BlankLines"`
-	Comments    int    `json:"Comments"`
-	CodeLines   int    `json:"CodeLines"`
-	LinesF      string `json:"LinesF"`
-	BlankLinesF string `json:"BlankLinesF"`
-	CommentsF   string `json:"CommentsF"`
-	CodeLinesF  string `json:"CodeLinesF"`
-	// TopLanguages are the repository's largest languages, biggest first, excluding the
-	// language held out of the totals. Empty when no by-language result file was found.
-	TopLanguages []utils.LanguageShare `json:"TopLanguages,omitempty"`
-	// Deselected marks a row excluded from the totals. Set only on the table view
-	// (PageData.TableRows), where counted and deselected rows are interleaved.
-	Deselected bool `json:"Deselected,omitempty"`
-}
+// The repository row, its inventory and the platform naming rules all live in pkg/utils
+// now. Aliases rather than copies: two structurally identical definitions were what let
+// this page and the generated reports drift apart in the first place.
+type (
+	RepositoryData = utils.RepositoryData
+	ProjectBranch  = utils.ProjectBranch
+	AnalysisResult = utils.AnalysisResult
+)
 
-// PrimaryLanguage returns the repository's largest language, or "" when unknown. Used as
-// the sort key for the Top Languages column.
-func (r RepositoryData) PrimaryLanguage() string {
-	if len(r.TopLanguages) == 0 {
-		return ""
-	}
-	return r.TopLanguages[0].Language
-}
-
-type ProjectBranch struct {
-	Org         string `json:"Org"`
-	ProjectKey  string `json:"ProjectKey"`
-	RepoSlug    string `json:"RepoSlug"`
-	MainBranch  string `json:"MainBranch"`
-	LargestSize int64  `json:"LargestSize"`
-}
-
-type AnalysisResult struct {
-	NumRepositories int             `json:"NumRepositories"`
-	ProjectBranches []ProjectBranch `json:"ProjectBranches"`
-}
-
+// AnalysisResult_ProjectBranch is the older spelling used through this file.
 type AnalysisResult_ProjectBranch = ProjectBranch
 
 type RepositoryLanguageData struct {
@@ -330,195 +294,28 @@ func isMainBranch(branchName string) bool {
 	return false
 }
 
+// getRepositoryData collects every analyzed repository. The layout logic — inventory
+// discovery, per-platform naming and the deselection key — lives in pkg/utils, so this
+// page and the generated reports read through exactly the same rules. They used to carry
+// separate copies, and the drift between them produced repositories that were deselected
+// here yet still counted in the PDF.
 func getRepositoryData() ([]RepositoryData, error) {
-	var repositories []RepositoryData
-
-	// Detect platform and read analysis results
-	platform, analysisFile, err := detectPlatformAndReadAnalysis()
-	if err != nil {
-		fmt.Printf("❌ Error reading analysis result file: %v\n", err)
-		return nil, err
-	}
-
-	var analysisResult AnalysisResult
-	err = json.Unmarshal(analysisFile, &analysisResult)
-	if err != nil {
-		fmt.Printf("❌ Error decoding JSON analysis result file for platform %s: %v\n", platform, err)
-		return nil, err
-	}
-
-	// Group by repository to avoid duplicate entries (needed for --all-branches mode)
-	repoMap := make(map[string]AnalysisResult_ProjectBranch)
-
-	// First pass: Group by repository and prefer main/master/default branches
-	for _, branch := range analysisResult.ProjectBranches {
-		repoKey := branch.RepoSlug
-
-		// If we haven't seen this repo, or if this is a main branch, use it
-		if existing, exists := repoMap[repoKey]; !exists || isMainBranch(branch.MainBranch) {
-			// Only override if current is main branch, or existing is not main branch
-			if !exists || isMainBranch(branch.MainBranch) || !isMainBranch(existing.MainBranch) {
-				repoMap[repoKey] = branch
-			}
-		}
-	}
-
-	// Process each unique repository (now showing only one branch per repository)
-	i := 0
-	for _, branch := range repoMap {
-		i++
-		// Construct filename for byfile report using platform-specific logic
-		var fileName, byLanguagePath string
-		if platform == "file" {
-			// File mode uses simpler naming: Result_{slug}_byfile.json
-			fileName = buildSecurePath(byFileReportDir,
-				fmt.Sprintf("Result_%s_byfile.json", sanitizePathComponent(branch.RepoSlug)))
-			byLanguagePath = buildSecurePath(byLanguageReportDir,
-				fmt.Sprintf("Result_%s.json", sanitizePathComponent(branch.RepoSlug)))
-		} else {
-			firstPart := getFirstPartForPlatform(platform, branch, branch.RepoSlug)
-			// Match the Result_<Org>__<Repo>__<Branch> convention written by
-			// performRepoAnalysis in golc.go. Double-underscore between fields
-			// keeps `_` free inside any component for unambiguous parsing.
-			fileName = buildSecurePath(byFileReportDir,
-				fmt.Sprintf("Result_%s__%s__%s_byfile.json",
-					sanitizePathComponent(firstPart),
-					sanitizePathComponent(branch.RepoSlug),
-					sanitizePathComponent(branch.MainBranch)))
-			byLanguagePath = buildSecurePath(byLanguageReportDir,
-				fmt.Sprintf("Result_%s__%s__%s.json",
-					sanitizePathComponent(firstPart),
-					sanitizePathComponent(branch.RepoSlug),
-					sanitizePathComponent(branch.MainBranch)))
-		}
-
-		// Read the byfile report
-		fileData, err := os.ReadFile(fileName)
-		if err != nil {
-			fmt.Printf("❌ Error reading byfile report %s: %v\n", fileName, err)
-			continue // Skip this repository if file doesn't exist
-		}
-
-		// Parse the JSON structure
-		var reportData struct {
-			TotalLines      int `json:"TotalLines"`
-			TotalBlankLines int `json:"TotalBlankLines"`
-			TotalComments   int `json:"TotalComments"`
-			TotalCodeLines  int `json:"TotalCodeLines"`
-		}
-
-		err = json.Unmarshal(fileData, &reportData)
-		if err != nil {
-			fmt.Printf("❌ Error decoding JSON byfile report %s: %v\n", fileName, err)
-			continue
-		}
-
-		// Code lines for report total: exclude JSON to match SonarQube behavior. The same
-		// parse yields the repository's largest languages — the per-language list is
-		// already in hand here, so surfacing the top few costs no extra read.
-		codeLinesForReport := reportData.TotalCodeLines
-		var topLanguages []utils.LanguageShare
-		if langData, err := os.ReadFile(byLanguagePath); err == nil {
-			var byLang struct {
-				Results []utils.LanguageShare `json:"Results"`
-			}
-			if json.Unmarshal(langData, &byLang) == nil {
-				for _, r := range byLang.Results {
-					if strings.TrimSpace(r.Language) == utils.LanguageExcludedFromTotalLOC {
-						codeLinesForReport = reportData.TotalCodeLines - r.CodeLines
-						break
-					}
-				}
-				topLanguages = utils.RankTopLanguages(byLang.Results, utils.TopLanguagesShown)
-			}
-		}
-
-		// Built from the inventory fields through the shared key function rather than
-		// read back out of byLanguagePath. This page and the report generators
-		// construct their paths separately, so a key recovered from a path inherits
-		// every difference between them — which is how a repository could be
-		// deselected here and still counted in the generated reports.
-		key := utils.DeselectionKeyForRepo(platform, getFirstPartForPlatform(platform, branch, branch.RepoSlug),
-			branch.RepoSlug, branch.MainBranch)
-
-		// Create repository data entry (CodeLines excludes JSON for report total)
-		repo := RepositoryData{
-			Number:       i,
-			Key:          key,
-			Repository:   branch.RepoSlug,
-			Org:          branch.Org,
-			Branch:       branch.MainBranch,
-			Lines:        reportData.TotalLines,
-			BlankLines:   reportData.TotalBlankLines,
-			Comments:     reportData.TotalComments,
-			CodeLines:    codeLinesForReport,
-			LinesF:       utils.FormatCodeLines(float64(reportData.TotalLines)),
-			BlankLinesF:  utils.FormatCodeLines(float64(reportData.TotalBlankLines)),
-			CommentsF:    utils.FormatCodeLines(float64(reportData.TotalComments)),
-			CodeLinesF:   utils.FormatCodeLines(float64(codeLinesForReport)),
-			TopLanguages: topLanguages,
-		}
-
-		repositories = append(repositories, repo)
-	}
-
-	// Sort repositories by Code Lines (descending) by default
-	sort.Slice(repositories, func(i, j int) bool {
-		return repositories[i].CodeLines > repositories[j].CodeLines
-	})
-
-	// Update numbers after sorting
-	for i := range repositories {
-		repositories[i].Number = i + 1
-	}
-
-	return repositories, nil
+	return utils.ReadRepositoryData(resultsBaseDir)
 }
 
 func detectPlatformAndReadAnalysis() (string, []byte, error) {
-	// Try to detect platform from existing analysis result files
-	// Supporting all platforms from config_sample.json
-	platforms := []string{"github", "gitlab", "bitbucket", "bitbucket_dc", "azure", "file"}
-
-	for _, platform := range platforms {
-		filePath := fmt.Sprintf("%s/analysis_result_%s.json", configResultsDir, platform)
-		if data, err := os.ReadFile(filePath); err == nil {
-			return platform, data, nil
-		}
-	}
-
-	// Default fallback to github if no specific file found
-	data, err := os.ReadFile(fmt.Sprintf("%s/analysis_result_github.json", configResultsDir))
-	if err != nil {
-		return "", nil, fmt.Errorf("no analysis result file found")
-	}
-	return "github", data, nil
+	spec, data, err := utils.DetectPlatform(resultsBaseDir)
+	return spec.Name, data, err
 }
 
-// Helper function to determine the correct first part of filename based on platform
+// getFirstPartForPlatform returns the leading component of a result file name — the
+// organization for GitHub and GitLab, the project key for Azure and Bitbucket.
 func getFirstPartForPlatform(platform string, branch AnalysisResult_ProjectBranch, repoName string) string {
-	switch platform {
-	case "azure":
-		// Azure uses ProjectKey for filenames
-		if branch.ProjectKey != "" {
-			return branch.ProjectKey
-		}
-		// Fallback to repoName if ProjectKey is not available
-		return repoName
-	case "bitbucket", "bitbucket_dc":
-		// Bitbucket uses ProjectKey for filenames
-		if branch.ProjectKey != "" {
-			return branch.ProjectKey
-		}
-		// Fallback to Org if ProjectKey is not available
-		return branch.Org
-	case "github", "gitlab", "file":
-		// GitHub, GitLab, and file use Org
-		return branch.Org
-	default:
-		// Default fallback to Org
+	spec, ok := utils.PlatformSpecFor(platform)
+	if !ok {
 		return branch.Org
 	}
+	return spec.FirstPart(branch)
 }
 
 // Helper function for cases where we only have orgName and repoName

--- a/pkg/utils/repository_reader.go
+++ b/pkg/utils/repository_reader.go
@@ -1,0 +1,254 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// resultsDirName is the results tree the reports have always read from, relative to the
+// binary's working directory.
+const resultsDirName = "Results"
+
+// The results page and the report generators each used to carry their own copy of
+// "find the inventory, work out the result file names, read them". The copies drifted:
+// they disagreed about the platform key for Bitbucket Data Center, about what to do when
+// a project key is missing, and about whether to sanitize path components. That drift
+// produced real bugs — a repository deselected on the page stayed counted in the PDF, and
+// the summary reports were never generated for Bitbucket Data Center at all.
+//
+// This file is the single description of that layout. Both callers read through it, so a
+// disagreement between them is no longer expressible.
+
+// PlatformSpec describes where one DevOps platform's analysis inventory lives and how its
+// per-repository result files are named.
+type PlatformSpec struct {
+	// Name is the canonical platform key, matching the DevOps value in config.json and
+	// the suffix of the inventory file. Using one string for both is what removes the old
+	// "bitbucketdc" versus "bitbucket_dc" mismatch.
+	Name string
+
+	// firstPart derives the leading component of a result file name. GitHub and GitLab
+	// group by organization; Azure and Bitbucket group by project key.
+	firstPart func(ProjectBranch) string
+
+	// singleComponent marks the `file` platform, whose results are named
+	// Result_<Repo>.json with no organization or branch.
+	singleComponent bool
+}
+
+// platformSpecs is ordered, and detection takes the first match. Order matters when a
+// Results directory holds inventories from more than one platform — a re-scan against a
+// different platform without clearing Results — because an unordered lookup would pick
+// randomly and the reports could then describe a different platform than the page.
+var platformSpecs = []PlatformSpec{
+	{Name: "github", firstPart: func(b ProjectBranch) string { return b.Org }},
+	{Name: "gitlab", firstPart: func(b ProjectBranch) string { return b.Org }},
+	{Name: "bitbucket", firstPart: projectKeyOrOrg},
+	{Name: "bitbucket_dc", firstPart: projectKeyOrOrg},
+	{Name: "azure", firstPart: projectKeyOrRepo},
+	{Name: "file", firstPart: func(b ProjectBranch) string { return b.RepoSlug }, singleComponent: true},
+}
+
+// projectKeyOrOrg is the Bitbucket rule: group by project key, falling back to the
+// organization. The fallback matters because an empty first component produces a file name
+// that matches nothing, so the repository would silently vanish from the reports.
+func projectKeyOrOrg(b ProjectBranch) string {
+	if b.ProjectKey != "" {
+		return b.ProjectKey
+	}
+	return b.Org
+}
+
+// projectKeyOrRepo is the Azure rule: group by project key, falling back to the repository
+// name for the same reason.
+func projectKeyOrRepo(b ProjectBranch) string {
+	if b.ProjectKey != "" {
+		return b.ProjectKey
+	}
+	return b.RepoSlug
+}
+
+// PlatformSpecFor returns the spec for a platform key.
+func PlatformSpecFor(name string) (PlatformSpec, bool) {
+	for _, spec := range platformSpecs {
+		if spec.Name == name {
+			return spec, true
+		}
+	}
+	return PlatformSpec{}, false
+}
+
+// InventoryPath returns the analysis inventory file for this platform.
+func (p PlatformSpec) InventoryPath(baseResultsDir string) string {
+	return filepath.Join(baseResultsDir, "config", "analysis_result_"+p.Name+".json")
+}
+
+// FirstPart returns the leading component of this repository's result file name — the
+// organization for GitHub and GitLab, the project key for Azure and Bitbucket.
+func (p PlatformSpec) FirstPart(b ProjectBranch) string {
+	if p.firstPart == nil {
+		return b.Org
+	}
+	return p.firstPart(b)
+}
+
+// resultStem returns the result file name without its extension or role suffix.
+// Components are sanitized so a GitLab subgroup or a `release/1.0` branch cannot turn the
+// name into a nested path — and so that the name matches what the reporters wrote.
+func (p PlatformSpec) resultStem(b ProjectBranch) string {
+	if p.singleComponent {
+		return "Result_" + SanitizeResultComponent(b.RepoSlug)
+	}
+	return "Result_" + SanitizeResultComponent(p.FirstPart(b)) +
+		keySeparator + SanitizeResultComponent(b.RepoSlug) +
+		keySeparator + SanitizeResultComponent(b.MainBranch)
+}
+
+// ByFilePath returns this repository's per-file result document.
+func (p PlatformSpec) ByFilePath(baseResultsDir string, b ProjectBranch) string {
+	return filepath.Join(baseResultsDir, "byfile-report", p.resultStem(b)+"_byfile.json")
+}
+
+// ByLanguagePath returns this repository's per-language result document.
+func (p PlatformSpec) ByLanguagePath(baseResultsDir string, b ProjectBranch) string {
+	return filepath.Join(baseResultsDir, "bylanguage-report", p.resultStem(b)+".json")
+}
+
+// DeselectionKey returns the key a deselection matches on, derived from the inventory
+// fields through the same rules that name the files.
+func (p PlatformSpec) DeselectionKey(b ProjectBranch) string {
+	return DeselectionKeyForRepo(p.Name, p.FirstPart(b), b.RepoSlug, b.MainBranch)
+}
+
+// DetectPlatform finds which platform produced the results under baseResultsDir and
+// returns its spec together with the raw inventory bytes.
+func DetectPlatform(baseResultsDir string) (PlatformSpec, []byte, error) {
+	for _, spec := range platformSpecs {
+		if data, err := os.ReadFile(spec.InventoryPath(baseResultsDir)); err == nil {
+			return spec, data, nil
+		}
+	}
+	return PlatformSpec{}, nil, fmt.Errorf("no analysis result file found for any supported platform")
+}
+
+// PreferredBranches collapses an inventory to one entry per repository, preferring a
+// main/master/default branch. An all-branches scan records several entries per repository,
+// and the summaries report one row each.
+func PreferredBranches(branches []ProjectBranch) map[string]ProjectBranch {
+	preferred := make(map[string]ProjectBranch, len(branches))
+	for _, branch := range branches {
+		existing, seen := preferred[branch.RepoSlug]
+		if !seen || isMainBranch(branch.MainBranch) || !isMainBranch(existing.MainBranch) {
+			preferred[branch.RepoSlug] = branch
+		}
+	}
+	return preferred
+}
+
+// ReadRepositoryData collects every analyzed repository from the result files under
+// baseResultsDir, largest first.
+//
+// A repository whose result documents are missing or unreadable is skipped rather than
+// failing the whole read: one unreadable file should not cost the user the entire report.
+func ReadRepositoryData(baseResultsDir string) ([]RepositoryData, error) {
+	spec, inventory, err := DetectPlatform(baseResultsDir)
+	if err != nil {
+		return nil, fmt.Errorf("error reading analysis result file: %w", err)
+	}
+
+	var analysis AnalysisResult
+	if err := json.Unmarshal(inventory, &analysis); err != nil {
+		return nil, fmt.Errorf("error decoding JSON analysis result file for platform %s: %w", spec.Name, err)
+	}
+
+	var repositories []RepositoryData
+	for _, branch := range PreferredBranches(analysis.ProjectBranches) {
+		repo, ok := readRepository(baseResultsDir, spec, branch)
+		if !ok {
+			continue
+		}
+		repositories = append(repositories, repo)
+	}
+
+	// Largest first, ties broken by key. The tiebreak matters: sort.Slice gives no
+	// ordering guarantee for equal elements and the input arrives from a map, so
+	// repositories with the same size — commonly several at zero — could be ordered
+	// differently between runs, Go versions or callers. That turns every report diff into
+	// noise and makes row numbers move for no reason.
+	sort.Slice(repositories, func(i, j int) bool {
+		if repositories[i].CodeLines != repositories[j].CodeLines {
+			return repositories[i].CodeLines > repositories[j].CodeLines
+		}
+		return repositories[i].Key < repositories[j].Key
+	})
+	for i := range repositories {
+		repositories[i].Number = i + 1
+	}
+	return repositories, nil
+}
+
+// readRepository builds one repository's row from its result documents, reporting ok=false
+// when they cannot be read.
+func readRepository(baseResultsDir string, spec PlatformSpec, branch ProjectBranch) (RepositoryData, bool) {
+	fileData, err := os.ReadFile(spec.ByFilePath(baseResultsDir, branch))
+	if err != nil {
+		return RepositoryData{}, false
+	}
+
+	var report struct {
+		TotalLines      int `json:"TotalLines"`
+		TotalBlankLines int `json:"TotalBlankLines"`
+		TotalComments   int `json:"TotalComments"`
+		TotalCodeLines  int `json:"TotalCodeLines"`
+	}
+	if err := json.Unmarshal(fileData, &report); err != nil {
+		return RepositoryData{}, false
+	}
+
+	// The per-language document answers two questions from one parse: how much of the
+	// total is the language held out of it (JSON), and which languages are the largest.
+	codeLines := report.TotalCodeLines
+	var topLanguages []LanguageShare
+	if langData, err := os.ReadFile(spec.ByLanguagePath(baseResultsDir, branch)); err == nil {
+		var byLang struct {
+			Results []LanguageShare `json:"Results"`
+		}
+		if json.Unmarshal(langData, &byLang) == nil {
+			for _, r := range byLang.Results {
+				if strings.TrimSpace(r.Language) == LanguageExcludedFromTotalLOC {
+					codeLines = report.TotalCodeLines - r.CodeLines
+					break
+				}
+			}
+			topLanguages = RankTopLanguages(byLang.Results, TopLanguagesShown)
+		}
+	}
+
+	// Org carries the naming component rather than the raw inventory Org, so that on Azure
+	// and Bitbucket it names the project the repository is actually grouped under. For
+	// GitHub and GitLab the two are the same value.
+	org := spec.FirstPart(branch)
+	if spec.singleComponent {
+		org = ""
+	}
+
+	return RepositoryData{
+		Key:          spec.DeselectionKey(branch),
+		Repository:   branch.RepoSlug,
+		Org:          org,
+		Branch:       branch.MainBranch,
+		Lines:        report.TotalLines,
+		BlankLines:   report.TotalBlankLines,
+		Comments:     report.TotalComments,
+		CodeLines:    codeLines,
+		LinesF:       FormatCodeLines(float64(report.TotalLines)),
+		BlankLinesF:  FormatCodeLines(float64(report.TotalBlankLines)),
+		CommentsF:    FormatCodeLines(float64(report.TotalComments)),
+		CodeLinesF:   FormatCodeLines(float64(codeLines)),
+		TopLanguages: topLanguages,
+	}, true
+}

--- a/pkg/utils/repository_reader.go
+++ b/pkg/utils/repository_reader.go
@@ -138,11 +138,18 @@ func DetectPlatform(baseResultsDir string) (PlatformSpec, []byte, error) {
 // PreferredBranches collapses an inventory to one entry per repository, preferring a
 // main/master/default branch. An all-branches scan records several entries per repository,
 // and the summaries report one row each.
+//
+// When no branch is a recognised main branch, the first one encountered wins. That is
+// arbitrary but it is the long-standing behaviour, and changing which branch's line counts
+// get reported is not something a repository-layout refactor should do quietly.
+//
+// The original spelling nested this inside a second, wider condition. The two were
+// equivalent — the inner test is implied by the outer one in all eight combinations, so it
+// never changed the outcome — and flattening it to the outer test alone is what this is.
 func PreferredBranches(branches []ProjectBranch) map[string]ProjectBranch {
 	preferred := make(map[string]ProjectBranch, len(branches))
 	for _, branch := range branches {
-		existing, seen := preferred[branch.RepoSlug]
-		if !seen || isMainBranch(branch.MainBranch) || !isMainBranch(existing.MainBranch) {
+		if _, seen := preferred[branch.RepoSlug]; !seen || isMainBranch(branch.MainBranch) {
 			preferred[branch.RepoSlug] = branch
 		}
 	}

--- a/pkg/utils/repository_reader_test.go
+++ b/pkg/utils/repository_reader_test.go
@@ -128,6 +128,68 @@ func TestDetectPlatformReportsNothingFound(t *testing.T) {
 	}
 }
 
+func TestPreferredBranchesKeepsFirstWhenNoneIsMain(t *testing.T) {
+	// In all-branches mode a repository can have several branches and none that counts as
+	// a main branch. Which one is reported is arbitrary, but it must not change: it decides
+	// whose line counts appear for that repository. First encountered wins.
+	got := PreferredBranches([]ProjectBranch{
+		{RepoSlug: "svc", MainBranch: "feature/a"},
+		{RepoSlug: "svc", MainBranch: "feature/b"},
+		{RepoSlug: "svc", MainBranch: "feature/c"},
+	})
+	if got["svc"].MainBranch != "feature/a" {
+		t.Errorf("kept %q, want the first branch encountered (feature/a)", got["svc"].MainBranch)
+	}
+}
+
+func TestPreferredBranchesMainWinsFromAnyPosition(t *testing.T) {
+	// A main branch must win wherever it appears, including after other branches.
+	for _, order := range [][]ProjectBranch{
+		{{RepoSlug: "svc", MainBranch: testBranchMain}, {RepoSlug: "svc", MainBranch: "feature/a"}},
+		{{RepoSlug: "svc", MainBranch: "feature/a"}, {RepoSlug: "svc", MainBranch: testBranchMain}},
+		{{RepoSlug: "svc", MainBranch: "feature/a"}, {RepoSlug: "svc", MainBranch: testBranchMain},
+			{RepoSlug: "svc", MainBranch: "feature/b"}},
+	} {
+		if got := PreferredBranches(order); got["svc"].MainBranch != testBranchMain {
+			t.Errorf("kept %q, want the main branch", got["svc"].MainBranch)
+		}
+	}
+}
+
+func TestPreferredBranchesMatchesTheOriginalNestedCondition(t *testing.T) {
+	// The original spelling nested two conditions. This pins that the flattened form
+	// agrees with it for every combination of (already seen, new is main, existing is
+	// main) — the property that makes the simplification safe rather than merely tidier.
+	original := func(preferred map[string]ProjectBranch, branch ProjectBranch) bool {
+		existing, exists := preferred[branch.RepoSlug]
+		if !exists || isMainBranch(branch.MainBranch) {
+			return !exists || isMainBranch(branch.MainBranch) || !isMainBranch(existing.MainBranch)
+		}
+		return false
+	}
+
+	branchNames := []string{testBranchMain, "feature/a"}
+	for _, existingBranch := range branchNames {
+		for _, newBranch := range branchNames {
+			for _, seen := range []bool{false, true} {
+				state := map[string]ProjectBranch{}
+				if seen {
+					state["svc"] = ProjectBranch{RepoSlug: "svc", MainBranch: existingBranch}
+				}
+				candidate := ProjectBranch{RepoSlug: "svc", MainBranch: newBranch}
+
+				_, isSeen := state["svc"]
+				flattened := !isSeen || isMainBranch(candidate.MainBranch)
+
+				if flattened != original(state, candidate) {
+					t.Errorf("seen=%v existing=%q new=%q: flattened=%v, original=%v",
+						seen, existingBranch, newBranch, flattened, original(state, candidate))
+				}
+			}
+		}
+	}
+}
+
 func TestPreferredBranchesPrefersMain(t *testing.T) {
 	// An all-branches scan records several entries per repository; the summaries show one.
 	got := PreferredBranches([]ProjectBranch{

--- a/pkg/utils/repository_reader_test.go
+++ b/pkg/utils/repository_reader_test.go
@@ -1,0 +1,341 @@
+package utils
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// These tests pin the result-file layout for every platform. Two independent copies of
+// this logic used to exist and drifted apart; the table below is what makes a future
+// divergence a test failure rather than a silently missing repository.
+
+func TestPlatformSpecNamingPerPlatform(t *testing.T) {
+	branch := ProjectBranch{
+		Org:        "acme-org",
+		ProjectKey: "PROJ",
+		RepoSlug:   "svc",
+		MainBranch: testBranchMain,
+	}
+
+	cases := []struct {
+		platform      string
+		wantFirstPart string
+		wantByFile    string
+		wantByLang    string
+	}{
+		// GitHub and GitLab group by organization.
+		{"github", "acme-org", "Result_acme-org__svc__main_byfile.json", "Result_acme-org__svc__main.json"},
+		{"gitlab", "acme-org", "Result_acme-org__svc__main_byfile.json", "Result_acme-org__svc__main.json"},
+		// Azure and Bitbucket group by project key.
+		{"bitbucket", "PROJ", "Result_PROJ__svc__main_byfile.json", "Result_PROJ__svc__main.json"},
+		{"bitbucket_dc", "PROJ", "Result_PROJ__svc__main_byfile.json", "Result_PROJ__svc__main.json"},
+		{"azure", "PROJ", "Result_PROJ__svc__main_byfile.json", "Result_PROJ__svc__main.json"},
+		// The file platform names results by directory alone.
+		{"file", "svc", "Result_svc_byfile.json", "Result_svc.json"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.platform, func(t *testing.T) {
+			spec, ok := PlatformSpecFor(tc.platform)
+			if !ok {
+				t.Fatalf("no spec for platform %q", tc.platform)
+			}
+			if got := spec.FirstPart(branch); got != tc.wantFirstPart {
+				t.Errorf("FirstPart = %q, want %q", got, tc.wantFirstPart)
+			}
+			if got := filepath.Base(spec.ByFilePath("Results", branch)); got != tc.wantByFile {
+				t.Errorf("ByFilePath = %q, want %q", got, tc.wantByFile)
+			}
+			if got := filepath.Base(spec.ByLanguagePath("Results", branch)); got != tc.wantByLang {
+				t.Errorf("ByLanguagePath = %q, want %q", got, tc.wantByLang)
+			}
+			// The inventory file name must match what the scanners write.
+			wantInv := filepath.Join("Results", "config", "analysis_result_"+tc.platform+".json")
+			if got := spec.InventoryPath("Results"); got != wantInv {
+				t.Errorf("InventoryPath = %q, want %q", got, wantInv)
+			}
+		})
+	}
+}
+
+func TestPlatformSpecFallsBackWhenProjectKeyMissing(t *testing.T) {
+	// An empty first component names a file that matches nothing, so the repository would
+	// vanish from the reports. Azure falls back to the repository, Bitbucket to the org.
+	noKey := ProjectBranch{Org: "acme-org", RepoSlug: "svc", MainBranch: testBranchMain}
+
+	cases := map[string]string{
+		"azure":        "svc",
+		"bitbucket":    "acme-org",
+		"bitbucket_dc": "acme-org",
+	}
+	for platform, want := range cases {
+		spec, _ := PlatformSpecFor(platform)
+		if got := spec.FirstPart(noKey); got != want {
+			t.Errorf("%s: FirstPart with no project key = %q, want %q", platform, got, want)
+		}
+		if got := spec.FirstPart(noKey); got == "" {
+			t.Errorf("%s: first component must never be empty", platform)
+		}
+	}
+}
+
+func TestPlatformSpecKeyMatchesFileName(t *testing.T) {
+	// The deselection key must be the stem of the file the numbers are read from, or a
+	// repository deselected on the page stays counted in the reports.
+	for _, spec := range platformSpecs {
+		branch := ProjectBranch{Org: "group/sub", ProjectKey: "PROJ", RepoSlug: "svc", MainBranch: "release/1.0"}
+		stem := spec.resultStem(branch)
+		fromName, ok := DeselectionKeyFromResultFileName(stem + ".json")
+		if !ok {
+			t.Errorf("%s: %q not recognised as a result file", spec.Name, stem)
+			continue
+		}
+		if got := spec.DeselectionKey(branch); got != fromName {
+			t.Errorf("%s: key from fields %q != key from file name %q", spec.Name, got, fromName)
+		}
+	}
+}
+
+func TestDetectPlatformIsOrderedNotRandom(t *testing.T) {
+	// With inventories from several platforms present, the pick must be deterministic:
+	// otherwise the reports can describe a different platform than the page.
+	base := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(base, "config"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"azure", "github", "gitlab"} {
+		body, _ := json.Marshal(AnalysisResult{})
+		if err := os.WriteFile(filepath.Join(base, "config", "analysis_result_"+name+".json"), body, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 5; i++ {
+		spec, _, err := DetectPlatform(base)
+		if err != nil {
+			t.Fatalf("DetectPlatform: %v", err)
+		}
+		if spec.Name != "github" {
+			t.Fatalf("detected %q, want the first spec in table order (github)", spec.Name)
+		}
+	}
+}
+
+func TestDetectPlatformReportsNothingFound(t *testing.T) {
+	if _, _, err := DetectPlatform(t.TempDir()); err == nil {
+		t.Error("expected an error when no inventory exists")
+	}
+}
+
+func TestPreferredBranchesPrefersMain(t *testing.T) {
+	// An all-branches scan records several entries per repository; the summaries show one.
+	got := PreferredBranches([]ProjectBranch{
+		{RepoSlug: "svc", MainBranch: "feature/x"},
+		{RepoSlug: "svc", MainBranch: testBranchMain},
+		{RepoSlug: "other", MainBranch: "release/2"},
+	})
+	if len(got) != 2 {
+		t.Fatalf("got %d repositories, want 2", len(got))
+	}
+	if got["svc"].MainBranch != testBranchMain {
+		t.Errorf("svc resolved to %q, want the main branch", got["svc"].MainBranch)
+	}
+	// A repository with no main-ish branch still yields its only entry.
+	if got["other"].MainBranch != "release/2" {
+		t.Errorf("other resolved to %q, want release/2", got["other"].MainBranch)
+	}
+}
+
+// writeRepoFixture lays down the inventory and result documents for one repository.
+func writeRepoFixture(t *testing.T, base, platform string, branch ProjectBranch, code int, langs []LanguageShare) {
+	t.Helper()
+	spec, ok := PlatformSpecFor(platform)
+	if !ok {
+		t.Fatalf("unknown platform %q", platform)
+	}
+	for _, dir := range []string{
+		filepath.Join(base, "config"),
+		filepath.Join(base, "byfile-report"),
+		filepath.Join(base, "bylanguage-report"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	inv, _ := json.Marshal(AnalysisResult{NumRepositories: 1, ProjectBranches: []ProjectBranch{branch}})
+	if err := os.WriteFile(spec.InventoryPath(base), inv, 0644); err != nil {
+		t.Fatal(err)
+	}
+	byFile, _ := json.Marshal(map[string]int{
+		"TotalLines": code * 2, "TotalBlankLines": 3, "TotalComments": 4, "TotalCodeLines": code,
+	})
+	if err := os.WriteFile(spec.ByFilePath(base, branch), byFile, 0644); err != nil {
+		t.Fatal(err)
+	}
+	byLang, _ := json.Marshal(map[string]any{"Results": langs})
+	if err := os.WriteFile(spec.ByLanguagePath(base, branch), byLang, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReadRepositoryDataEndToEnd(t *testing.T) {
+	base := t.TempDir()
+	branch := ProjectBranch{Org: "acme", ProjectKey: "PROJ", RepoSlug: "svc", MainBranch: testBranchMain}
+	// TotalCodeLines is the sum of every language including the held-out one, as the
+	// scanner writes it: 700 + 200 + 5000. The headline figure must come out at 900.
+	writeRepoFixture(t, base, "azure", branch, 5900, []LanguageShare{
+		{Language: "Go", CodeLines: 700},
+		{Language: "YAML", CodeLines: 200},
+		{Language: LanguageExcludedFromTotalLOC, CodeLines: 5000},
+	})
+
+	repos, err := ReadRepositoryData(base)
+	if err != nil {
+		t.Fatalf("ReadRepositoryData: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("got %d repositories, want 1", len(repos))
+	}
+	repo := repos[0]
+
+	if repo.Repository != "svc" || repo.Branch != testBranchMain {
+		t.Errorf("identity = %q/%q, want svc/main", repo.Repository, repo.Branch)
+	}
+	// Azure groups by project key, so that is what Org names.
+	if repo.Org != "PROJ" {
+		t.Errorf("Org = %q, want the project key PROJ", repo.Org)
+	}
+	// The held-out language is subtracted from the headline figure and excluded from the
+	// language ranking.
+	if repo.CodeLines != 900 {
+		t.Errorf("CodeLines = %d, want 900 (5900 total less the 5000 held out)", repo.CodeLines)
+	}
+	if repo.CodeLinesF != FormatCodeLines(900) {
+		t.Errorf("CodeLinesF = %q, want %q", repo.CodeLinesF, FormatCodeLines(900))
+	}
+	if repo.PrimaryLanguage() != "Go" {
+		t.Errorf("PrimaryLanguage = %q, want Go", repo.PrimaryLanguage())
+	}
+	if len(repo.TopLanguages) != 2 {
+		t.Errorf("TopLanguages = %+v, want Go and YAML only", repo.TopLanguages)
+	}
+	if repo.Key != (PlatformSpec{Name: "azure", firstPart: projectKeyOrRepo}).DeselectionKey(branch) {
+		t.Errorf("Key = %q, does not match the platform rule", repo.Key)
+	}
+	if repo.Number != 1 {
+		t.Errorf("Number = %d, want 1", repo.Number)
+	}
+}
+
+func TestReadRepositoryDataOrdersTiesDeterministically(t *testing.T) {
+	// Repositories of equal size — commonly several at zero — must come out in a defined
+	// order. sort.Slice makes no promise for equal elements and the input arrives from a
+	// map, so without a tiebreak the order can differ between runs, Go versions or
+	// callers, turning every report diff into noise and moving row numbers for no reason.
+	base := t.TempDir()
+	spec, _ := PlatformSpecFor("github")
+	branches := []ProjectBranch{
+		{Org: "acme", RepoSlug: "zulu", MainBranch: testBranchMain},
+		{Org: "acme", RepoSlug: "alpha", MainBranch: testBranchMain},
+		{Org: "acme", RepoSlug: "mike", MainBranch: testBranchMain},
+	}
+	for _, b := range branches {
+		writeRepoFixture(t, base, "github", b, 0, nil) // all tied at zero
+	}
+	inv, _ := json.Marshal(AnalysisResult{NumRepositories: len(branches), ProjectBranches: branches})
+	if err := os.WriteFile(spec.InventoryPath(base), inv, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var first []string
+	for run := 0; run < 5; run++ {
+		repos, err := ReadRepositoryData(base)
+		if err != nil {
+			t.Fatalf("ReadRepositoryData: %v", err)
+		}
+		order := make([]string, 0, len(repos))
+		for _, r := range repos {
+			order = append(order, r.Repository)
+		}
+		if first == nil {
+			first = order
+			// Ties resolve by key, which for these repositories means alphabetical.
+			if want := []string{"alpha", "mike", "zulu"}; !equalStrings(order, want) {
+				t.Errorf("tie order = %v, want %v (by key)", order, want)
+			}
+			continue
+		}
+		if !equalStrings(order, first) {
+			t.Fatalf("order changed between runs: %v then %v", first, order)
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestReadRepositoryDataSkipsUnreadableRepositories(t *testing.T) {
+	// One missing result document must cost that repository, not the whole report.
+	base := t.TempDir()
+	present := ProjectBranch{Org: "acme", RepoSlug: "present", MainBranch: testBranchMain}
+	writeRepoFixture(t, base, "github", present, 100, []LanguageShare{{Language: "Go", CodeLines: 100}})
+
+	// Add a second repository to the inventory without writing its result documents.
+	spec, _ := PlatformSpecFor("github")
+	inv, _ := json.Marshal(AnalysisResult{NumRepositories: 2, ProjectBranches: []ProjectBranch{
+		present,
+		{Org: "acme", RepoSlug: "missing", MainBranch: testBranchMain},
+	}})
+	if err := os.WriteFile(spec.InventoryPath(base), inv, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ReadRepositoryData(base)
+	if err != nil {
+		t.Fatalf("ReadRepositoryData: %v", err)
+	}
+	if len(repos) != 1 || repos[0].Repository != "present" {
+		t.Errorf("got %+v, want only the readable repository", repos)
+	}
+}
+
+func TestReadRepositoryDataSortsBySizeAndNumbers(t *testing.T) {
+	base := t.TempDir()
+	spec, _ := PlatformSpecFor("github")
+	branches := []ProjectBranch{
+		{Org: "acme", RepoSlug: "small", MainBranch: testBranchMain},
+		{Org: "acme", RepoSlug: "big", MainBranch: testBranchMain},
+		{Org: "acme", RepoSlug: "mid", MainBranch: testBranchMain},
+	}
+	for i, b := range branches {
+		writeRepoFixture(t, base, "github", b, (i+1)*100, []LanguageShare{{Language: "Go", CodeLines: (i + 1) * 100}})
+	}
+	inv, _ := json.Marshal(AnalysisResult{NumRepositories: len(branches), ProjectBranches: branches})
+	if err := os.WriteFile(spec.InventoryPath(base), inv, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := ReadRepositoryData(base)
+	if err != nil {
+		t.Fatalf("ReadRepositoryData: %v", err)
+	}
+	want := []string{"mid", "big", "small"} // 300, 200, 100
+	for i, name := range want {
+		if repos[i].Repository != name {
+			t.Errorf("position %d = %q, want %q (largest first)", i, repos[i].Repository, name)
+		}
+		if repos[i].Number != i+1 {
+			t.Errorf("position %d numbered %d, want %d", i, repos[i].Number, i+1)
+		}
+	}
+}

--- a/pkg/utils/repository_summary.go
+++ b/pkg/utils/repository_summary.go
@@ -79,6 +79,10 @@ type RepositoryData struct {
 	// TopLanguages are the repository's largest languages, biggest first, excluding the
 	// language held out of the totals. Empty when no by-language result file was found.
 	TopLanguages []LanguageShare `json:"TopLanguages,omitempty"`
+	// Deselected marks a row excluded from the totals. Set only on the results page's
+	// table view, where counted and deselected rows are interleaved so a deselected
+	// repository keeps its ranked position.
+	Deselected bool `json:"Deselected,omitempty"`
 }
 
 // PrimaryLanguage returns the repository's largest language, or "" when unknown.
@@ -149,192 +153,29 @@ func isMainBranch(branchName string) bool {
 	return false
 }
 
-// detectPlatformAndReadAnalysis detects the platform and reads the analysis file.
-//
-// The candidates are an ordered slice, not a map: when a Results directory holds
-// inventories from more than one platform (a re-scan against a different platform
-// without clearing Results), map iteration order would make the pick random and the
-// summary reports could describe a different platform than the results page, which
-// resolves the same ambiguity in this same order.
+// detectPlatformAndReadAnalysis reports which platform produced the results and returns
+// the raw inventory. Delegates to the shared platform table; kept as a name the existing
+// tests exercise.
 func detectPlatformAndReadAnalysis() (string, []byte, error) {
-	// Platform keys must match the cases in getFirstPartForPlatform, since the
-	// returned platform selects the result-file naming convention.
-	platformFiles := []struct{ platform, fileName string }{
-		{"github", "Results/config/analysis_result_github.json"},
-		{"gitlab", "Results/config/analysis_result_gitlab.json"},
-		{"bitbucket", "Results/config/analysis_result_bitbucket.json"},
-		{"bitbucketdc", "Results/config/analysis_result_bitbucket_dc.json"},
-		{"azure", "Results/config/analysis_result_azure.json"},
-		{"file", "Results/config/analysis_result_file.json"},
-	}
-
-	for _, candidate := range platformFiles {
-		if data, err := os.ReadFile(candidate.fileName); err == nil {
-			return candidate.platform, data, nil
-		}
-	}
-
-	return "", nil, fmt.Errorf("no analysis result file found for any supported platform")
+	spec, data, err := DetectPlatform(resultsDirName)
+	return spec.Name, data, err
 }
 
-// getFirstPartForPlatform returns the first part of filename for different platforms
+// getFirstPartForPlatform returns the leading component of a result file name for a
+// platform. Delegates to the shared platform table.
 func getFirstPartForPlatform(platform string, branch ProjectBranch, repoSlug string) string {
-	switch platform {
-	case "azure":
-		return branch.ProjectKey
-	case "bitbucketdc":
-		return branch.ProjectKey
-	case "bitbucket":
-		return branch.ProjectKey
-	case "gitlab":
-		return branch.Org
-	case "github":
-		return branch.Org
-	default:
+	spec, ok := PlatformSpecFor(platform)
+	if !ok {
 		return repoSlug
 	}
+	return spec.FirstPart(branch)
 }
 
-// getRepositoryData collects all repository data from byfile reports
+// getRepositoryData collects all repository data from the result files. The layout logic
+// lives in repository_reader.go so the results page and these reports cannot disagree
+// about it.
 func getRepositoryData() ([]RepositoryData, error) {
-	var repositories []RepositoryData
-
-	// Detect platform and read analysis results
-	platform, analysisFile, err := detectPlatformAndReadAnalysis()
-	if err != nil {
-		return nil, fmt.Errorf("error reading analysis result file: %v", err)
-	}
-
-	var analysisResult AnalysisResult
-	err = json.Unmarshal(analysisFile, &analysisResult)
-	if err != nil {
-		return nil, fmt.Errorf("error decoding JSON analysis result file for platform %s: %v", platform, err)
-	}
-
-	// Group by repository to avoid duplicate entries (needed for --all-branches mode)
-	repoMap := make(map[string]ProjectBranch)
-
-	// First pass: Group by repository and prefer main/master/default branches
-	for _, branch := range analysisResult.ProjectBranches {
-		repoKey := branch.RepoSlug
-
-		// If we haven't seen this repo, or if this is a main branch, use it
-		if existing, exists := repoMap[repoKey]; !exists || isMainBranch(branch.MainBranch) {
-			// Only override if current is main branch, or existing is not main branch
-			if !exists || isMainBranch(branch.MainBranch) || !isMainBranch(existing.MainBranch) {
-				repoMap[repoKey] = branch
-			}
-		}
-	}
-
-	// Process each unique repository (now showing only one branch per repository)
-	i := 0
-	for _, branch := range repoMap {
-		i++
-		// Construct file paths using platform-specific naming.
-		// File mode uses a shorter pattern (no project key or branch suffix)
-		// because goloc names files as Result_<dirname>_byfile.json in that mode.
-		// Components are sanitized before being interpolated, matching the results
-		// page. Without it, a GitLab subgroup or a `release/1.0` branch turns the file
-		// name into a nested path and this lookup misses a file the page finds.
-		firstPart := getFirstPartForPlatform(platform, branch, branch.RepoSlug)
-		var byfilePath, byLanguagePath, org string
-		if platform == "file" {
-			slug := SanitizeResultComponent(branch.RepoSlug)
-			byfilePath = fmt.Sprintf("Results/byfile-report/Result_%s_byfile.json", slug)
-			byLanguagePath = fmt.Sprintf("Results/bylanguage-report/Result_%s.json", slug)
-		} else {
-			org = firstPart
-			byfilePath = fmt.Sprintf("Results/byfile-report/Result_%s__%s__%s_byfile.json",
-				SanitizeResultComponent(firstPart),
-				SanitizeResultComponent(branch.RepoSlug),
-				SanitizeResultComponent(branch.MainBranch))
-			byLanguagePath = fmt.Sprintf("Results/bylanguage-report/Result_%s__%s__%s.json",
-				SanitizeResultComponent(firstPart),
-				SanitizeResultComponent(branch.RepoSlug),
-				SanitizeResultComponent(branch.MainBranch))
-		}
-
-		// Built from the inventory fields through the shared key function rather than
-		// read back out of the file path. The page and these reports construct their
-		// paths separately, so a key recovered from a path inherits every difference
-		// between them — which is how a repository could be deselected on the page and
-		// still counted here.
-		key := DeselectionKeyForRepo(platform, firstPart, branch.RepoSlug, branch.MainBranch)
-
-		// Read the byfile report
-		fileData, err := os.ReadFile(byfilePath)
-		if err != nil {
-			// Skip this repository if file doesn't exist
-			continue
-		}
-
-		// Parse the JSON structure
-		var reportData struct {
-			TotalLines      int `json:"TotalLines"`
-			TotalBlankLines int `json:"TotalBlankLines"`
-			TotalComments   int `json:"TotalComments"`
-			TotalCodeLines  int `json:"TotalCodeLines"`
-		}
-
-		err = json.Unmarshal(fileData, &reportData)
-		if err != nil {
-			// Skip this repository if JSON is invalid
-			continue
-		}
-
-		// Code lines for report total: exclude JSON to match SonarQube behavior. The same
-		// parse yields the repository's largest languages — the per-language list is
-		// already in hand here, so surfacing the top few costs no extra read.
-		codeLinesForReport := reportData.TotalCodeLines
-		var topLanguages []LanguageShare
-		if langData, err := os.ReadFile(byLanguagePath); err == nil {
-			var byLang struct {
-				Results []LanguageShare `json:"Results"`
-			}
-			if json.Unmarshal(langData, &byLang) == nil {
-				for _, r := range byLang.Results {
-					if strings.TrimSpace(r.Language) == LanguageExcludedFromTotalLOC {
-						codeLinesForReport = reportData.TotalCodeLines - r.CodeLines
-						break
-					}
-				}
-				topLanguages = RankTopLanguages(byLang.Results, TopLanguagesShown)
-			}
-		}
-
-		// Create repository data entry (CodeLines excludes JSON for report total)
-		repo := RepositoryData{
-			Number:       i,
-			Key:          key,
-			Repository:   branch.RepoSlug,
-			Org:          org,
-			Branch:       branch.MainBranch,
-			Lines:        reportData.TotalLines,
-			BlankLines:   reportData.TotalBlankLines,
-			Comments:     reportData.TotalComments,
-			CodeLines:    codeLinesForReport,
-			LinesF:       FormatCodeLines(float64(reportData.TotalLines)),
-			BlankLinesF:  FormatCodeLines(float64(reportData.TotalBlankLines)),
-			CommentsF:    FormatCodeLines(float64(reportData.TotalComments)),
-			CodeLinesF:   FormatCodeLines(float64(codeLinesForReport)),
-			TopLanguages: topLanguages,
-		}
-
-		repositories = append(repositories, repo)
-	}
-
-	// Sort repositories by Code Lines (descending) by default
-	sort.Slice(repositories, func(i, j int) bool {
-		return repositories[i].CodeLines > repositories[j].CodeLines
-	})
-
-	// Update numbers after sorting
-	for i := range repositories {
-		repositories[i].Number = i + 1
-	}
-
-	return repositories, nil
+	return ReadRepositoryData(resultsDirName)
 }
 
 // PartitionDeselected splits repositories into those still counted and those the

--- a/pkg/utils/repository_summary_test.go
+++ b/pkg/utils/repository_summary_test.go
@@ -183,7 +183,11 @@ func TestGetFirstPartForPlatform(t *testing.T) {
 		expected string
 	}{
 		{"Azure platform", "azure", testProjectName},
-		{"BitBucket DC platform", "bitbucketdc", testProjectName},
+		// Canonical key, matching config.json's DevOps value, the inventory file
+		// name and the results page. pkg/utils used to spell it "bitbucketdc"
+		// internally, which is how the summary reports came to look for an inventory
+		// file no scanner writes.
+		{"BitBucket DC platform", "bitbucket_dc", testProjectName},
 		{"BitBucket platform", "bitbucket", testProjectName},
 		{"GitLab platform", "gitlab", testOrgName},
 		{"GitHub platform", "github", testOrgName},
@@ -813,8 +817,8 @@ func TestAdvancedPlatformDetection(t *testing.T) {
 		if err != nil {
 			t.Errorf("detectPlatformAndReadAnalysis() error = %v, want nil", err)
 		}
-		if platform != "bitbucketdc" {
-			t.Errorf(msgDetectPlatformAnalysisResult, platform, "bitbucketdc")
+		if platform != "bitbucket_dc" {
+			t.Errorf(msgDetectPlatformAnalysisResult, platform, "bitbucket_dc")
 		}
 		if len(data) == 0 {
 			t.Error("detectPlatformAndReadAnalysis() returned empty data for BitBucket DC")
@@ -827,11 +831,11 @@ func TestAdvancedPlatformDetection(t *testing.T) {
 	t.Run("All supported platforms", func(t *testing.T) {
 		// Test all platforms defined in the detection map
 		platforms := map[string]string{
-			"github":      "analysis_result_github.json",
-			"azure":       "analysis_result_azure.json",
-			"bitbucket":   "analysis_result_bitbucket.json",
-			"gitlab":      "analysis_result_gitlab.json",
-			"bitbucketdc": "analysis_result_bitbucket_dc.json",
+			"github":       "analysis_result_github.json",
+			"azure":        "analysis_result_azure.json",
+			"bitbucket":    "analysis_result_bitbucket.json",
+			"gitlab":       "analysis_result_gitlab.json",
+			"bitbucket_dc": "analysis_result_bitbucket_dc.json",
 		}
 
 		for platform, filename := range platforms {


### PR DESCRIPTION
Follow-up to #99. Pure refactor — no feature change — so it can be reviewed and bisected on its own.

## The problem

The results page and the report generators each carried their own copy of *find the inventory, work out the result file names, read them*. The copies had drifted, and **every divergence had already caused a bug**:

| Divergence | Consequence |
|---|---|
| platform key `bitbucket_dc` vs `bitbucketdc` | summary reports looked for an inventory file no scanner writes → **never generated for Bitbucket DC** |
| fallback when `ProjectKey` is empty (`""` vs org/repo) | an empty first component names a file matching nothing → repository silently missing |
| only one sanitised path components | a repository deselected on the page **stayed counted in the PDF** |

Each was found and patched individually during #99. This removes the thing that generated them.

## The change

`pkg/utils/repository_reader.go` is now the single description of the layout: an ordered platform table giving each platform its inventory file and naming rule, plus one reader built on it. Both callers read through it, so a disagreement is **no longer expressible**.

`ResultsAll`'s `RepositoryData`, `ProjectBranch` and `AnalysisResult` become aliases of the `pkg/utils` types rather than structurally identical copies — that copy is what allowed the drift.

The old entry points remain as thin delegations, deliberately: the 46 existing tests calling them keep working and act as the regression net across the move. Removing them is a separate, trivial follow-up.

Net: **−414 / +56** in the existing files, plus a 246-line shared reader and 285 lines of tests.

## Evidence that behaviour is unchanged

Built the merged `main` and this branch, ran **both dashboards against the same real scan** (20 repos, github.com):

- `/api/repositories` — every field of all 20 repositories identical
- `/api/global-info` — `2.46K`, 20 repos, same largest repository
- `repository_summary.csv` — **byte-identical**
- deselection round-trip on the refactored build: page and regenerated report agree on the key

Plus new table tests pinning the naming rule for all six platforms, so a future divergence is a test failure rather than a missing repository.

## Two deliberate changes

**1. Canonical platform key is `bitbucket_dc` everywhere** — matching `config.json`'s `DevOps` value, the inventory file name and the results page. Three tests pinned the internal-only spelling and were updated.

**2. Size ties are now ordered by key.** `sort.Slice` makes no promise for equal elements and the input arrives from a map, so tie order was *unspecified* — the before and after binaries disagreed about two zero-line repositories and neither was wrong. Left alone it would shift again on a Go upgrade or a different repository count, making report diffs noisy and moving row numbers for no reason.

Also: `Org` now carries the naming component rather than the raw inventory `Org`, so on Azure and Bitbucket it names the project the repository is grouped under. For GitHub and GitLab the two are the same value.

## Verification gap

Verified live on **GitHub**; GitLab was verified against #99's code, which shares this reader's behaviour. **Azure and Bitbucket DC were not run live** — they are exactly where the two implementations differed, so their `ProjectKey` fallbacks are covered by the new table tests rather than by a live scan. Worth a live Bitbucket DC run before merge if credentials are handy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)