### PR TITLE
chore: remove disabled all-branches mode, document branch selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **GoLC** counts physical lines of source code across all programming languages supported by [SonarQube](https://www.sonarsource.com/knowledge/languages/) — without running a full Sonar analysis.
 
-It connects to your DevOps platform, identifies the largest branch of each repository, counts lines of code per language, and presents the results in an interactive web dashboard with PDF, JSON, and CSV exports.
+It connects to your DevOps platform, counts one branch per repository, and presents the results in an interactive web dashboard with PDF, JSON, and CSV exports.
 
 **Supported platforms:** GitHub.com · GitHub Enterprise Server · GitLab Cloud · GitLab Self-Managed · Bitbucket Cloud · Bitbucket Data Center · Azure DevOps Services · Local files/directories
 
@@ -21,6 +21,7 @@ It connects to your DevOps platform, identifies the largest branch of each repos
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
   - [Optional Parameters](#optional-parameters)
+  - [Which branch is counted](#which-branch-is-counted)
 - [Reports](#reports)
   - [Languages per repository](#languages-per-repository)
   - [Excluding repositories from the totals](#excluding-repositories-from-the-totals)
@@ -74,8 +75,9 @@ Credentials are entered in the browser and saved automatically — no config fil
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `DefaultBranch` | bool | `true` = default branch only (faster). `false` = scan all branches and pick the largest. |
-| `Branch` | string | Analyze a specific branch name across all repos. Leave blank for auto. |
+| `DefaultBranch` | bool | `true` (default) = count each repository's default branch. `false` = count its most recently active branch instead. See [Which branch is counted](#which-branch-is-counted). |
+| `Branch` | string | Count this branch name in every repository instead. Requires `DefaultBranch: false`. |
+| `Period` | int | How far back to look when deciding which branch is most active, in months (e.g. `-1` = the last month). Only used when `DefaultBranch: false` and `Branch` is empty. Default `-1`; Bitbucket Data Center `-5`. |
 | `Multithreading` | bool | Enable parallel analysis. Default: `true`. |
 | `Workers` | int | Concurrent workers. Default: `10`. |
 | `FolderKeywords` | array | Exclude folders whose name contains the keyword as a whole word at any depth. Word boundaries are delimiters `-`, `_`, `.` — so `"test"` matches `integration-test/` and `test_helpers/` but not `protest/` or `latest/`. |
@@ -88,6 +90,28 @@ Credentials are entered in the browser and saved automatically — no config fil
 | `Org` | bool | `true` = analyze an organization account, `false` = analyze a personal account. GitHub and GitHub Enterprise only. Default: `true`. |
 | `WorkDir` | string | Base directory where repositories are cloned before counting, then deleted. Leave blank to use the system temp directory (the default). Set this to a path on a disk with enough free space when `/tmp` is small or RAM-backed and large/many repos fail with `no space left on device`. The directory is created if missing and must be writable. Can also be set globally with the `GOLC_WORKDIR` environment variable; the per-platform `WorkDir` value takes precedence over the environment variable. |
 
+
+---
+
+### Which branch is counted
+
+**GoLC counts exactly one branch per repository** — never several, and never all of them
+added together. This keeps the total comparable to what SonarQube would report.
+
+Which one depends on the **Analyze default branch only** switch in the UI:
+
+| Setting | Branch counted | Use it when |
+|---------|----------------|-------------|
+| **On** (default) | the repository's **default** branch | Almost always. Fastest, and matches what SonarQube analyses. |
+| **Off** | the **most recently active** branch | Your main line of work is not the default branch. |
+| **Off** + *Specific branch name* | that **exact branch**, in every repository | You size a named branch such as `develop` or `release/2025`. |
+
+"Most recently active" means the branch with the most commits in the last `Period`
+months (`-1` by default, so the last month).
+
+> **If no branch has commits in that window, GoLC falls back to the default branch.** For
+> repositories that have been quiet, turning the switch off therefore changes nothing.
+> Widen `Period` (for example `-12`) if you want a longer history taken into account.
 
 ---
 

--- a/golc.go
+++ b/golc.go
@@ -1308,56 +1308,23 @@ func runGolcInProcess(platform string) {
 
 		var fileexclusion = ".cloc_github_ignore"
 		fileexclusionEX := getFileNameIfExists(fileexclusion)
-		var fast bool
 
 		startTime = time.Now()
 
-		if false {
-			// fast mode (not available via web UI)
+		// GoLC analyses one branch per repository: the default branch, a branch named
+		// explicitly in the configuration, or — when neither applies — the most active
+		// branch. Selection happens inside the platform getter.
+		repositories, err := getgithub.GetRepoGithubList(platformConfig, fileexclusionEX, false)
+		if err != nil {
+			logger.Errorf(errorMessageRepos, platformConfig["Organization"].(string), err)
+			return
+		}
+
+		if len(repositories) == 0 {
+			logger.Error(errorMessageAnalyse)
+			exitGolc(1)
 		} else {
-			fast = false
-
-			if false {
-				fmt.Println("🌿 All-branches mode enabled for Github")
-				logger.Infof("🌿 All-branches mode enabled - analyzing ALL branches for each repository")
-
-				// Get the main repositories list (one per repo)
-				repositories, err := getgithub.GetRepoGithubList(platformConfig, fileexclusionEX, fast)
-				if err != nil {
-					logger.Errorf(errorMessageRepos, platformConfig["Organization"].(string), err)
-					return
-				}
-
-				if len(repositories) == 0 {
-					logger.Error(errorMessageAnalyse)
-					exitGolc(1)
-				} else {
-					// Get all branches for each repository and analyze them
-					allBranches, err := getgithub.GetAllBranchesForRepositories(platformConfig, repositories)
-					if err != nil {
-						logger.Errorf("❌ Error getting all branches: %v", err)
-						return
-					}
-
-					NumberRepos = AnalyseReposListGithub(DestinationResult, platformConfig, allBranches)
-				}
-			} else {
-				repositories, err := getgithub.GetRepoGithubList(platformConfig, fileexclusionEX, fast)
-				if err != nil {
-					logger.Errorf(errorMessageRepos, platformConfig["Organization"].(string), err)
-					return
-				}
-
-				if len(repositories) == 0 {
-					logger.Error(errorMessageAnalyse)
-					exitGolc(1)
-
-				} else {
-
-					NumberRepos = AnalyseReposListGithub(DestinationResult, platformConfig, repositories)
-
-				}
-			}
+			NumberRepos = AnalyseReposListGithub(DestinationResult, platformConfig, repositories)
 		}
 
 	case "gitlab":

--- a/pkg/devops/getgithub/getgithub.go
+++ b/pkg/devops/getgithub/getgithub.go
@@ -486,61 +486,6 @@ func getAllBranches(ctx context.Context, client *github.Client, repoName, organi
 // Get Infos for all Repositories in Organization
 
 // GetRepoGithubListAllBranches retrieves ALL branches for ALL repositories in the organization
-// GetAllBranchesForRepositories takes a repository list and expands it to analyze all branches
-func GetAllBranchesForRepositories(platformConfig map[string]interface{}, repositories []ProjectBranch) ([]ProjectBranch, error) {
-	var allBranches []ProjectBranch
-	loggers := utils.SharedLogger()
-
-	client := github.NewClient(nil).WithAuthToken(platformConfig["AccessToken"].(string))
-	ctx := withRateLimitSleep(context.Background())
-
-	spin1 := spinner.New(spinner.CharSets[35], 100*time.Millisecond)
-	spin1.Color("green", "bold")
-
-	for i, repo := range repositories {
-		messageB := fmt.Sprintf("   🌿 Getting all branches for repo %d/%d: %s ", i+1, len(repositories), repo.RepoSlug)
-		spin1.Suffix = messageB
-		spin1.Start()
-
-		// Get ALL branches for this repository
-		branchOpt := &github.BranchListOptions{
-			ListOptions: github.ListOptions{PerPage: 100},
-		}
-
-		var repoBranches []*github.Branch
-		for {
-			branches, resp, err := client.Repositories.ListBranches(ctx, repo.Org, repo.RepoSlug, branchOpt)
-			if err != nil {
-				loggers.Errorf("❌ Error getting branches for repo %s: %v", repo.RepoSlug, err)
-				break
-			}
-			repoBranches = append(repoBranches, branches...)
-			if resp.NextPage == 0 {
-				break
-			}
-			branchOpt.Page = resp.NextPage
-		}
-
-		// Create a ProjectBranch entry for EACH branch (for analysis purposes)
-		for _, branch := range repoBranches {
-			allBranches = append(allBranches, ProjectBranch{
-				Org:         repo.Org,
-				RepoSlug:    repo.RepoSlug,
-				MainBranch:  branch.GetName(),
-				LargestSize: repo.LargestSize,
-			})
-		}
-
-		spin1.Stop()
-		loggers.Infof("\r\t\t\t\t✅ %d Repo: %s - Found %d branches", i+1, repo.RepoSlug, len(repoBranches))
-	}
-
-	loggers.Infof("✅ Branch expansion completed:")
-	loggers.Infof("   - Repositories: %d", len(repositories))
-	loggers.Infof("   - Total branches to analyze: %d", len(allBranches))
-
-	return allBranches, nil
-}
 
 // getAllRepositories fetches all repositories from GitHub organization
 func getAllRepositories(client *github.Client, ctx context.Context, orgName string) ([]*github.Repository, error) {

--- a/pkg/devops/getgithub/getgithub_test.go
+++ b/pkg/devops/getgithub/getgithub_test.go
@@ -1362,30 +1362,6 @@ func TestListFunctions(t *testing.T) {
 		}
 	})
 
-	t.Run("GetAllBranchesForRepositories function", func(t *testing.T) {
-		platformConfig := map[string]interface{}{
-			"AccessToken": testToken,
-		}
-
-		repositories := []ProjectBranch{
-			{Org: testOrgName, RepoSlug: "test-repo", MainBranch: "main"},
-		}
-
-		// This will test the error handling path
-		branches, err := GetAllBranchesForRepositories(platformConfig, repositories)
-
-		// Function should handle errors gracefully - may return nil or empty slice on error
-		if branches == nil {
-			t.Logf("GetAllBranchesForRepositories returned nil slice on error (acceptable)")
-		} else {
-			t.Logf("GetAllBranchesForRepositories returned slice with %d elements", len(branches))
-		}
-
-		// Error is expected due to invalid token/network
-		if err != nil {
-			t.Logf("GetAllBranchesForRepositories handled error as expected: %v", err)
-		}
-	})
 }
 
 // TestGetGithubLanguages tests language analysis functionality


### PR DESCRIPTION
## Dead code

`golc.go` carried two `if false` blocks — a "fast mode" and an all-branches mode for GitHub. Neither could ever run.

The second was actively misleading: it made the codebase look as though GoLC could count every branch of a repository. It also explains something from #100 — because that path is disabled, the inventory never holds more than one entry per repository, which is why the branch-preference logic Gitar flagged there turned out to be **unreachable in the shipped tool**.

Removed both blocks, plus `GetAllBranchesForRepositories` and its test, which existed only to serve the disabled path. Nothing else referenced them. It's recoverable from history; re-enabling the feature would need a config flag, a UI control and the multi-entry inventory path regardless.

## README was wrong in two places

Both would mislead someone sizing a customer estimate:

| Was | Actually |
|---|---|
| "identifies the **largest** branch of each repository" | selects by **recent commit activity**, not size |
| `DefaultBranch: false` = "scan all branches and pick the largest" | scans none of them in full; picks by activity |

Replaced with a short **Which branch is counted** section — one branch per repository, and a table mapping the UI switch to the outcome:

| Setting | Branch counted |
|---|---|
| **Analyze default branch only** = on (default) | the default branch |
| off | the most recently active branch |
| off + *Specific branch name* | that exact branch |

`Period` is now documented at all. It was the undocumented setting that decides the activity window, and its one-month default means that **on a quiet repository, turning the switch off changes nothing** — the behaviour that made branch selection look broken in the first place.

## Verified

All three documented states checked against a live Azure DevOps scan, not just read from the code:

```
toggle ON (default branch)                     -> master
toggle OFF + specific branch 'feature-todo'    -> feature-todo
toggle OFF, no name, Period=-1 (quiet repo)    -> master   (documented fallback)
```

Builds and full test suite green under all three build tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)