### PR TITLE
Count the final line of a file that does not end in a newline

### DIFF
--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -156,12 +156,19 @@ func (sc *Scanner) scanFile(file analyzer.FileMetadata) (scanResult, error) {
 	reader := bufio.NewReader(f)
 	for {
 		line, err := reader.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
+		if err != nil && err != io.EOF {
 			return result, err
 		}
+
+		// ReadString returns the final chunk together with io.EOF when a file does not end
+		// in a newline. Breaking on the error discarded that chunk, losing one line from
+		// every such file. An empty chunk means the file did end in a newline and there is
+		// genuinely nothing left.
+		lastLine := err == io.EOF
+		if lastLine && line == "" {
+			break
+		}
+
 		line = strings.TrimSpace(line)
 
 		if isInBlockComment {

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -215,3 +215,112 @@ func TestScanCountsDelimiterLikeLinesForOtherLanguages(t *testing.T) {
 		t.Errorf("CodeLines = %d, want 2 (no NonCodeLines configured)", got.CodeLines)
 	}
 }
+
+// A file that does not end in a newline still has a final line. ReadString returns that
+// chunk together with io.EOF, and breaking on the error used to discard it, losing one
+// line from every such file.
+func TestScanCountsFinalLineWithoutTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+
+	sc := NewScanner(language.Languages{
+		"Go": {
+			LineComments:      []string{"//"},
+			MultiLineComments: [][]string{{"/*", "*/"}},
+			Extensions:        []string{".go"},
+		},
+	})
+
+	cases := []struct {
+		name                         string
+		content                      string
+		code, comments, blank, lines int
+	}{
+		{
+			name:    "code on the final line, no newline",
+			content: "a := 1\nb := 2",
+			code:    2, lines: 2,
+		},
+		{
+			name:    "same file with a trailing newline counts the same",
+			content: "a := 1\nb := 2\n",
+			code:    2, lines: 2,
+		},
+		{
+			name:    "a comment on the final line, no newline",
+			content: "a := 1\n// trailing note",
+			code:    1, comments: 1, lines: 2,
+		},
+		{
+			name:    "whitespace-only final line is blank, not code",
+			content: "a := 1\n   ",
+			code:    1, blank: 1, lines: 2,
+		},
+		{
+			name:    "a single line with no newline at all",
+			content: "only := 1",
+			code:    1, lines: 1,
+		},
+		{
+			name:    "empty file",
+			content: "",
+			lines:   0,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			path := filepath.Join(dir, "f.go")
+			if err := os.WriteFile(path, []byte(c.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := sc.scanFile(analyzer.FileMetadata{
+				FilePath: path, Extension: ".go", Language: "Go",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.CodeLines != c.code {
+				t.Errorf("CodeLines = %d, want %d", got.CodeLines, c.code)
+			}
+			if got.Comments != c.comments {
+				t.Errorf("Comments = %d, want %d", got.Comments, c.comments)
+			}
+			if got.BlankLines != c.blank {
+				t.Errorf("BlankLines = %d, want %d", got.BlankLines, c.blank)
+			}
+			if got.Lines != c.lines {
+				t.Errorf("Lines = %d, want %d", got.Lines, c.lines)
+			}
+		})
+	}
+}
+
+// An unterminated block comment that runs to the end of the file must still have its final
+// line counted as a comment.
+func TestScanCountsFinalLineInsideBlockComment(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.go")
+	if err := os.WriteFile(path, []byte("a := 1\n/* open\nstill open"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sc := NewScanner(language.Languages{
+		"Go": {
+			LineComments:      []string{"//"},
+			MultiLineComments: [][]string{{"/*", "*/"}},
+			Extensions:        []string{".go"},
+		},
+	})
+
+	got, err := sc.scanFile(analyzer.FileMetadata{
+		FilePath: path, Extension: ".go", Language: "Go",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CodeLines != 1 || got.Comments != 2 {
+		t.Errorf("got code=%d comments=%d, want code=1 comments=2",
+			got.CodeLines, got.Comments)
+	}
+}


### PR DESCRIPTION
## The bug

`scanFile` read with `reader.ReadString('\n')` and broke out of the loop the moment it saw `io.EOF`:

```go
line, err := reader.ReadString('\n')
if err != nil {
    if err == io.EOF {
        break          // the chunk in `line` is thrown away
    }
    return result, err
}
```

`ReadString` returns the final chunk **together with** `io.EOF` when a file has no trailing newline. Breaking on the error discarded it, losing **one line from every such file** — whether that line was code, a comment, or part of an unterminated block comment.

## The fix

Treat `io.EOF` as a normal outcome and stop only when the chunk is *also* empty, which is what a file that did end in a newline returns.

No explicit `break` is needed after classification: once the reader is exhausted it returns `("", io.EOF)` on every call, so the following iteration exits. That also keeps the existing `continue` statements working unchanged.

## Impact

Small but real — one line per affected file, always an under-count. Files that already end in a newline are unaffected, as is an empty file.

## Tests

`TestScanCountsFinalLineWithoutTrailingNewline` covers code, a comment, and a whitespace-only chunk on an unterminated final line; a single-line file with no newline at all; plus two controls that must **not** change (trailing newline present, empty file). `TestScanCountsFinalLineInsideBlockComment` covers an unterminated block comment running to end of file.

Verified the tests actually catch the defect: reverting the fix fails five subtests, while both controls keep passing.

`go build ./...` clean, `go test ./assets/ ./pkg/...` all pass, DEEP SonarQube analysis clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)