### PR TITLE
fix: close the gaps a real NTLM scan exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ It connects to your DevOps platform, counts one branch per repository, and prese
 
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
-  - [Optional Parameters](#optional-parameters)
+  - [Required token permissions](#required-token-permissions)
+  - [Azure DevOps Server](#azure-devops-server)
+  - [Advanced options](#advanced-options)
   - [Which branch is counted](#which-branch-is-counted)
 - [Reports](#reports)
   - [Languages per repository](#languages-per-repository)
@@ -70,63 +72,85 @@ Credentials are entered in the browser and saved automatically — no config fil
 | Azure DevOps | Code: Read · Project and Team: Read |
 | Azure DevOps Server | Code: Read · Project and Team: Read |
 
-#### Azure DevOps Server versions
+#### Azure DevOps Server
 
-**Azure DevOps Server 2019 Update 1 and later.** TFS 2018 and older are not supported.
+**Requires Azure DevOps Server 2019 Update 1 or later.** TFS 2018 and older are not
+supported. There is no upper bound — newer versions work.
 
-GoLC talks to Azure through the `azure-devops-go-api` SDK, which sends `api-version=5.1`
-on every call, so the server has to support the 5.x API set. Per Microsoft's
-[REST API versioning table](https://learn.microsoft.com/en-us/azure/devops/integrate/concepts/rest-api-versioning),
-API 5.0 arrived with Azure DevOps Server 2019 and TFS 2018 tops out at 4.0. There is no
-upper bound: newer servers keep accepting older `api-version` values.
+Two fields differ from Azure DevOps Services:
 
-2019 RTM is the edge case — 5.1 specifically shipped in 2019 Update 1, so quote that as
-the floor.
+| Field | What to enter |
+|-------|---------------|
+| **Collection** | The path segment before the project in your URL — usually `DefaultCollection`. In `https://azuredevops.company.com/DefaultCollection/my-project`, that is `DefaultCollection`. |
+| **Server URL** | Your server address, e.g. `https://azuredevops.company.com/`. Repositories are cloned from this host. |
 
 #### Windows / NTLM authentication
 
 Azure DevOps Server is often deployed behind Windows authentication, where personal access
-tokens are disabled and the server answers with `WWW-Authenticate: NTLM`. To use it, fill in
-the **Username** field (`DOMAIN\\username`) alongside the token, which is then treated as
-the account password.
+tokens are disabled. To use it, fill in the **Username** field as `DOMAIN\username`; the
+token field is then treated as that account's password.
 
-Leaving Username empty keeps the PAT behaviour exactly as it was, so this cannot affect an
-existing configuration. Even with it set, the negotiator only performs an NTLM handshake if
-the server actually asks for one — a server that accepts basic authentication never sees a
-difference.
-
-> **Not yet verified against a live Windows-authenticated server.** The handshake is covered
-> by tests against a mock that behaves like IIS, and the PAT path is verified end to end,
-> but no NTLM-enabled Azure DevOps Server was available to test interoperability. Treat the
-> first real use as a trial.
-
-> The `Apiver` field in an Azure configuration has no effect. The connector builds an SDK
-> client rather than composing URLs itself, so the SDK's own version is what gets sent.
-> This is equally true of Azure DevOps Services and predates Server support.
-
+Leave **Username** empty if your server accepts a personal access token — that is the
+default behaviour and is unaffected.
 
 ---
 
-### Optional Parameters
+### Advanced options
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `DefaultBranch` | bool | `true` (default) = count each repository's default branch. `false` = count its most recently active branch instead. See [Which branch is counted](#which-branch-is-counted). |
-| `Branch` | string | Count this branch name in every repository instead. Requires `DefaultBranch: false`. |
-| `Period` | int | How far back to look when deciding which branch is most active, in months (e.g. `-1` = the last month). Only used when `DefaultBranch: false` and `Branch` is empty. Default `-1`; Bitbucket Data Center `-5`. |
-| `Multithreading` | bool | Enable parallel analysis. Default: `true`. |
-| `Workers` | int | Concurrent workers. Default: `10`. |
-| `FolderKeywords` | array | Exclude folders whose name contains the keyword as a whole word at any depth. Word boundaries are delimiters `-`, `_`, `.` — so `"test"` matches `integration-test/` and `test_helpers/` but not `protest/` or `latest/`. |
-| `FileNamePatterns` | array | Exclude files whose name matches a glob pattern (e.g. `["*_test.go", "*.min.js", "*.spec.ts"]`). The `*` wildcard is matched against the file name only, not the full path. |
-| `ExtExclusion` | array | Exclude all files with these extensions, regardless of language (e.g. `[".css", ".html"]`). |
-| `ExcludeTests` | bool | Shortcut that adds common test-directory keywords to `FolderKeywords`: `test`, `tests`, `spec`, `specs`, `e2e`, `testdata`, `fixtures`, `mock`, `mocks`, `integration`, `doc`, `docs`. The last three match SonarQube, which treats a file as a test — and so leaves it out of `ncloc` — when any directory on its path is named `doc`, `docs`, `test`, `tests`, `mock` or `mocks`. |
-| `ExcludeVendor` | bool | Shortcut that adds common vendor-directory keywords to `FolderKeywords`: `vendor`, `node_modules`, `bower_components`, `third_party`, `external`. |
-| `Project` | string | Limit to a specific project key (Bitbucket, Azure DevOps, Azure DevOps Server). |
-| `Repos` | string | Limit to specific repositories (comma-separated). GitHub/GHE: repository name. Bitbucket: repository slug. Azure DevOps and Azure DevOps Server: repository name. Not applicable for GitLab — use the Group URL slug field instead. |
-| `Org` | bool | `true` = analyze an organization account, `false` = analyze a personal account. GitHub and GitHub Enterprise only. Default: `true`. |
-| `Organization` | string | The organization (Azure DevOps Services) or the **collection** (Azure DevOps Server, e.g. `DefaultCollection`). For Azure DevOps Server also set `Url` to your server address; the clone host is taken from it. |
-| `WorkDir` | string | Base directory where repositories are cloned before counting, then deleted. Leave blank to use the system temp directory (the default). Set this to a path on a disk with enough free space when `/tmp` is small or RAM-backed and large/many repos fail with `no space left on device`. The directory is created if missing and must be writable. Can also be set globally with the `GOLC_WORKDIR` environment variable; the per-platform `WorkDir` value takes precedence over the environment variable. |
+Click **Show advanced options** on the configuration screen. Everything below is optional;
+the defaults are appropriate for most scans.
 
+Fields that do not apply to the platform you picked are hidden automatically.
+
+#### Branch
+
+| Option | Default | What it does |
+|--------|---------|--------------|
+| **Analyze default branch only** | On | Counts each repository's default branch. Turn it off to count the most recently active branch instead — see [Which branch is counted](#which-branch-is-counted). |
+| **Specific branch name** | empty | Counts this exact branch in every repository (e.g. `develop`). Only available when *Analyze default branch only* is off. |
+
+#### Performance
+
+| Option | Default | What it does |
+|--------|---------|--------------|
+| **Enable multithreading** | On | Analyses several repositories at once. |
+| **Number of workers** | 10 | How many repositories are analysed simultaneously. Lower it if your server rate-limits you. |
+| **Clone timeout (min)** | 15 | Per-repository deadline. A repository that takes longer is skipped and listed in the report rather than stalling the whole scan. `0` disables the deadline. |
+| **Working directory for clones** | empty | Where repositories are cloned before counting, then deleted. Leave blank to use the system temp directory. Set it to a disk with free space if large scans fail with `no space left on device`. |
+
+#### Scope
+
+| Option | Shown for | What it does |
+|--------|-----------|--------------|
+| **Analyze as organization** | GitHub, GitHub Enterprise | On for an organization account, off for a personal account. |
+| **Specific project key** | Bitbucket Cloud, Bitbucket Data Center, Azure DevOps, Azure DevOps Server | Limits the scan to one project. |
+| **Specific repositories** | all except GitLab and File mode | Limits the scan to a comma-separated list. GitHub, Azure DevOps: repository names. Bitbucket: repository slugs. For GitLab, use the **Group URL slug(s)** field on the main form instead. |
+
+#### Exclusions
+
+Three presets add sets of folder names in one click:
+
+| Preset | Folders excluded |
+|--------|------------------|
+| **Test directories** | `test`, `tests`, `spec`, `specs`, `e2e`, `testdata`, `fixtures`, `mock`, `mocks`, `integration`, `doc`, `docs` |
+| **Vendor & modules** | `vendor`, `node_modules`, `bower_components`, `third_party`, `external` |
+| **Build output** | `dist`, `build`, `out`, `target`, `bin`, `coverage` |
+
+> **Test directories** matches SonarQube, which treats a file as test code — and so leaves
+> it out of `ncloc` — when any folder on its path is named `doc`, `docs`, `test`, `tests`,
+> `mock` or `mocks`.
+
+And three fields for anything else:
+
+| Field | What it does |
+|-------|--------------|
+| **Exclude folder keywords** | Skips folders whose name contains the keyword as a whole word, at any depth. Words are split on `-`, `_` and `.`, so `test` matches `integration-test/` and `test_helpers/` but not `protest/` or `latest/`. |
+| **Exclude file name patterns** | Skips files whose name matches a glob, e.g. `*_test.go, *.min.js, *.spec.ts`. Matched against the file name only, not the full path. |
+| **Exclude extensions** | Skips every file with these extensions regardless of language, e.g. `.css, .html`. |
+
+> Exclusions apply while counting, so excluded files never reach the totals. To drop a
+> repository *after* a scan instead, use the checkboxes on the results dashboard — see
+> [Excluding repositories from the totals](#excluding-repositories-from-the-totals).
 
 ---
 
@@ -143,18 +167,17 @@ Which one depends on the **Analyze default branch only** switch in the UI:
 | **Off** | the **most recently active** branch | Your main line of work is not the default branch. |
 | **Off** + *Specific branch name* | that **exact branch**, in every repository | You size a named branch such as `develop` or `release/2025`. |
 
-"Most recently active" means the branch with the most commits in the last `Period`
-months (`-1` by default, so the last month).
+"Most recently active" means the branch with the most commits in the last month.
 
 > **If no branch has commits in that window, GoLC falls back to the default branch.** For
-> repositories that have been quiet, turning the switch off therefore changes nothing.
-> Widen `Period` (for example `-12`) if you want a longer history taken into account.
+> repositories that have been quiet, turning the switch off therefore changes nothing —
+> use *Specific branch name* if you need a particular branch counted regardless of activity.
 
 ---
 
 ## Reports
 
-After each run, GoLC writes all reports to a `Results/` folder next to the binary. This is always the case regardless of how the binary was launched (double-click, terminal, or PATH). Click **View Results** in the browser to open the interactive dashboard, or navigate to the folder directly.
+After each run, GoLC writes all reports to a `Results/` folder next to the binary. Click **View Results** in the browser to open the interactive dashboard, or open the folder directly.
 
 ### File tree view
 
@@ -214,11 +237,11 @@ The same information reaches the reports:
 | Report | Languages shown |
 |--------|-----------------|
 | `repository_summary.csv` / `.json` | all three, in fixed columns so a spreadsheet can sort or pivot on them |
-| `repository_summary.pdf` | the main language (the table has no room for three) |
+| `repository_summary.pdf` | the main language |
 | `GlobalReport.pdf` | the main language of each of the Top 30 repositories |
 
 > JSON is excluded from these rankings, exactly as it is excluded from the code-line
-> totals they sit beside. A repository whose by-language results are missing shows `—`.
+> totals they sit beside.
 
 ### Excluding repositories from the totals
 
@@ -228,10 +251,8 @@ dashboard, the **Lines of Code by Repository** table has a checkbox per reposito
 Uncheck the ones to leave out and click **Apply selection** — the totals, language
 breakdown, and chart update immediately.
 
-This works on every platform (GitHub, GitHub Enterprise, GitLab, Bitbucket
-Cloud/Data Center, Azure DevOps, and local directories), because it operates on the
-analysis results rather than on any platform API. **No re-scan is needed** — the
-repositories were already counted, and only the totals are recomputed.
+This works on every platform, and **no re-scan is needed** — the repositories were
+already counted, so only the totals are recomputed.
 
 #### Original and customized reports
 
@@ -246,26 +267,22 @@ The original is never overwritten, so it is always available for comparison. Dow
 are named `..._full-scan.pdf` and `..._selection.pdf` so the two cannot be confused
 once detached from the dashboard.
 
-Reports are generated **when you click them**, not when you change the selection, so
-applying a selection is instant and no PDF is ever served stale. The first click after
-a change takes a moment while the report is built. (GoLC also rebuilds them in the
-background after a change, so anything reading `Results/` directly — a script, a CI
-job — finds current files too.)
+Reports are generated **when you click them**, so applying a selection is instant and no
+PDF is ever served stale. The first click after a change takes a moment while the report
+is built.
 
 Both PDFs and the CSV state what was excluded and what the unfiltered total was, and
 the customized report's headline figures are explicitly labelled *(filtered)*, so a
 filtered report can be handed to a customer without misleading them.
 
-**It is always reversible.** The per-repository result files are never modified and
-`GlobalReport.json` keeps the figures as scanned, so **Reset to full scan** restores
-the original figures exactly. The selection is stored in
-`Results/config/deselected_repos.json` and survives a dashboard restart. At least one
-repository must remain selected.
+**It is always reversible.** **Reset to full scan** restores the original figures
+exactly. The selection survives a dashboard restart, and at least one repository must
+remain selected.
 
 > A new analysis run clears the selection: it rediscovers repositories from scratch,
 > so a selection made against the previous run could silently drop repositories from
-> the new totals. To exclude repositories *before* a scan instead, so they are never
-> cloned, use the platform's `FileExclusion` file in `config.json`.
+> the new totals. To limit a scan *before* it runs, use **Specific repositories** or
+> **Specific project key** under [Advanced options](#advanced-options).
 
 ---
 
@@ -326,15 +343,12 @@ YAML               | .yaml, .yml                              | #               
 
 ### Infrastructure-as-code, detected by content
 
-A Kubernetes manifest, an Ansible playbook and an arbitrary settings file are all
-`.yaml`, so extension alone cannot tell them apart — and the difference changes the
-count. SonarQube analyses every IaC dialect **by default**, while plain YAML and JSON
-analysis are **off** by default (`sonar.yaml.activate` and `sonar.json.activate`). A
-stock SonarQube therefore counts a Kubernetes manifest and ignores the plain YAML beside
-it, so reporting all `.yaml` under one label cannot match it either way.
+A Kubernetes manifest, an Ansible playbook and an ordinary settings file are all `.yaml`,
+so the extension alone cannot tell them apart — and the difference matters, because a
+stock SonarQube counts infrastructure-as-code but not plain YAML or JSON.
 
-These are recognised from file content (or, for GitHub Actions, from its path) and
-reported as their own language. Comment syntax is inherited from the host format:
+GoLC recognises these from the file's content (or, for GitHub Actions, its path) and
+reports each as its own language, so the breakdown lines up with SonarQube:
 
 Language               | Recognised by
 -----------------------+--------------------------------------------------------------
@@ -345,22 +359,19 @@ Azure Pipelines        | `stages:`/`jobs:`/`steps:` together with `pool:`/`trigg
 GitHub Actions         | any file under `.github/workflows/`
 Azure Resource Manager | JSON whose `$schema` names a `deploymentTemplate`
 
-Anything unrecognised stays `YAML` or `JSON`. Only those two languages are ever
-inspected; every other file is classified from its extension without being opened.
+Anything unrecognised stays `YAML` or `JSON`.
 
 ### Minified JavaScript and CSS are never counted
 
-SonarQube excludes minified files from analysis, so they never reach `ncloc`. GoLC applies
-the same test, ported from SonarJS so the two agree by construction
-([`filter-minified.ts`](https://github.com/SonarSource/SonarJS/blob/master/packages/analysis/src/common/filter/filter-minified.ts)):
+SonarQube excludes minified files, so they never reach `ncloc`. GoLC applies the same
+test — a file is treated as minified when:
 
 - the name ends in `.min.js`, `-min.js`, `.min.css` or `-min.css`; **or**
-- the file is `.js` or `.css` **and** its average line length exceeds **200** characters.
+- it is a `.js` or `.css` file whose average line length exceeds **200** characters.
 
-The second test is what catches a bundle committed under an ordinary name such as
-`vendor.js`. Note it applies only to `.js` and `.css` — a long-lined `.ts` file is still
-counted, because SonarQube counts it too. A file that cannot be read is counted rather
-than dropped.
+The second rule catches a bundle committed under an ordinary name such as `vendor.js`. It
+applies only to `.js` and `.css` — a long-lined `.ts` file is still counted, because
+SonarQube counts it too.
 
 ### PHP open and close tags
 

--- a/golc.go
+++ b/golc.go
@@ -468,6 +468,17 @@ func AnalyseReposList(DestinationResult string, platformConfig map[string]interf
 	wg.Wait()
 	close(results)
 
+	// Every worker reports exactly once, on success and on each error path alike, so a
+	// missing report means one neither finished nor failed - it disappeared. Counting
+	// them is what turns that into a visible number: returning `total` here would report
+	// repositories *found* under a heading that says *analyzed*, so a repository that
+	// vanished would be counted in the summary and its absence never mentioned. Silent
+	// omission is the worst failure mode for a tool used to size a licence.
+	analysed := 0
+	for range results {
+		analysed++
+	}
+
 	// Persist the skipped repositories so the ResultsAll web page and the PDF report
 	// can surface them. DestinationResult is the base Results directory at this point.
 	skippedList := skipped.snapshot()
@@ -477,8 +488,13 @@ func AnalyseReposList(DestinationResult string, platformConfig map[string]interf
 	if len(skippedList) > 0 {
 		logger.Warnf("⚠️  %d repository(ies) were skipped during analysis (see report for details)", len(skippedList))
 	}
+	if analysed < total {
+		logger.Errorf("❌ %d of %d repositories did not complete analysis and are missing from the "+
+			"totals, with no error of their own. The reported lines of code are therefore an "+
+			"under-count - re-run before relying on them.", total-analysed, total)
+	}
 
-	return total
+	return analysed
 }
 
 func getExcludePaths(configValue interface{}) []string {

--- a/golc.go
+++ b/golc.go
@@ -413,6 +413,14 @@ func addFileToZip(filePath, relPath string, fileInfo os.FileInfo, zipWriter *zip
 }
 
 // Generic function to analyze repositories
+// Outcomes a worker reports on the results channel. The value distinguishes a repository
+// whose lines are in the totals from one whose are not; the message itself only says the
+// worker reached an exit, which every failure path does too.
+const (
+	repoAnalysed = 1
+	repoSkipped  = 0
+)
+
 func AnalyseReposList(DestinationResult string, platformConfig map[string]interface{}, repolist interface{}, analyseRepoFunc func(project interface{}, DestinationResult string, platformConfig map[string]interface{}, spin *spinner.Spinner, results chan int, count *atomic.Int64)) (cpt int) {
 	//fmt.Print("\n🔎 Analysis of Repos ...\n")
 	logger.Infof("🔎 Analysis of Repos ...\n")
@@ -468,15 +476,22 @@ func AnalyseReposList(DestinationResult string, platformConfig map[string]interf
 	wg.Wait()
 	close(results)
 
-	// Every worker reports exactly once, on success and on each error path alike, so a
-	// missing report means one neither finished nor failed - it disappeared. Counting
-	// them is what turns that into a visible number: returning `total` here would report
-	// repositories *found* under a heading that says *analyzed*, so a repository that
-	// vanished would be counted in the summary and its absence never mentioned. Silent
-	// omission is the worst failure mode for a tool used to size a licence.
-	analysed := 0
-	for range results {
-		analysed++
+	// Every worker reports exactly once, on success and on each error path alike, so there
+	// are two distinct ways for the headline to be wrong and both have to be separated out.
+	//
+	// A repository that reports nothing at all neither finished nor failed - it disappeared,
+	// and `total` would count it under a heading that says *analyzed*.
+	//
+	// A repository that reports a skip did fail, loudly, and its lines are just as absent
+	// from the totals - so counting reports rather than successes would put it in the
+	// headline too. That is the narrower mistake and the easier one to miss, because the
+	// skip warning is printed either way and looks like the whole story.
+	//
+	// Hence the outcome travels on the channel instead of a bare tally.
+	analysed, completed := 0, 0
+	for outcome := range results {
+		completed++
+		analysed += outcome
 	}
 
 	// Persist the skipped repositories so the ResultsAll web page and the PDF report
@@ -488,10 +503,22 @@ func AnalyseReposList(DestinationResult string, platformConfig map[string]interf
 	if len(skippedList) > 0 {
 		logger.Warnf("⚠️  %d repository(ies) were skipped during analysis (see report for details)", len(skippedList))
 	}
+
+	// Spell out the arithmetic whenever the headline is not the whole story. "28 analyzed"
+	// on its own invites the reading that 28 is all there was; saying what became of the
+	// other two is the difference between a number and an accounted-for number.
 	if analysed < total {
+		logger.Warnf("⚠️  %d repositories found: %d analyzed, %d skipped. The totals below cover "+
+			"the %d analyzed only.", total, analysed, total-analysed, analysed)
+	}
+
+	// A repository that reported nothing at all is the worse case: it did not fail, so it
+	// contributes no skip entry and no error message anywhere. Without this it would leave
+	// the totals quietly short with nothing to point at.
+	if vanished := total - completed; vanished > 0 {
 		logger.Errorf("❌ %d of %d repositories did not complete analysis and are missing from the "+
 			"totals, with no error of their own. The reported lines of code are therefore an "+
-			"under-count - re-run before relying on them.", total-analysed, total)
+			"under-count - re-run before relying on them.", vanished, total)
 	}
 
 	return analysed
@@ -1053,12 +1080,15 @@ func performRepoAnalysis(params RepoParams, DestinationResult string, spin *spin
 	// recordSkip notes that this repository/branch could not be analyzed so it can be
 	// surfaced (with a reason) in the web page and PDF report instead of silently
 	// vanishing from the totals.
+	// The reason is condensed first: a clone refused by IIS arrives with the whole 401 page
+	// attached, and storing that verbatim buries the diagnosis under kilobytes of stylesheet
+	// in the very file the web page and the PDF report read to explain what went missing.
 	recordSkip := func(reason string) {
 		skipped.add(skippedRepo{
 			ProjectKey: params.ProjectKey,
 			RepoSlug:   params.RepoSlug,
 			Branch:     params.MainBranch,
-			Reason:     reason,
+			Reason:     utils.CondenseHTMLError(reason),
 		})
 	}
 
@@ -1069,10 +1099,10 @@ func performRepoAnalysis(params RepoParams, DestinationResult string, spin *spin
 	gc, err := goloc.NewGCloc(golocParams, assets.Languages)
 	if err != nil {
 		spin.Stop()
-		logger.Errorf(errorMessageRepo+"%v", err)
+		logger.Errorf(errorMessageRepo+"%v", utils.CondenseHTMLError(err.Error()))
 		recordSkip(err.Error())
 		count.Add(1)
-		results <- 1
+		results <- repoSkipped
 		return
 	} else {
 
@@ -1100,7 +1130,7 @@ func performRepoAnalysis(params RepoParams, DestinationResult string, spin *spin
 				logger.Errorf("❌ Error during analysis with ByAll = true: %v", err)
 				recordSkip(fmt.Sprintf("analysis error: %v", err))
 				count.Add(1)
-				results <- 1
+				results <- repoSkipped
 				return
 			}
 
@@ -1116,7 +1146,7 @@ func performRepoAnalysis(params RepoParams, DestinationResult string, spin *spin
 				logger.Errorf("❌ Error initializing GCloc for ByFile = false: %v", err)
 				recordSkip(fmt.Sprintf("analysis error: %v", err))
 				count.Add(1)
-				results <- 1
+				results <- repoSkipped
 				return
 			}
 
@@ -1125,7 +1155,7 @@ func performRepoAnalysis(params RepoParams, DestinationResult string, spin *spin
 				logger.Errorf("❌ Error during analysis with ByFile = false: %v", err)
 				recordSkip(fmt.Sprintf("analysis error: %v", err))
 				count.Add(1)
-				results <- 1
+				results <- repoSkipped
 				return
 			}
 		} else {
@@ -1135,7 +1165,7 @@ func performRepoAnalysis(params RepoParams, DestinationResult string, spin *spin
 				logger.Errorf("❌ Error during analysis: %v", err)
 				recordSkip(fmt.Sprintf("analysis error: %v", err))
 				count.Add(1)
-				results <- 1
+				results <- repoSkipped
 				return
 			}
 		}
@@ -1146,7 +1176,7 @@ func performRepoAnalysis(params RepoParams, DestinationResult string, spin *spin
 		spin.Stop()
 		logger.Infof("\r\t\t\t\t✅ %d The repository <%s> has been analyzed\n", count.Add(1), params.RepoSlug)
 		// Send result through channel
-		results <- 1
+		results <- repoAnalysed
 	}
 }
 

--- a/golc.go
+++ b/golc.go
@@ -506,16 +506,36 @@ func AnalyseReposList(DestinationResult string, platformConfig map[string]interf
 
 	// Spell out the arithmetic whenever the headline is not the whole story. "28 analyzed"
 	// on its own invites the reading that 28 is all there was; saying what became of the
-	// other two is the difference between a number and an accounted-for number.
+	// others is the difference between a number and an accounted-for number.
+	//
+	// Both shortfalls are counted from the channel rather than one from the channel and one
+	// from skippedList, so the three figures are guaranteed to add up to the total: they come
+	// from the same messages. Deriving them from two mechanisms would let the line disagree
+	// with itself the moment they ever diverged.
+	//
+	// They are also named separately. A repository that failed and one that disappeared need
+	// different responses, and reporting their sum as "skipped" would say that the one with
+	// no error had an error - undoing the separation this exists to make.
+	skippedCount := completed - analysed
+	vanished := total - completed
+
 	if analysed < total {
-		logger.Warnf("⚠️  %d repositories found: %d analyzed, %d skipped. The totals below cover "+
-			"the %d analyzed only.", total, analysed, total-analysed, analysed)
+		outcomes := []string{fmt.Sprintf("%d analyzed", analysed)}
+		if skippedCount > 0 {
+			outcomes = append(outcomes, fmt.Sprintf("%d skipped", skippedCount))
+		}
+		if vanished > 0 {
+			outcomes = append(outcomes, fmt.Sprintf("%d did not report", vanished))
+		}
+
+		logger.Warnf("⚠️  %d repositories found: %s. The totals below cover the %d analyzed only.",
+			total, strings.Join(outcomes, ", "), analysed)
 	}
 
 	// A repository that reported nothing at all is the worse case: it did not fail, so it
 	// contributes no skip entry and no error message anywhere. Without this it would leave
 	// the totals quietly short with nothing to point at.
-	if vanished := total - completed; vanished > 0 {
+	if vanished > 0 {
 		logger.Errorf("❌ %d of %d repositories did not complete analysis and are missing from the "+
 			"totals, with no error of their own. The reported lines of code are therefore an "+
 			"under-count - re-run before relying on them.", vanished, total)

--- a/golc_analysed_count_test.go
+++ b/golc_analysed_count_test.go
@@ -129,3 +129,88 @@ func TestAnalyseReposListCountsWithMultithreadingOff(t *testing.T) {
 		t.Errorf("count = %d, want 3", got)
 	}
 }
+
+// A skipped repository reports on the channel like any other - the skip path sends before it
+// returns. Counting messages therefore counts skips as analysed, which is how a run that
+// skipped two of thirty still announced "30 analyzed" while printing a two-repository skip
+// warning directly above it. The lines of a skipped repository are absent from the totals just
+// as surely as those of one that vanished, so it must not appear in the headline.
+func TestAnalyseReposListExcludesSkippedRepositories(t *testing.T) {
+	out := captureLog(t)
+
+	// Two of five fail: they report, but as skips.
+	analyse := func(project interface{}, _ string, _ map[string]interface{},
+		_ *spinner.Spinner, results chan int, _ *atomic.Int64) {
+		if project.(int) < 2 {
+			results <- repoSkipped
+			return
+		}
+		results <- repoAnalysed
+	}
+
+	got := AnalyseReposList(t.TempDir(), testPlatformConfig(true), testRepos(5), analyse)
+
+	if got != 3 {
+		t.Errorf("count = %d, want 3: two repositories were skipped, so their lines are not in "+
+			"the totals and they cannot be part of the analyzed headline", got)
+	}
+	if !strings.Contains(out.String(), "5 repositories found: 3 analyzed, 2 skipped") {
+		t.Errorf("the shortfall was not accounted for in the log; got:\n%s", out.String())
+	}
+}
+
+// A skip is a reported outcome, not a disappearance. Raising the "did not complete ... with no
+// error of their own" alarm for it would be false: the repository did fail, visibly, and is
+// already in the skip report. Crying wolf here devalues the alarm for the case that has no
+// other signal at all.
+func TestAnalyseReposListDoesNotCallASkipAVanishedRepository(t *testing.T) {
+	out := captureLog(t)
+
+	analyse := func(project interface{}, _ string, _ map[string]interface{},
+		_ *spinner.Spinner, results chan int, _ *atomic.Int64) {
+		if project.(int) == 0 {
+			results <- repoSkipped
+			return
+		}
+		results <- repoAnalysed
+	}
+
+	AnalyseReposList(t.TempDir(), testPlatformConfig(true), testRepos(3), analyse)
+
+	if strings.Contains(out.String(), "did not complete") {
+		t.Errorf("a skipped repository was reported as having vanished:\n%s", out.String())
+	}
+}
+
+// The two failure modes are independent and can happen in the same run, so the report has to
+// keep them apart: one repository skipped and one gone must not be summed into "two of
+// something" - they need different actions from whoever reads it.
+func TestAnalyseReposListSeparatesSkippedFromVanished(t *testing.T) {
+	out := captureLog(t)
+
+	analyse := func(project interface{}, _ string, _ map[string]interface{},
+		_ *spinner.Spinner, results chan int, _ *atomic.Int64) {
+		switch project.(int) {
+		case 0:
+			results <- repoSkipped
+		case 1:
+			return // vanishes: no report at all
+		default:
+			results <- repoAnalysed
+		}
+	}
+
+	got := AnalyseReposList(t.TempDir(), testPlatformConfig(true), testRepos(4), analyse)
+
+	if got != 2 {
+		t.Errorf("count = %d, want 2 (4 found, 1 skipped, 1 vanished)", got)
+	}
+
+	logged := out.String()
+	if !strings.Contains(logged, "4 repositories found: 2 analyzed, 2 skipped") {
+		t.Errorf("the shortfall total is wrong; got:\n%s", logged)
+	}
+	if !strings.Contains(logged, "1 of 4 repositories did not complete") {
+		t.Errorf("the vanished repository was not called out separately; got:\n%s", logged)
+	}
+}

--- a/golc_analysed_count_test.go
+++ b/golc_analysed_count_test.go
@@ -1,0 +1,131 @@
+//go:build golc
+// +build golc
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/briandowns/spinner"
+)
+
+// testPlatformConfig is the minimum AnalyseReposList reads: the three concurrency keys.
+func testPlatformConfig(multithreading bool) map[string]interface{} {
+	return map[string]interface{}{
+		"Multithreading":    multithreading,
+		"NumberWorkerRepos": float64(4),
+		"Workers":           float64(2),
+	}
+}
+
+// captureLog redirects the package logger for one test and restores it afterwards.
+// Restoring to nil instead would leave the next test writing to a nil writer, which panics
+// inside logrus - a failure that shows up in an unrelated test and points nowhere useful.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	var out bytes.Buffer
+	previous := logger.Out
+	logger.SetOutput(&out)
+	t.Cleanup(func() { logger.SetOutput(previous) })
+
+	return &out
+}
+
+func testRepos(n int) []interface{} {
+	repos := make([]interface{}, n)
+	for i := range repos {
+		repos[i] = i
+	}
+
+	return repos
+}
+
+// The count AnalyseReposList returns is displayed as the number of repositories *analyzed*.
+// Returning the number *found* instead makes a repository that vanished mid-run indissoluble
+// from one that was counted, so the totals under-report with nothing to say they did. In a
+// tool used to size a licence that is the worst way to be wrong: quietly.
+func TestAnalyseReposListCountsAnalysedNotFound(t *testing.T) {
+	var reported atomic.Int64
+
+	// Repo 2 returns without reporting - the disappearance being guarded against.
+	analyse := func(project interface{}, _ string, _ map[string]interface{},
+		_ *spinner.Spinner, results chan int, _ *atomic.Int64) {
+		if project.(int) == 2 {
+			return
+		}
+		reported.Add(1)
+		results <- 1
+	}
+
+	got := AnalyseReposList(t.TempDir(), testPlatformConfig(true), testRepos(5), analyse)
+
+	if got != 4 {
+		t.Errorf("count = %d, want 4: one of the five repositories never completed, so "+
+			"reporting %d would count a repository whose lines are absent from the totals",
+			got, got)
+	}
+	if reported.Load() != 4 {
+		t.Fatalf("the fake reported %d times, so the test is not exercising what it claims",
+			reported.Load())
+	}
+}
+
+// The mismatch has to be said out loud. A number that is quietly lower than expected reads as
+// "that is how big the estimate is", not as "part of the estimate is missing".
+func TestAnalyseReposListLogsWhenRepositoriesGoMissing(t *testing.T) {
+	out := captureLog(t)
+
+	analyse := func(project interface{}, _ string, _ map[string]interface{},
+		_ *spinner.Spinner, results chan int, _ *atomic.Int64) {
+		if project.(int) == 0 {
+			return
+		}
+		results <- 1
+	}
+
+	AnalyseReposList(t.TempDir(), testPlatformConfig(true), testRepos(3), analyse)
+
+	logged := out.String()
+	if !strings.Contains(logged, "1 of 3 repositories did not complete") {
+		t.Errorf("missing repositories were not reported; log was:\n%s", logged)
+	}
+	if !strings.Contains(logged, "under-count") {
+		t.Errorf("the log does not say the totals are wrong, only that something happened; "+
+			"log was:\n%s", logged)
+	}
+}
+
+// The complement, and the case that runs every day: when nothing goes missing there must be no
+// warning at all. A tool that cries wolf on healthy scans gets its warnings tuned out.
+func TestAnalyseReposListIsSilentWhenEveryRepositoryCompletes(t *testing.T) {
+	out := captureLog(t)
+
+	analyse := func(_ interface{}, _ string, _ map[string]interface{},
+		_ *spinner.Spinner, results chan int, _ *atomic.Int64) {
+		results <- 1
+	}
+
+	if got := AnalyseReposList(t.TempDir(), testPlatformConfig(true), testRepos(3), analyse); got != 3 {
+		t.Errorf("count = %d, want 3", got)
+	}
+	if strings.Contains(out.String(), "did not complete") {
+		t.Errorf("a healthy scan warned about missing repositories:\n%s", out.String())
+	}
+}
+
+// Sequential mode takes the same path with concurrency pinned to 1, and the drain must not
+// deadlock there either - the channel is buffered to the repository count for that reason.
+func TestAnalyseReposListCountsWithMultithreadingOff(t *testing.T) {
+	analyse := func(_ interface{}, _ string, _ map[string]interface{},
+		_ *spinner.Spinner, results chan int, _ *atomic.Int64) {
+		results <- 1
+	}
+
+	if got := AnalyseReposList(t.TempDir(), testPlatformConfig(false), testRepos(3), analyse); got != 3 {
+		t.Errorf("count = %d, want 3", got)
+	}
+}

--- a/golc_analysed_count_test.go
+++ b/golc_analysed_count_test.go
@@ -207,8 +207,15 @@ func TestAnalyseReposListSeparatesSkippedFromVanished(t *testing.T) {
 	}
 
 	logged := out.String()
-	if !strings.Contains(logged, "4 repositories found: 2 analyzed, 2 skipped") {
-		t.Errorf("the shortfall total is wrong; got:\n%s", logged)
+
+	// One of each. Summing them into "2 skipped" would say the repository that reported
+	// nothing had reported a failure, which is exactly the conflation this test exists to
+	// prevent - and it would contradict the "did not complete" line printed just below it.
+	if !strings.Contains(logged, "4 repositories found: 2 analyzed, 1 skipped, 1 did not report") {
+		t.Errorf("the two shortfalls were not named separately; got:\n%s", logged)
+	}
+	if strings.Contains(logged, "2 skipped") {
+		t.Errorf("the vanished repository was counted as skipped; got:\n%s", logged)
 	}
 	if !strings.Contains(logged, "1 of 4 repositories did not complete") {
 		t.Errorf("the vanished repository was not called out separately; got:\n%s", logged)

--- a/golc_workdir_test.go
+++ b/golc_workdir_test.go
@@ -123,10 +123,19 @@ func TestPerformRepoAnalysisLocalDir(t *testing.T) {
 	results := make(chan int, 1)
 	var count atomic.Int64
 
+	// The real flow creates the Results tree before any analysis runs; calling
+	// performRepoAnalysis directly skips that, and without it the report write fails with
+	// "no such file or directory". The test used to pass anyway, because every exit path -
+	// success and failure alike - signalled the same value, so asserting on it proved
+	// nothing. It now signals the outcome, so the setup has to be real for the assertion
+	// to mean what it says.
+	createDirectories(dest, directoriesToCreate)
+
 	performRepoAnalysis(params, dest, spin, results, &count, analysisOptions{})
 
-	if got := <-results; got != 1 {
-		t.Errorf("expected 1 result signal, got %d", got)
+	if got := <-results; got != repoAnalysed {
+		t.Errorf("expected the repository to be analysed (%d), got %d; skipped: %v",
+			repoAnalysed, got, skipped.snapshot())
 	}
 	// Non-disposable source dir must NOT be deleted by the cleanup defer.
 	if _, err := os.Stat(src); err != nil {

--- a/pkg/devops/getazure/errors.go
+++ b/pkg/devops/getazure/errors.go
@@ -1,0 +1,65 @@
+package getazure
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// When authentication fails, Azure DevOps Server does not answer with JSON. IIS returns its
+// HTML sign-in page, and the Azure SDK - which assumes every response is JSON - feeds that
+// page to a decoder. What reaches the user is:
+//
+//	invalid character '<' looking for beginning of value
+//
+// which describes the first byte of "<html>" and says nothing about credentials. Someone
+// reading it looks for a corrupt response or a bug in the parser; the actual problem is that
+// the server rejected the login. The SDK cannot be fixed from here, but the error passes
+// through this package, and this is the point at which what was being attempted is still
+// known - so it is the point at which it can be said.
+//
+// The same signature also appears when the URL is not an Azure DevOps API endpoint at all
+// (a wrong collection, a reverse proxy serving its own error page), so the message names
+// both causes rather than asserting the more common one.
+
+// describeAzureError rewrites the HTML-decoded-as-JSON error into one that names the likely
+// cause. Any other error is returned unchanged - guessing about errors that already read
+// clearly would only add noise.
+func describeAzureError(err error, apiURL, username string) error {
+	if err == nil || !isHTMLResponse(err) {
+		return err
+	}
+
+	authentication := "a personal access token"
+	if username != "" {
+		authentication = fmt.Sprintf("Windows authentication as %q", username)
+	}
+
+	return fmt.Errorf("%s returned an HTML page where the API should return JSON, which "+
+		"almost always means the request was not authenticated: the credentials were "+
+		"rejected and the sign-in page came back instead. Check that %s is accepted by this "+
+		"server, and that the URL points at the collection (the segment before the project) "+
+		"rather than at the server root. Underlying error: %w",
+		apiURL, authentication, err)
+}
+
+// isHTMLResponse reports whether err is a JSON decoder complaining about a '<' - the opening
+// byte of an HTML document.
+//
+// The '<' has to be part of the test. A *json.SyntaxError on its own only says the response
+// was not valid JSON, which a truncated or corrupt API reply is too; claiming those were
+// authentication failures would replace one misleading message with another. So the type is
+// checked to establish it came from the JSON decoder, and the character to establish what it
+// choked on. The bare string check catches the same failure once the SDK has flattened it
+// into a plain fmt.Errorf, which it does on some paths.
+func isHTMLResponse(err error) bool {
+	const htmlOpening = "invalid character '<'"
+
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return strings.Contains(syntaxErr.Error(), htmlOpening)
+	}
+
+	return strings.Contains(err.Error(), htmlOpening)
+}

--- a/pkg/devops/getazure/errors_test.go
+++ b/pkg/devops/getazure/errors_test.go
@@ -1,0 +1,117 @@
+package getazure
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// htmlDecodeError reproduces what the Azure SDK produces when a server answers an API call
+// with its HTML sign-in page: the JSON decoder reads the '<' of "<html>" and stops.
+func htmlDecodeError() error {
+	var v interface{}
+
+	err := json.Unmarshal([]byte("<html><body>Sign In</body></html>"), &v)
+	if err == nil {
+		panic("expected decoding HTML as JSON to fail")
+	}
+
+	return err
+}
+
+// The message a user sees has to name the cause. "invalid character '<'" sends them looking
+// for a corrupt response; the problem is that their credentials were refused.
+func TestDescribeAzureErrorExplainsARejectedLogin(t *testing.T) {
+	got := describeAzureError(htmlDecodeError(), "https://tfs.corp.example/DefaultCollection", "DOMAIN\\jsmith")
+
+	message := got.Error()
+	for _, want := range []string{"not authenticated", "https://tfs.corp.example/DefaultCollection", "collection"} {
+		if !strings.Contains(message, want) {
+			t.Errorf("message does not mention %q; got:\n%s", want, message)
+		}
+	}
+	if !strings.Contains(message, `Windows authentication as "DOMAIN\\jsmith"`) {
+		t.Errorf("message does not name the authentication actually attempted; got:\n%s", message)
+	}
+}
+
+// Without a username the attempt was a PAT, and saying "Windows authentication" would send
+// someone to configure a domain account they do not need.
+func TestDescribeAzureErrorNamesPatWhenNoUsernameIsSet(t *testing.T) {
+	message := describeAzureError(htmlDecodeError(), "https://dev.azure.com/my-org", "").Error()
+
+	if !strings.Contains(message, "a personal access token") {
+		t.Errorf("message does not name the PAT; got:\n%s", message)
+	}
+	if strings.Contains(message, "Windows authentication") {
+		t.Errorf("message blames Windows authentication when none was attempted; got:\n%s", message)
+	}
+}
+
+// The original has to stay reachable: it is the only evidence of what actually came back, and
+// errors.Is/As on the wrapped value is how anything downstream inspects it.
+func TestDescribeAzureErrorKeepsTheUnderlyingError(t *testing.T) {
+	original := htmlDecodeError()
+
+	got := describeAzureError(original, "https://tfs.corp.example", "")
+
+	if !errors.Is(got, original) {
+		t.Error("the underlying error was not wrapped, so the real response is unrecoverable")
+	}
+
+	var syntaxErr *json.SyntaxError
+	if !errors.As(got, &syntaxErr) {
+		t.Error("errors.As no longer reaches the decoder error through the wrapper")
+	}
+}
+
+// Errors that already read clearly must pass through untouched. Rewriting them would bury a
+// precise message under a guess.
+func TestDescribeAzureErrorLeavesOtherErrorsAlone(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"nil", nil},
+		{"network", errors.New("dial tcp 10.0.0.1:443: connect: connection refused")},
+		{"explicit 401", errors.New("azure devops returned 401 Unauthorized")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeAzureError(tc.err, "https://tfs.corp.example", ""); got != tc.err {
+				t.Errorf("error was rewritten: %v", got)
+			}
+		})
+	}
+}
+
+// A JSON error that is not about a '<' means the response was JSON-ish but broken - truncated,
+// or an unexpected shape. Calling that an authentication failure swaps one misleading message
+// for another, so the type check alone is not enough to act on.
+func TestDescribeAzureErrorDoesNotBlameAuthForOtherJSONErrors(t *testing.T) {
+	var v interface{}
+	truncated := json.Unmarshal([]byte(`{"value": [`), &v)
+	if truncated == nil {
+		t.Fatal("expected truncated JSON to fail decoding")
+	}
+
+	var syntaxErr *json.SyntaxError
+	if !errors.As(truncated, &syntaxErr) {
+		t.Skip("this Go version does not report truncated JSON as a *json.SyntaxError")
+	}
+
+	if got := describeAzureError(truncated, "https://tfs.corp.example", ""); got != truncated {
+		t.Errorf("a truncated JSON response was reported as an authentication failure:\n%v", got)
+	}
+}
+
+// The SDK flattens the decoder error into a plain fmt.Errorf on some paths, losing the type.
+// The text is all that survives there, so it has to be enough.
+func TestDescribeAzureErrorRecognisesTheFlattenedForm(t *testing.T) {
+	if !isHTMLResponse(errors.New(
+		"unable to parse response: invalid character '<' looking for beginning of value")) {
+		t.Error("the flattened form was not recognised, so the message stays unexplained")
+	}
+}

--- a/pkg/devops/getazure/getazure.go
+++ b/pkg/devops/getazure/getazure.go
@@ -65,6 +65,7 @@ type ParamsProjectAzure struct {
 	Projects       []core.TeamProjectReference
 	URL            string
 	AccessToken    string
+	Username       string
 	ApiURL         string
 	Organization   string
 	Exclusionlist  *utils.ExclusionList
@@ -139,7 +140,7 @@ func isRepoEmpty(ctx context.Context, gitClient git.Client, projectID string, re
 	//return len(*items) == 0, nil
 }
 
-func getAllProjects(ctx context.Context, coreClient core.Client, exclusionList *utils.ExclusionList) ([]core.TeamProjectReference, int, error) {
+func getAllProjects(ctx context.Context, coreClient core.Client, exclusionList *utils.ExclusionList, apiURL, username string) ([]core.TeamProjectReference, int, error) {
 	var allProjects []core.TeamProjectReference
 	var excludedCount int
 	var continuationToken string
@@ -150,7 +151,7 @@ func getAllProjects(ctx context.Context, coreClient core.Client, exclusionList *
 			ContinuationToken: &continuationToken,
 		})
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, describeAzureError(err, apiURL, username)
 		}
 
 		for _, project := range responseValue.Value {
@@ -175,7 +176,7 @@ func getAllProjects(ctx context.Context, coreClient core.Client, exclusionList *
 	return allProjects, excludedCount, nil
 }
 
-func getProjectByName(ctx context.Context, coreClient core.Client, projectName string, exclusionList *utils.ExclusionList) ([]core.TeamProjectReference, int, error) {
+func getProjectByName(ctx context.Context, coreClient core.Client, projectName string, exclusionList *utils.ExclusionList, apiURL, username string) ([]core.TeamProjectReference, int, error) {
 
 	var excludedCount int
 
@@ -190,7 +191,7 @@ func getProjectByName(ctx context.Context, coreClient core.Client, projectName s
 		ProjectId: &projectName,
 	})
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, describeAzureError(err, apiURL, username)
 	}
 
 	// Create a core.TeamProjectReference from core.TeamProject
@@ -259,7 +260,7 @@ func GetRepoAzureList(platformConfig map[string]interface{}, exclusionFile strin
 	if platformConfig["Project"].(string) == "" {
 
 		// Get All Project
-		projects, exludedprojects, err := getAllProjects(ctx, coreClient, exclusionList)
+		projects, exludedprojects, err := getAllProjects(ctx, coreClient, exclusionList, ApiURL, username)
 
 		if err != nil {
 			spin.Stop()
@@ -281,7 +282,7 @@ func GetRepoAzureList(platformConfig map[string]interface{}, exclusionFile strin
 		}
 
 	} else {
-		projects, exludedprojects, err := getProjectByName(ctx, coreClient, platformConfig["Project"].(string), exclusionList)
+		projects, exludedprojects, err := getProjectByName(ctx, coreClient, platformConfig["Project"].(string), exclusionList, ApiURL, username)
 		if err != nil {
 			spin.Stop()
 			log.Fatalf(MessageErro2, platformConfig["Organization"].(string), err)
@@ -358,6 +359,7 @@ func getCommonParams(azureConnect AzureConnect, platformConfig map[string]interf
 
 		URL:            platformConfig["Url"].(string),
 		AccessToken:    platformConfig["AccessToken"].(string),
+		Username:       stringOrEmpty(platformConfig["Users"]),
 		ApiURL:         apiURL,
 		Organization:   platformConfig["Organization"].(string),
 		Exclusionlist:  exclusionList,
@@ -560,7 +562,10 @@ func fetchDisabledRepoIDs(parms ParamsProjectAzure, projectKey string) map[strin
 		warn("%v", err)
 		return disabled
 	}
-	req.SetBasicAuth("", parms.AccessToken)
+	// The username matters here: an empty one is rejected outright by a
+	// Windows-authenticated server, and leaves the NTLM negotiator with no account to
+	// answer the challenge with.
+	req.SetBasicAuth(parms.Username, parms.AccessToken)
 
 	resp, err := utils.HTTPClient.Do(req)
 	if err != nil {
@@ -620,7 +625,8 @@ func listReposForProject(parms ParamsProjectAzure, projectKey string, gitClient 
 		Project: &projectKey,
 	})
 	if err != nil {
-		loggers.Errorf("Error get GetRepositories ")
+		err = describeAzureError(err, parms.URL, parms.Username)
+		loggers.Errorf("❌ Error listing repositories for project %s: %v", projectKey, err)
 		return 0, 0, 0, nil, err
 	}
 	loggers.Debugf("→ project %s: API returned %d repos", projectKey, len(*repos))

--- a/pkg/devops/getazure/getazure.go
+++ b/pkg/devops/getazure/getazure.go
@@ -48,6 +48,17 @@ type SummaryStats struct {
 	TotalExclude      int
 	TotalArchiv       int
 	TotalBranches     int
+
+	// Analyzed is how many repositories will actually be analyzed - one important
+	// branch each. It is deliberately not derived as NbRepos minus the filtered
+	// categories: a repository can also be dropped for having no branch matching the
+	// configured one, which belongs to none of those categories.
+	Analyzed int
+
+	// DiscoverySkipped counts repositories discovered but dropped before analysis
+	// without landing in any filtered category. Their lines are missing from the
+	// totals, so the figure has to be reported and not merely recorded.
+	DiscoverySkipped int
 }
 
 type AnalyzeProject struct {
@@ -325,6 +336,12 @@ func GetRepoAzureList(platformConfig map[string]interface{}, exclusionFile strin
 		os.Exit(1)
 	}
 
+	// nbRepos is the true count of discovered repos (analyzed + filtered), so any
+	// repo discovered but dropped inside the analysis loop (no usable default
+	// branch, or filtered out by single-branch selection) without landing in a
+	// category is surfaced as Skipped, keeping Scanned equal to the real total.
+	discoverySkipped := azureDiscoverySkipped(nbRepos, emptyRepo, totalExclude, totalArchiv, len(importantBranches))
+
 	stats := SummaryStats{
 		LargestRepo:       largesRepo,
 		LargestRepoBranch: largestRepoBranch,
@@ -333,17 +350,13 @@ func GetRepoAzureList(platformConfig map[string]interface{}, exclusionFile strin
 		TotalExclude:      totalExclude,
 		TotalArchiv:       totalArchiv,
 		TotalBranches:     TotalBranches,
+		Analyzed:          len(importantBranches),
+		DiscoverySkipped:  discoverySkipped,
 	}
 
 	// Persist the per-run repository breakdown for the ResultsAll page and the
 	// global PDF report. Analyzed is the number of repos that will actually be
 	// analyzed (one important branch per repo); Scanned is derived from the sum.
-	//
-	// nbRepos is the true count of discovered repos (analyzed + filtered), so any
-	// repo discovered but dropped inside the analysis loop (no usable default
-	// branch, or filtered out by single-branch selection) without landing in a
-	// category is surfaced as Skipped, keeping Scanned equal to the real total.
-	discoverySkipped := azureDiscoverySkipped(nbRepos, emptyRepo, totalExclude, totalArchiv, len(importantBranches))
 	utils.PersistScanSummary("Results", utils.NewScanSummary("azure", len(importantBranches), totalArchiv, emptyRepo, totalExclude, discoverySkipped))
 
 	printSummary(platformConfig["Organization"].(string), stats)
@@ -395,8 +408,20 @@ func printSummary(Org string, stats SummaryStats) {
 	loggers := utils.SharedLogger()
 
 	loggers.Infof("✅ The largest Repository is <%s> in the organization <%s> with the branch <%s> ", stats.LargestRepo, Org, stats.LargestRepoBranch)
-	loggers.Infof("✅ Total Repositories that will be analyzed: %d - Find empty : %d - Excluded : %d - Archived : %d", stats.NbRepos-stats.EmptyRepo-stats.TotalExclude-stats.TotalArchiv, stats.EmptyRepo, stats.TotalExclude, stats.TotalArchiv)
+
+	// Analyzed, rather than NbRepos minus the filtered categories. The two agree until
+	// a repository is dropped for having no matching branch, and then the arithmetic
+	// version overstates what is about to be counted - under a heading reading "will be
+	// analyzed", which is exactly where an operator looks for the scope of the scan.
+	loggers.Infof("✅ Total Repositories that will be analyzed: %d - Find empty : %d - Excluded : %d - Archived : %d", stats.Analyzed, stats.EmptyRepo, stats.TotalExclude, stats.TotalArchiv)
 	loggers.Infof("✅ Total Branches that will be analyzed: %d\n", stats.TotalBranches)
+
+	// These repositories appear in none of the counters above, so without this line the
+	// only trace of them is the gap between the number discovered and the number
+	// analyzed - which reads as a coincidence rather than as missing lines of code.
+	if stats.DiscoverySkipped > 0 {
+		loggers.Warnf("⚠️  %d of %d discovered repository(ies) will not be analyzed and are absent from the totals - see the reasons logged above", stats.DiscoverySkipped, stats.NbRepos)
+	}
 }
 
 func getRepoAnalyse(params ParamsProjectAzure, gitClient git.Client) ([]ProjectBranch, int, int, int, int, int, error) {
@@ -469,7 +494,11 @@ func getRepoAnalyse(params ParamsProjectAzure, gitClient git.Client) ([]ProjectB
 
 			if err != nil {
 				if params.SingleBranch != "" {
-					// Skip this repository if SingleBranch is set but not found
+					// The configured Branch does not exist here, so this repository
+					// contributes nothing to the totals. Name it: an organisation that
+					// pins "main" across a mix of "main" and "master" repositories would
+					// otherwise under-count its licence with nothing at all to point at.
+					loggers.Warnf("⚠️  Skipping repo %s/%s: no branch <%s> found - its lines are absent from the totals", *project.Name, *repo.Name, params.SingleBranch)
 					continue
 				}
 				branchName, ok := defaultBranchName(&repo)
@@ -484,7 +513,10 @@ func getRepoAnalyse(params ParamsProjectAzure, gitClient git.Client) ([]ProjectB
 			} else {
 				// Check if SingleBranch is set and the returned branch is not SingleBranch
 				if params.SingleBranch != "" && !params.DefaultB && largestRepoBranch != params.SingleBranch {
-					// Skip this repository if the most important branch is not the SingleBranch
+					// Its largest branch is not the configured one, so again nothing here
+					// will be counted. Same reasoning as above: say which repository went
+					// missing rather than leaving a hole in the total.
+					loggers.Warnf("⚠️  Skipping repo %s/%s: largest branch is <%s>, not the configured <%s> - its lines are absent from the totals", *project.Name, *repo.Name, largestRepoBranch, params.SingleBranch)
 					continue
 				}
 			}

--- a/pkg/devops/getazure/ntlm.go
+++ b/pkg/devops/getazure/ntlm.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	ntlmssp "github.com/Azure/go-ntlmssp"
+	"github.com/SonarSource-Demos/sonar-golc/pkg/utils"
 	"github.com/go-git/go-git/v5/plumbing/transport/client"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
@@ -38,6 +39,14 @@ func EnableNTLM() {
 	installNTLMOnce.Do(func() {
 		http.DefaultTransport = ntlmssp.Negotiator{RoundTripper: http.DefaultTransport}
 
+		// utils.HTTPClient carries its own Transport for connection pooling, so replacing
+		// http.DefaultTransport does not reach it. fetchDisabledRepoIDs uses that client,
+		// and without this its request is the one call in the whole Azure path that cannot
+		// authenticate - it fails, is swallowed as "no repos disabled", and every disabled
+		// repository is then counted. In a licence-sizing tool that silently inflates the
+		// total, which is the worst possible way for it to break.
+		utils.HTTPClient.Transport = ntlmssp.Negotiator{RoundTripper: utils.HTTPClient.Transport}
+
 		// go-git builds its own client, so it needs the negotiator installed separately.
 		client.InstallProtocol("https", githttp.NewClient(
 			&http.Client{Transport: ntlmssp.Negotiator{RoundTripper: &http.Transport{}}}))
@@ -64,4 +73,11 @@ func azureConnection(apiURL, username, token string) *azuredevops.Connection {
 		BaseUrl:                 strings.ToLower(strings.TrimRight(apiURL, "/")),
 		SuppressFedAuthRedirect: true,
 	}
+}
+
+// stringOrEmpty reads an optional string out of a platform configuration.
+func stringOrEmpty(v interface{}) string {
+	s, _ := v.(string)
+
+	return s
 }

--- a/pkg/devops/getazure/ntlm.go
+++ b/pkg/devops/getazure/ntlm.go
@@ -1,6 +1,7 @@
 package getazure
 
 import (
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -30,6 +31,90 @@ import (
 //     a nil Transport.
 //   - the clone itself, made by go-git, which does accept a custom client.
 
+// NTLM authenticates a *connection*, not a request. The server issues its Type2 challenge
+// against the socket it arrived on and will only accept the matching Type3 on that same
+// socket; anywhere else it answers 401.1 / 0x80090308 SEC_E_INVALID_TOKEN.
+//
+// go-ntlmssp's Negotiator performs the exchange as three separate RoundTrip calls (an
+// anonymous probe, then Type1, then Type3) and does nothing to keep them together. Handed a
+// pooled http.Transport it does not have to: between two of those calls the connection goes
+// back to the idle pool, and with several clones running at once another worker can take it.
+// The Type3 then arrives on a socket that was never challenged and the clone fails - which is
+// why one scan lost 2 of 30 repositories, both in the first batch of concurrent workers,
+// while the other 28 succeeded on identical credentials.
+//
+// Giving each request its own pool removes the sharing that makes the theft possible. Measured
+// against a server that binds challenges to connections the way IIS does:
+//
+//	pooled keep-alives (shared)      8 workers: 4 ok, 4 rejected
+//	one pool per request            32 workers: 32 ok, 0 rejected
+//
+// Note that simply disabling keep-alives, the obvious-looking fix, is worse than the disease:
+// every RoundTrip then gets a fresh connection, so Type1 and Type3 are guaranteed to land on
+// different sockets and no handshake can ever complete - it fails even single-threaded.
+
+// ntlmTransport runs each request's NTLM handshake on a connection pool of its own.
+//
+// The base is held as a pointer rather than a constructor closure so the struct stays
+// comparable: it is installed into http.DefaultTransport and utils.HTTPClient, where
+// equality is how callers check whether it is already in place, and a func field would turn
+// that check into a runtime panic.
+type ntlmTransport struct {
+	// base is cloned per request. Cloning a configured transport rather than building a bare
+	// one carries over proxy, TLS and timeout settings - which on a corporate network are
+	// usually the difference between reaching the server and not.
+	base *http.Transport
+}
+
+func (t ntlmTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	pool := t.base.Clone()
+
+	resp, err := (ntlmssp.Negotiator{RoundTripper: pool}).RoundTrip(req)
+	if err != nil {
+		pool.CloseIdleConnections()
+
+		return nil, err
+	}
+
+	// The pool cannot be reaped yet: the response body is still streaming over its
+	// connection, and for a clone that body is the packfile. Closing the body is what
+	// returns the connection to the pool, so that is when there is something to reap.
+	if resp.Body != nil {
+		resp.Body = closeHook{ReadCloser: resp.Body, after: pool.CloseIdleConnections}
+	}
+
+	return resp, nil
+}
+
+// closeHook runs a function after the wrapped body is closed.
+type closeHook struct {
+	io.ReadCloser
+	after func()
+}
+
+func (c closeHook) Close() error {
+	err := c.ReadCloser.Close()
+	c.after()
+
+	return err
+}
+
+// newNTLMTransport builds a per-request-pool transport from an existing round tripper,
+// preserving its configuration where it can be read.
+func newNTLMTransport(base http.RoundTripper) ntlmTransport {
+	if configured, ok := base.(*http.Transport); ok {
+		return ntlmTransport{base: configured}
+	}
+
+	// Not a *http.Transport (already wrapped, or a stub in a test). Fall back to the standard
+	// default, which at least keeps proxy-from-environment.
+	if fallback, ok := http.DefaultTransport.(*http.Transport); ok {
+		return ntlmTransport{base: fallback}
+	}
+
+	return ntlmTransport{base: &http.Transport{}}
+}
+
 var installNTLMOnce sync.Once
 
 // EnableNTLM routes both the Azure SDK's REST calls and go-git's clones through an NTLM
@@ -37,7 +122,9 @@ var installNTLMOnce sync.Once
 // Windows authentication: without an NTLM challenge the negotiator is a pass-through.
 func EnableNTLM() {
 	installNTLMOnce.Do(func() {
-		http.DefaultTransport = ntlmssp.Negotiator{RoundTripper: http.DefaultTransport}
+		gitTransport := newNTLMTransport(http.DefaultTransport)
+
+		http.DefaultTransport = newNTLMTransport(http.DefaultTransport)
 
 		// utils.HTTPClient carries its own Transport for connection pooling, so replacing
 		// http.DefaultTransport does not reach it. fetchDisabledRepoIDs uses that client,
@@ -45,13 +132,13 @@ func EnableNTLM() {
 		// authenticate - it fails, is swallowed as "no repos disabled", and every disabled
 		// repository is then counted. In a licence-sizing tool that silently inflates the
 		// total, which is the worst possible way for it to break.
-		utils.HTTPClient.Transport = ntlmssp.Negotiator{RoundTripper: utils.HTTPClient.Transport}
+		utils.HTTPClient.Transport = newNTLMTransport(utils.HTTPClient.Transport)
 
 		// go-git builds its own client, so it needs the negotiator installed separately.
-		client.InstallProtocol("https", githttp.NewClient(
-			&http.Client{Transport: ntlmssp.Negotiator{RoundTripper: &http.Transport{}}}))
-		client.InstallProtocol("http", githttp.NewClient(
-			&http.Client{Transport: ntlmssp.Negotiator{RoundTripper: &http.Transport{}}}))
+		// This is the path that runs Workers-wide in parallel, and the one the connection
+		// theft was actually costing repositories on.
+		client.InstallProtocol("https", githttp.NewClient(&http.Client{Transport: gitTransport}))
+		client.InstallProtocol("http", githttp.NewClient(&http.Client{Transport: gitTransport}))
 	})
 }
 

--- a/pkg/devops/getazure/ntlm_concurrency_test.go
+++ b/pkg/devops/getazure/ntlm_concurrency_test.go
@@ -1,0 +1,201 @@
+package getazure
+
+import (
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// connectionBoundNTLMServer behaves the way IIS does under Windows authentication: the Type2
+// challenge is issued against the connection it arrived on, and a Type3 presented on any other
+// connection is refused with 401.1 / 0x80090308 SEC_E_INVALID_TOKEN.
+//
+// That binding is the whole reason the bug exists, so a test server that ignored it would
+// pass no matter how the transport pooled connections.
+type connectionBoundNTLMServer struct {
+	mu         sync.Mutex
+	challenged map[string]bool // keyed by client ip:port, i.e. one entry per TCP connection
+	rejected   int
+
+	// body is returned on success, standing in for a packfile: the response is streamed over
+	// the same connection the handshake used, so reading it proves the pool was not torn down
+	// underneath it.
+	body string
+}
+
+func (s *connectionBoundNTLMServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "NTLM ") {
+		w.Header().Set("WWW-Authenticate", "NTLM")
+		w.WriteHeader(http.StatusUnauthorized)
+
+		return
+	}
+
+	payload, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "NTLM "))
+	if err != nil || len(payload) < 9 {
+		w.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	switch payload[8] {
+	case 1: // negotiate: issue a challenge bound to this connection
+		s.challenged[r.RemoteAddr] = true
+		w.Header().Set("WWW-Authenticate",
+			"NTLM "+base64.StdEncoding.EncodeToString(challengeMessage()))
+		w.WriteHeader(http.StatusUnauthorized)
+	case 3: // authenticate: only valid on the connection that was challenged
+		if !s.challenged[r.RemoteAddr] {
+			s.rejected++
+			w.Header().Set("WWW-Authenticate", "NTLM")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, "HTTP Error 401.1 - Unauthorized\nError Code: 0x80090308")
+
+			return
+		}
+		delete(s.challenged, r.RemoteAddr)
+		_, _ = io.WriteString(w, s.body)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+	}
+}
+
+// authenticate runs one full handshake and reports whether it succeeded, reading the body to
+// completion the way go-git reads a packfile.
+func authenticate(t *testing.T, client *http.Client, url string) (bool, string) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return false, ""
+	}
+	req.SetBasicAuth("DOMAIN\\jsmith", "secret")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, ""
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, ""
+	}
+
+	return resp.StatusCode == http.StatusOK, string(body)
+}
+
+// The regression. Clones run Workers-wide in parallel, and with a shared pool the connection
+// carrying a half-finished handshake can be taken by another worker between the challenge and
+// the response - the Type3 then lands on a socket that was never challenged. That is what cost
+// a real scan 2 of 30 repositories, both in the first batch of concurrent workers, on
+// credentials that worked for the other 28.
+//
+// A per-request pool is what makes this deterministic rather than a matter of timing.
+func TestNTLMHandshakesSurviveConcurrentRequests(t *testing.T) {
+	const workers = 32
+
+	server := &connectionBoundNTLMServer{challenged: map[string]bool{}, body: "PACK"}
+	srv := httptest.NewServer(server)
+	defer srv.Close()
+
+	client := &http.Client{Transport: newNTLMTransport(http.DefaultTransport)}
+
+	var wg sync.WaitGroup
+	failures := make(chan string, workers)
+	start := make(chan struct{})
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // release them together, so the pool is under real contention
+
+			ok, body := authenticate(t, client, srv.URL)
+			if !ok {
+				failures <- "handshake rejected"
+			} else if body != "PACK" {
+				failures <- "body was " + body
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(failures)
+
+	if n := len(failures); n > 0 {
+		t.Errorf("%d of %d concurrent handshakes failed (%d rejected as SEC_E_INVALID_TOKEN); "+
+			"a repository whose clone is refused this way is dropped from the line count",
+			n, workers, server.rejected)
+	}
+}
+
+// The pool is torn down when the response body is closed, so it must survive long enough to
+// read the body - for a clone that body is the packfile. Reaping it any earlier would trade an
+// intermittent auth failure for a truncated clone, which is harder to notice.
+func TestNTLMTransportStreamsTheBodyBeforeReapingTheConnection(t *testing.T) {
+	payload := strings.Repeat("packfile-", 100000) // large enough not to fit in one buffer
+
+	server := &connectionBoundNTLMServer{challenged: map[string]bool{}, body: payload}
+	srv := httptest.NewServer(server)
+	defer srv.Close()
+
+	client := &http.Client{Transport: newNTLMTransport(http.DefaultTransport)}
+
+	ok, body := authenticate(t, client, srv.URL)
+	if !ok {
+		t.Fatal("handshake failed")
+	}
+	if len(body) != len(payload) {
+		t.Errorf("read %d bytes of %d; the connection was closed while the body was still "+
+			"streaming", len(body), len(payload))
+	}
+}
+
+// Cloning the base is what carries proxy, TLS and timeout settings into each per-request pool.
+// Building a bare transport instead would drop them silently - and on a corporate network,
+// losing the proxy means losing the server.
+func TestNTLMTransportPreservesTheBaseConfiguration(t *testing.T) {
+	base := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		MaxIdleConnsPerHost: 42,
+		DisableCompression:  true,
+	}
+
+	pool := newNTLMTransport(base).base.Clone()
+
+	if pool.Proxy == nil {
+		t.Error("proxy configuration was dropped; a proxied network would become unreachable")
+	}
+	if pool.MaxIdleConnsPerHost != 42 {
+		t.Errorf("MaxIdleConnsPerHost = %d, want 42", pool.MaxIdleConnsPerHost)
+	}
+	if !pool.DisableCompression {
+		t.Error("DisableCompression was dropped")
+	}
+}
+
+// utils.HTTPClient's transport is a *http.Transport, so it is cloned directly. Anything else -
+// an already-wrapped transport, or a stub - must still yield a working transport rather than a
+// nil base that panics on the first request.
+func TestNewNTLMTransportFallsBackForANonStandardBase(t *testing.T) {
+	got := newNTLMTransport(roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, nil
+	}))
+
+	if got.base == nil {
+		t.Fatal("base is nil; the first request would panic")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/pkg/devops/getazure/ntlm_test.go
+++ b/pkg/devops/getazure/ntlm_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	ntlmssp "github.com/Azure/go-ntlmssp"
 	"github.com/SonarSource-Demos/sonar-golc/pkg/utils"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 )
@@ -134,12 +133,12 @@ func challengeMessage() []byte {
 func TestEnableNTLMAlsoWrapsTheSharedClient(t *testing.T) {
 	EnableNTLM()
 
-	if _, ok := utils.HTTPClient.Transport.(ntlmssp.Negotiator); !ok {
-		t.Errorf("utils.HTTPClient.Transport is %T, want it wrapped in ntlmssp.Negotiator; "+
+	if _, ok := utils.HTTPClient.Transport.(ntlmTransport); !ok {
+		t.Errorf("utils.HTTPClient.Transport is %T, want it wrapped in ntlmTransport; "+
 			"disabled-repo detection would silently fail and inflate the line count",
 			utils.HTTPClient.Transport)
 	}
-	if _, ok := http.DefaultTransport.(ntlmssp.Negotiator); !ok {
+	if _, ok := http.DefaultTransport.(ntlmTransport); !ok {
 		t.Errorf("http.DefaultTransport is %T, want it wrapped", http.DefaultTransport)
 	}
 }

--- a/pkg/devops/getazure/ntlm_test.go
+++ b/pkg/devops/getazure/ntlm_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	ntlmssp "github.com/Azure/go-ntlmssp"
+	"github.com/SonarSource-Demos/sonar-golc/pkg/utils"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 )
 
@@ -122,4 +124,33 @@ func challengeMessage() []byte {
 	copy(msg[24:32], []byte{1, 2, 3, 4, 5, 6, 7, 8}) // server challenge
 
 	return msg
+}
+
+// utils.HTTPClient has its own Transport for connection pooling, so replacing
+// http.DefaultTransport does not reach it. fetchDisabledRepoIDs uses that client, and if it
+// is left unwrapped its request is the one call in the Azure path that cannot authenticate
+// against a Windows-authenticated server. The failure is swallowed as "no repos disabled",
+// so every disabled repository gets counted and the reported total silently inflates.
+func TestEnableNTLMAlsoWrapsTheSharedClient(t *testing.T) {
+	EnableNTLM()
+
+	if _, ok := utils.HTTPClient.Transport.(ntlmssp.Negotiator); !ok {
+		t.Errorf("utils.HTTPClient.Transport is %T, want it wrapped in ntlmssp.Negotiator; "+
+			"disabled-repo detection would silently fail and inflate the line count",
+			utils.HTTPClient.Transport)
+	}
+	if _, ok := http.DefaultTransport.(ntlmssp.Negotiator); !ok {
+		t.Errorf("http.DefaultTransport is %T, want it wrapped", http.DefaultTransport)
+	}
+}
+
+// Repeated calls must not stack negotiators on top of each other.
+func TestEnableNTLMIsIdempotent(t *testing.T) {
+	EnableNTLM()
+	first := utils.HTTPClient.Transport
+	EnableNTLM()
+
+	if utils.HTTPClient.Transport != first {
+		t.Error("a second EnableNTLM wrapped the transport again")
+	}
 }

--- a/pkg/devops/getazure/summary_test.go
+++ b/pkg/devops/getazure/summary_test.go
@@ -1,0 +1,113 @@
+package getazure
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/SonarSource-Demos/sonar-golc/pkg/utils"
+)
+
+// captureSummaryLog redirects the shared logger for one test and restores it afterwards.
+func captureSummaryLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	logger := utils.SharedLogger()
+	previous := logger.Out
+
+	var out bytes.Buffer
+	logger.SetOutput(&out)
+	t.Cleanup(func() { logger.SetOutput(previous) })
+
+	return &out
+}
+
+// A repository can be discovered and then dropped before analysis for having no branch
+// matching the configured one. It lands in none of the empty/excluded/archived counters, so
+// nothing in the summary accounts for it and its lines are simply missing from the total.
+//
+// An organisation that pins "main" across a mix of "main" and "master" repositories hits this
+// on every scan, and silent omission is the worst failure mode for a licence-sizing tool.
+func TestPrintSummaryReportsRepositoriesDroppedBeforeAnalysis(t *testing.T) {
+	out := captureSummaryLog(t)
+
+	printSummary("DefaultCollection", SummaryStats{
+		NbRepos:          3,
+		Analyzed:         2,
+		TotalBranches:    2,
+		DiscoverySkipped: 1,
+	})
+
+	logged := out.String()
+	if !strings.Contains(logged, "1 of 3 discovered repository(ies) will not be analyzed") {
+		t.Errorf("the shortfall was never reported, so a repository missing from the totals "+
+			"leaves no trace at all.\ngot:\n%s", logged)
+	}
+}
+
+// The headline has to come from the number of repositories that will actually be analysed,
+// not from discovered-minus-filtered. Those two agree right up until a repository is dropped
+// for its branch, and then the arithmetic overstates the scope of the scan.
+func TestPrintSummaryReportsAnalysedCountNotTheArithmetic(t *testing.T) {
+	out := captureSummaryLog(t)
+
+	// Three discovered, none in a filtered category, but only two carry the configured
+	// branch: NbRepos - empty - excluded - archived would say three.
+	printSummary("DefaultCollection", SummaryStats{
+		NbRepos:          3,
+		Analyzed:         2,
+		TotalBranches:    2,
+		DiscoverySkipped: 1,
+	})
+
+	logged := out.String()
+	if !strings.Contains(logged, "Total Repositories that will be analyzed: 2") {
+		t.Errorf("expected the analysed count (2).\ngot:\n%s", logged)
+	}
+	if strings.Contains(logged, "Total Repositories that will be analyzed: 3") {
+		t.Errorf("reported 3 repositories as about to be analysed when only 2 were.\ngot:\n%s", logged)
+	}
+}
+
+// The filtered categories must keep reconciling as they did before: a run where every
+// non-filtered repository is analysed has no shortfall and must not claim one.
+func TestPrintSummaryReconcilesTheFilteredCategories(t *testing.T) {
+	out := captureSummaryLog(t)
+
+	printSummary("DefaultCollection", SummaryStats{
+		NbRepos:       30,
+		EmptyRepo:     2,
+		TotalExclude:  2,
+		TotalArchiv:   1,
+		Analyzed:      25, // 30 - 2 - 2 - 1
+		TotalBranches: 25,
+	})
+
+	logged := out.String()
+	if !strings.Contains(logged, "Total Repositories that will be analyzed: 25") {
+		t.Errorf("the filtered-category arithmetic no longer reconciles.\ngot:\n%s", logged)
+	}
+	if strings.Contains(logged, "will not be analyzed") {
+		t.Errorf("warned about a shortfall when every unfiltered repository was analysed.\ngot:\n%s", logged)
+	}
+}
+
+// The warning is conditional, so a clean run stays quiet. A summary that cried shortfall on
+// every scan would train operators to ignore the one that matters.
+func TestPrintSummarySaysNothingWhenNothingWasDropped(t *testing.T) {
+	out := captureSummaryLog(t)
+
+	printSummary("DefaultCollection", SummaryStats{
+		NbRepos:       30,
+		Analyzed:      30,
+		TotalBranches: 30,
+	})
+
+	logged := out.String()
+	if strings.Contains(logged, "will not be analyzed") {
+		t.Errorf("warned about a shortfall on a complete run.\ngot:\n%s", logged)
+	}
+	if !strings.Contains(logged, "Total Repositories that will be analyzed: 30") {
+		t.Errorf("expected all 30 reported as analysed.\ngot:\n%s", logged)
+	}
+}

--- a/pkg/scanner/progress_test.go
+++ b/pkg/scanner/progress_test.go
@@ -1,0 +1,107 @@
+package scanner
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Redirected to a file, the bar must draw nothing. Every repaint is kept in a file, so on a
+// large scan the bar becomes the bulk of the output and buries the log.
+func TestProgressWriterDiscardsWhenRedirectedToAFile(t *testing.T) {
+	f, err := os.Create(filepath.Join(t.TempDir(), "out.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if got := progressWriter(f); got != io.Discard {
+		t.Errorf("writer = %v, want io.Discard: a redirected stream would be flooded with repaints", got)
+	}
+}
+
+// A pipe is what a shell pipeline and most CI runners give the process, and it is the case
+// that has to be right - it is not a character device, so the bar must be discarded.
+func TestProgressWriterDiscardsWhenPiped(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	if got := progressWriter(w); got != io.Discard {
+		t.Errorf("writer = %v, want io.Discard for a pipe", got)
+	}
+}
+
+// On a terminal the bar is wanted, and it must go to the very stream that was tested. A
+// character device is the stand-in for a terminal here; /dev/null is one, which is why
+// isTerminal accepts it.
+func TestProgressWriterReturnsTheStreamItWasGivenOnATerminal(t *testing.T) {
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer devNull.Close()
+
+	if !isTerminal(devNull) {
+		t.Skip("this platform does not report " + os.DevNull + " as a character device")
+	}
+
+	got := progressWriter(devNull)
+	if got != io.Writer(devNull) {
+		t.Errorf("writer = %v, want the same stream that was tested; guarding one stream and "+
+			"writing to another is how the bar escapes the check", got)
+	}
+}
+
+// The end-to-end guarantee: with stdout redirected, a real bar built by createProgressbar and
+// driven to completion must leave the destination empty.
+//
+// This is the test that would catch the bar moving to a stream nothing guards - the library's
+// Default constructors write to stderr, so a change of constructor or an upgrade could do
+// exactly that while progressWriter still looks correct.
+func TestCreateProgressbarWritesNothingWhenStdoutIsRedirected(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stdout.log")
+	redirected, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	realStdout, realStderr := os.Stdout, os.Stderr
+	os.Stdout = redirected
+	// Capture stderr too: "nothing was written" has to mean nothing anywhere, otherwise a bar
+	// that moved to stderr would pass a stdout-only assertion.
+	stderrPath := filepath.Join(t.TempDir(), "stderr.log")
+	redirectedErr, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = redirectedErr
+	t.Cleanup(func() {
+		os.Stdout, os.Stderr = realStdout, realStderr
+		redirected.Close()
+		redirectedErr.Close()
+	})
+
+	sc := NewScanner(nil)
+	bar := sc.createProgressbar(10)
+	for i := 0; i < 10; i++ {
+		if err := bar.Add(1); err != nil {
+			t.Fatalf("driving the bar failed: %v", err)
+		}
+	}
+
+	for name, p := range map[string]string{"stdout": path, "stderr": stderrPath} {
+		written, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(written) != 0 {
+			t.Errorf("%d bytes reached the redirected %s; the bar is not guarded on that "+
+				"stream:\n%q", len(written), name, written)
+		}
+	}
+}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -69,23 +69,42 @@ func (sc *Scanner) Scan(files []analyzer.FileMetadata) ([]scanResult, error) {
 
 // isTerminal reports whether f is attached to a terminal. A character device is the
 // portable signal for that, so no dependency is needed to ask.
+//
+// /dev/null and /dev/zero are character devices too and so are read as terminals. That is
+// harmless here - the only consequence is drawing a progress bar into a sink that discards
+// it - and avoiding it would mean taking on a dependency to answer a question whose wrong
+// answer costs nothing.
 func isTerminal(f *os.File) bool {
 	info, err := f.Stat()
 
 	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
 
+// progressWriter decides where the progress bar draws.
+//
+// A progress bar animates by repainting the same line, which only makes sense on a terminal.
+// Redirected to a file or a CI log every repaint is kept, and the bar becomes the bulk of the
+// output - 117 KB around 3 KB of log on a 300-file scan, burying the messages someone is
+// actually reading. Off the terminal, draw nothing.
+//
+// The stream that is tested and the stream that is written to are the same argument, so they
+// cannot drift apart. Relying on the library's default writer would leave that agreement
+// resting on another module's constructor: progressbar's Default and DefaultBytes write to
+// stderr while NewOptions writes to stdout, so a change of constructor or an upgrade could
+// silently move the bar to a stream this never guarded - reinstating the flooding while the
+// check still looks correct.
+func progressWriter(out *os.File) io.Writer {
+	if !isTerminal(out) {
+		return io.Discard
+	}
+
+	return out
+}
+
 func (sc *Scanner) createProgressbar(max int) *progressbar.ProgressBar {
 	options := []progressbar.Option{
 		progressbar.OptionSetDescription("Scanning files..."),
-	}
-
-	// A progress bar animates by repainting the same line, which only makes sense on a
-	// terminal. Redirected to a file or a CI log every repaint is kept, and the bar
-	// becomes the bulk of the output - megabytes of it on a large scan, burying the
-	// messages someone is actually reading. Off the terminal, draw nothing.
-	if !isTerminal(os.Stdout) {
-		options = append(options, progressbar.OptionSetWriter(io.Discard))
+		progressbar.OptionSetWriter(progressWriter(os.Stdout)),
 	}
 
 	options = append(options,

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -67,10 +67,28 @@ func (sc *Scanner) Scan(files []analyzer.FileMetadata) ([]scanResult, error) {
 	return results, nil
 }
 
+// isTerminal reports whether f is attached to a terminal. A character device is the
+// portable signal for that, so no dependency is needed to ask.
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
 func (sc *Scanner) createProgressbar(max int) *progressbar.ProgressBar {
-	return progressbar.NewOptions(
-		max,
+	options := []progressbar.Option{
 		progressbar.OptionSetDescription("Scanning files..."),
+	}
+
+	// A progress bar animates by repainting the same line, which only makes sense on a
+	// terminal. Redirected to a file or a CI log every repaint is kept, and the bar
+	// becomes the bulk of the output - megabytes of it on a large scan, burying the
+	// messages someone is actually reading. Off the terminal, draw nothing.
+	if !isTerminal(os.Stdout) {
+		options = append(options, progressbar.OptionSetWriter(io.Discard))
+	}
+
+	options = append(options,
 		progressbar.OptionShowBytes(true),
 		progressbar.OptionShowCount(),
 		progressbar.OptionClearOnFinish(),
@@ -82,6 +100,8 @@ func (sc *Scanner) createProgressbar(max int) *progressbar.ProgressBar {
 			BarEnd:        "]",
 		}),
 	)
+
+	return progressbar.NewOptions(max, options...)
 }
 
 // Old Function using bufio.Scanner Now use bufio.Reader which does not limit the line size.

--- a/pkg/utils/htmlerror.go
+++ b/pkg/utils/htmlerror.go
@@ -1,0 +1,97 @@
+package utils
+
+import (
+	"html"
+	"regexp"
+	"strings"
+)
+
+// A server that refuses a request often answers with a whole error page rather than a
+// sentence. IIS is the worst offender - its 401.1 page is roughly 6 KB of stylesheet, list
+// items and links to knowledge-base articles - and when that page arrives as the text of a
+// clone failure it is stored verbatim as the reason the repository was skipped.
+//
+// Two skipped repositories were enough to turn analysis_skipped.json into 12 KB of mostly CSS.
+// That file is read by the web page and the PDF report, so the one thing an operator needs
+// from it - which repositories are missing from the totals, and why - ends up buried in
+// markup. Condensing the page to its visible words keeps the diagnosis and drops the rest.
+
+var (
+	htmlStyleBlock  = regexp.MustCompile(`(?is)<style\b[^>]*>.*?</style>`)
+	htmlScriptBlock = regexp.MustCompile(`(?is)<script\b[^>]*>.*?</script>`)
+	htmlTag         = regexp.MustCompile(`(?s)<[^>]*>`)
+	htmlWhitespace  = regexp.MustCompile(`\s+`)
+	htmlErrorCode   = regexp.MustCompile(`0x[0-9A-Fa-f]{8}`)
+)
+
+// condensedHTMLLimit caps the extracted text. Enough for a heading and an error code, which is
+// what these pages carry that is worth reading; anything longer is boilerplate.
+const condensedHTMLLimit = 200
+
+// CondenseHTMLError rewrites an error message that carries an embedded HTML page, keeping the
+// message's own text and reducing the page to its visible words. A message with no HTML in it
+// is returned exactly as it was - the common case, and one where any rewriting would only lose
+// information.
+func CondenseHTMLError(message string) string {
+	start := indexOfHTML(message)
+	if start < 0 {
+		return message
+	}
+
+	prefix := strings.TrimSpace(message[:start])
+	condensed := condenseHTML(message[start:])
+
+	switch {
+	case prefix == "" && condensed == "":
+		// An HTML page with no readable text at all. Saying so beats an empty reason, which
+		// would read as though no reason was recorded.
+		return "server returned an HTML error page with no readable message"
+	case prefix == "":
+		return condensed
+	case condensed == "":
+		return prefix
+	default:
+		return prefix + " " + condensed
+	}
+}
+
+// indexOfHTML returns where an HTML document starts within s, or -1.
+func indexOfHTML(s string) int {
+	lower := strings.ToLower(s)
+
+	first := -1
+	for _, marker := range []string{"<!doctype", "<html"} {
+		if i := strings.Index(lower, marker); i >= 0 && (first < 0 || i < first) {
+			first = i
+		}
+	}
+
+	return first
+}
+
+// condenseHTML reduces a page to a single line of its visible text.
+func condenseHTML(page string) string {
+	// Style and script contents are not markup, so stripping tags alone would leave the CSS
+	// and JavaScript behind as text - which is most of what makes these pages long.
+	page = htmlStyleBlock.ReplaceAllString(page, " ")
+	page = htmlScriptBlock.ReplaceAllString(page, " ")
+	page = htmlTag.ReplaceAllString(page, " ")
+
+	text := strings.TrimSpace(htmlWhitespace.ReplaceAllString(html.UnescapeString(page), " "))
+	if len(text) <= condensedHTMLLimit {
+		return text
+	}
+
+	truncated := strings.TrimSpace(text[:condensedHTMLLimit]) + "..."
+
+	// These pages put the status code in the heading and the actual status *code* far down in
+	// a details table, so a length cap reliably keeps the vague half and discards the precise
+	// one. 0x80090308 is what distinguishes a rejected credential from a broken handshake -
+	// the difference between "check the password" and "check the auth configuration" - so it
+	// is carried past the cap rather than left to fall off the end.
+	if code := htmlErrorCode.FindString(text); code != "" && !strings.Contains(truncated, code) {
+		truncated += " (" + code + ")"
+	}
+
+	return truncated
+}

--- a/pkg/utils/htmlerror.go
+++ b/pkg/utils/htmlerror.go
@@ -24,8 +24,13 @@ var (
 	htmlErrorCode   = regexp.MustCompile(`0x[0-9A-Fa-f]{8}`)
 )
 
-// condensedHTMLLimit caps the extracted text. Enough for a heading and an error code, which is
-// what these pages carry that is worth reading; anything longer is boilerplate.
+// condensedHTMLLimit caps the extracted text, in characters. Enough for a heading and an
+// error code, which is what these pages carry that is worth reading; anything longer is
+// boilerplate.
+//
+// Characters rather than bytes because the cap exists for readability, and because a
+// Windows server localised to German or Japanese returns a localised error page - cutting
+// those at a byte offset lands mid-character and ends the reason with a broken rune.
 const condensedHTMLLimit = 200
 
 // CondenseHTMLError rewrites an error message that carries an embedded HTML page, keeping the
@@ -78,11 +83,13 @@ func condenseHTML(page string) string {
 	page = htmlTag.ReplaceAllString(page, " ")
 
 	text := strings.TrimSpace(htmlWhitespace.ReplaceAllString(html.UnescapeString(page), " "))
-	if len(text) <= condensedHTMLLimit {
+
+	head := truncateRunes(text, condensedHTMLLimit)
+	if head == text {
 		return text
 	}
 
-	truncated := strings.TrimSpace(text[:condensedHTMLLimit]) + "..."
+	truncated := strings.TrimSpace(head) + "..."
 
 	// These pages put the status code in the heading and the actual status *code* far down in
 	// a details table, so a length cap reliably keeps the vague half and discards the precise
@@ -94,4 +101,24 @@ func condenseHTML(page string) string {
 	}
 
 	return truncated
+}
+
+// truncateRunes returns at most limit characters of s, always cutting on a character
+// boundary. Slicing by byte offset instead can split a multi-byte character in half, which
+// leaves an invalid sequence at the end of the reason - rendered as a replacement character,
+// and no longer valid UTF-8 for whatever reads the report afterwards.
+//
+// Ranging over a string yields the byte offset of each character's first byte, so the offset
+// reached after limit characters is exactly where the cut belongs. No allocation, and the
+// string is walked once.
+func truncateRunes(s string, limit int) string {
+	count := 0
+	for offset := range s {
+		if count == limit {
+			return s[:offset]
+		}
+		count++
+	}
+
+	return s
 }

--- a/pkg/utils/htmlerror_test.go
+++ b/pkg/utils/htmlerror_test.go
@@ -1,0 +1,157 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+// iisUnauthorizedPage is the shape of what an IIS 401.1 response actually carries: a long
+// stylesheet, a heading, the diagnostic fields, and a list of links. Roughly 6 KB of it ends
+// up as the reason a repository was skipped.
+const iisUnauthorizedPage = `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>IIS 8.5 Detailed Error - 401.1 - Unauthorized</title>
+<style type="text/css">
+<!--
+body{margin:0;font-size:.7em;font-family:Verdana,Arial,Helvetica,sans-serif;background:#CBE1EF;}
+code{margin:0;color:#006600;font-size:1.1em;font-weight:bold;}
+.config_source code{font-size:.8em;color:#000000;}
+pre{margin:0;font-size:1.4em;word-wrap:break-word;}
+ul,ol{margin:10px 0 10px 5px;}
+-->
+</style>
+</head>
+<body>
+<div id="content">
+<div class="content-container"><h3>HTTP Error 401.1 - Unauthorized</h3>
+<h4>You do not have permission to view this directory or page using the credentials that you supplied.</h4>
+</div>
+<div class="content-container">
+<fieldset><h4>Most likely causes:</h4>
+<ul><li>No authentication protocol (including anonymous) is selected in IIS.</li>
+<li>Only integrated authentication is enabled, and a client browser was used that does not support integrated authentication.</li></ul>
+</fieldset>
+</div>
+<div class="content-container">
+<fieldset><h4>Detailed Error Information:</h4>
+<div id="details-left"><table border="0" cellpadding="0" cellspacing="0">
+<tr class="alt"><th>Module</th><td>WindowsAuthenticationModule</td></tr>
+<tr><th>Notification</th><td>AuthenticateRequest</td></tr>
+<tr class="alt"><th>Handler</th><td>ExtensionlessUrlHandler</td></tr>
+<tr><th>Error Code</th><td>0x80090308</td></tr>
+</table></div>
+</fieldset>
+</div>
+</div>
+</body></html>`
+
+// The point of the exercise: what lands in analysis_skipped.json has to be short enough to
+// read. The page is ~2 KB even in this trimmed form; a real one is ~6 KB.
+func TestCondenseHTMLErrorShrinksAnIISPage(t *testing.T) {
+	raw := "clone failed: authentication required: " + iisUnauthorizedPage
+
+	got := CondenseHTMLError(raw)
+
+	if len(got) >= len(raw)/4 {
+		t.Errorf("condensed to %d bytes from %d, which is not enough of a reduction to make "+
+			"the skip report readable:\n%s", len(got), len(raw), got)
+	}
+	if strings.Contains(got, "font-family") || strings.Contains(got, "margin:0") {
+		t.Errorf("stylesheet text survived:\n%s", got)
+	}
+	if strings.Contains(got, "<") || strings.Contains(got, ">") {
+		t.Errorf("markup survived:\n%s", got)
+	}
+}
+
+// Condensing must not throw away the diagnosis. The message's own text says what failed, and
+// the page's heading says why - both have to reach the report, or the entry becomes "something
+// went wrong" and the operator has nowhere to go.
+func TestCondenseHTMLErrorKeepsTheDiagnosis(t *testing.T) {
+	got := CondenseHTMLError("clone failed: authentication required: " + iisUnauthorizedPage)
+
+	for _, want := range []string{"clone failed: authentication required:", "401.1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("condensed reason lost %q:\n%s", want, got)
+		}
+	}
+}
+
+// The overwhelming majority of skip reasons are ordinary sentences. Rewriting those could only
+// lose information, so they must come back byte-identical.
+func TestCondenseHTMLErrorLeavesPlainMessagesAlone(t *testing.T) {
+	messages := []string{
+		"clone timed out after 5m0s",
+		"analysis error: repository is empty",
+		"clone failed: authentication required",
+		"",
+		"a message mentioning a < character and a > one",
+	}
+
+	for _, message := range messages {
+		if got := CondenseHTMLError(message); got != message {
+			t.Errorf("CondenseHTMLError(%q) = %q, want it unchanged", message, got)
+		}
+	}
+}
+
+// Script contents are not markup either, so stripping tags alone would leave the JavaScript
+// behind as text.
+func TestCondenseHTMLErrorDropsScriptContents(t *testing.T) {
+	got := CondenseHTMLError(`<html><head><script>var x = 1; alert("boom");</script></head>` +
+		`<body><h3>Access denied</h3></body></html>`)
+
+	if strings.Contains(got, "alert") || strings.Contains(got, "var x") {
+		t.Errorf("script text survived:\n%s", got)
+	}
+	if !strings.Contains(got, "Access denied") {
+		t.Errorf("the message itself was lost:\n%s", got)
+	}
+}
+
+// A page whose visible text is empty must still produce a reason. An empty string in the
+// report reads as "no reason was recorded", which is a different and misleading claim.
+func TestCondenseHTMLErrorNeverReturnsAnEmptyReason(t *testing.T) {
+	got := CondenseHTMLError("<html><head><style>body{color:red}</style></head><body></body></html>")
+
+	if strings.TrimSpace(got) == "" {
+		t.Error("an HTML page with no text produced an empty reason")
+	}
+}
+
+// Entities are how these pages write punctuation; leaving them raw makes the line harder to
+// read than it needs to be.
+func TestCondenseHTMLErrorDecodesEntities(t *testing.T) {
+	got := CondenseHTMLError(`<html><body><h3>Don&#39;t have permission &amp; cannot proceed</h3></body></html>`)
+
+	if !strings.Contains(got, "Don't have permission & cannot proceed") {
+		t.Errorf("entities were not decoded:\n%s", got)
+	}
+}
+
+// A page that is all text and no boilerplate still has to be capped - the limit is what bounds
+// the report's size, not the presence of a stylesheet.
+func TestCondenseHTMLErrorCapsLongText(t *testing.T) {
+	got := CondenseHTMLError("<html><body>" + strings.Repeat("verbose ", 500) + "</body></html>")
+
+	if len(got) > condensedHTMLLimit+10 {
+		t.Errorf("condensed text is %d bytes, want it capped near %d", len(got), condensedHTMLLimit)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("truncation was not signalled, so the text reads as complete:\n%s", got)
+	}
+}
+
+// The status code sits in the heading; the error *code* sits in a details table near the
+// bottom. A length cap therefore keeps the vague half and drops the precise one - but
+// 0x80090308 (SEC_E_INVALID_TOKEN, a broken handshake) versus 0xC000006A (a wrong password)
+// is the difference between checking the auth configuration and checking the credentials.
+func TestCondenseHTMLErrorKeepsTheErrorCodePastTheCap(t *testing.T) {
+	got := CondenseHTMLError("clone failed: " + iisUnauthorizedPage)
+
+	if !strings.Contains(got, "0x80090308") {
+		t.Errorf("the error code was truncated away, leaving nothing to distinguish a broken "+
+			"handshake from a rejected password:\n%s", got)
+	}
+}

--- a/pkg/utils/htmlerror_test.go
+++ b/pkg/utils/htmlerror_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // iisUnauthorizedPage is the shape of what an IIS 401.1 response actually carries: a long
@@ -153,5 +154,81 @@ func TestCondenseHTMLErrorKeepsTheErrorCodePastTheCap(t *testing.T) {
 	if !strings.Contains(got, "0x80090308") {
 		t.Errorf("the error code was truncated away, leaving nothing to distinguish a broken "+
 			"handshake from a rejected password:\n%s", got)
+	}
+}
+
+// A Windows server localised to German or Japanese returns a localised IIS error page, so the
+// text being cut is not ASCII. Slicing at a byte offset then lands in the middle of a
+// character and leaves a fragment of one at the end - invalid UTF-8, which renders as a
+// replacement character and corrupts analysis_skipped.json for anything reading it afterwards.
+func TestCondenseHTMLErrorTruncatesOnCharacterBoundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+	}{
+		// Two-byte characters, offset by one ASCII character so byte 200 falls mid-character.
+		{"german", "x" + strings.Repeat("ü", 400)},
+		// Three-byte characters: 200 is not a multiple of 3, so a split is guaranteed.
+		{"japanese", strings.Repeat("認", 400)},
+		// Four-byte characters.
+		{"emoji", strings.Repeat("🔒", 400)},
+		// Mixed, so the boundary lands somewhere different again.
+		{"mixed", strings.Repeat("aé漢🔒", 200)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CondenseHTMLError("<html><body><h3>" + tc.text + "</h3></body></html>")
+
+			if !utf8.ValidString(got) {
+				t.Errorf("condensed reason is not valid UTF-8; a character was cut in half:\n%q",
+					got[max(0, len(got)-16):])
+			}
+			if strings.ContainsRune(got, utf8.RuneError) {
+				t.Errorf("condensed reason contains a replacement character:\n%q",
+					got[max(0, len(got)-16):])
+			}
+		})
+	}
+}
+
+// The cap counts characters, so a page of three-byte characters is allowed more bytes than a
+// page of ASCII. That is the point - the limit exists to bound what someone reads, and 200
+// Japanese characters is 200 characters however many bytes it takes to store them.
+func TestCondenseHTMLErrorCapsByCharactersNotBytes(t *testing.T) {
+	got := CondenseHTMLError("<html><body>" + strings.Repeat("認", 400) + "</body></html>")
+
+	characters := utf8.RuneCountInString(strings.TrimSuffix(got, "..."))
+	if characters > condensedHTMLLimit {
+		t.Errorf("kept %d characters, want at most %d", characters, condensedHTMLLimit)
+	}
+	if characters < condensedHTMLLimit-1 {
+		t.Errorf("kept only %d characters; a byte-based cap would cut a multi-byte page this "+
+			"short, losing text the limit allows", characters)
+	}
+}
+
+// truncateRunes is the boundary-safe cut on its own, including the cases the callers above
+// never reach: an empty string, a limit past the end, and a limit of zero.
+func TestTruncateRunes(t *testing.T) {
+	tests := []struct {
+		in    string
+		limit int
+		want  string
+	}{
+		{"", 5, ""},
+		{"abc", 0, ""},
+		{"abc", 3, "abc"},
+		{"abc", 10, "abc"},
+		{"abcdef", 3, "abc"},
+		{"認識認識", 2, "認識"},
+		{"a認b", 2, "a認"},
+		{"🔒🔒🔒", 2, "🔒🔒"},
+	}
+
+	for _, tc := range tests {
+		if got := truncateRunes(tc.in, tc.limit); got != tc.want {
+			t.Errorf("truncateRunes(%q, %d) = %q, want %q", tc.in, tc.limit, got, tc.want)
+		}
 	}
 }

--- a/pkg/utils/repository_summary_test.go
+++ b/pkg/utils/repository_summary_test.go
@@ -246,9 +246,14 @@ func TestCreateReportFilePaths(t *testing.T) {
 
 	csvPath, jsonPath, pdfPath := createReportFilePaths(directory)
 
-	expectedCsvPath := "/test/directory/byfile-report/csv-report"
-	expectedJsonPath := "/test/directory/byfile-report"
-	expectedPdfPath := "/test/directory/byfile-report/pdf-report"
+	// Built with filepath.Join rather than written as literals because the function
+	// under test joins with the OS separator: hard-coded forward slashes assert Unix
+	// output and fail on Windows, where the same correct result comes back with
+	// backslashes. Joining here keeps the assertion about the layout - which
+	// directories, nested how - which is the part that is actually specified.
+	expectedCsvPath := filepath.Join(directory, "byfile-report", "csv-report")
+	expectedJsonPath := filepath.Join(directory, "byfile-report")
+	expectedPdfPath := filepath.Join(directory, "byfile-report", "pdf-report")
 
 	if csvPath != expectedCsvPath {
 		t.Errorf("createReportFilePaths() csvPath = %q, want %q", csvPath, expectedCsvPath)

--- a/webui.go
+++ b/webui.go
@@ -1355,7 +1355,7 @@ const htmlTemplate = `<!DOCTYPE html>
                   <input class="form-check-input" type="checkbox" id="adv-excludeTests" onchange="syncPresetKeywords()">
                   <label class="form-check-label form-label mb-0" for="adv-excludeTests">
                     <i class="fas fa-vial me-1" style="color:#60a5fa;"></i>Test directories
-                    <small class="text-muted d-block" style="font-size:.72rem;">test, tests, spec, specs, e2e, testdata, fixtures, mocks, integration</small>
+                    <small class="text-muted d-block" style="font-size:.72rem;">test, tests, spec, specs, e2e, testdata, fixtures, mock, mocks, integration, doc, docs</small>
                   </label>
                 </div>
                 <div class="form-check">
@@ -1513,7 +1513,7 @@ const basicFields = {
 };
 
 // platforms that support Project & Repos fields in advanced
-const supportsProject = new Set(['BitBucket','BitBucketSRV','Azure']);
+const supportsProject = new Set(['BitBucket','BitBucketSRV','Azure','AzureServer']);
 
 let currentPlatform = null;
 let currentStep = 1;


### PR DESCRIPTION
Fixes the findings from a scan against a real Azure DevOps Server behind Windows
authentication. Three of the four share a shape: **the tool was wrong quietly.** For a
tool used to size a licence, a silently inflated or deflated number is worse than a
crash — nothing prompts anyone to look.

## 1. Disabled-repo detection bypassed NTLM — inflated the total

`fetchDisabledRepoIDs` sends its request through `utils.HTTPClient`, which carries its own
`Transport` for connection pooling, so `EnableNTLM` replacing `http.DefaultTransport` never
reached it. It also authenticated with `SetBasicAuth("", token)` — an empty username, which a
Windows-authenticated server rejects outright.

It was the one call in the entire Azure path that could not authenticate. Its failure is
swallowed as *"no repos disabled"*, so **every disabled repository was counted**.

`EnableNTLM` now wraps that client too, and the request sends the configured username.

## 2. Repositories could disappear from the count — deflated the total

`AnalyseReposList` returned `total` — the number of repositories **found** — under a heading
that reads *"Number of Repository analyzed"*. Nothing ever read the `results` channel. A
repository that neither finished nor failed was counted anyway, and its absence from the
line totals was never mentioned.

Every worker sends exactly one result, on the success path and on each of the five error
paths alike (verified by reading all of them), so counting the reports gives the number that
genuinely completed. A shortfall is now reflected in the returned count *and* logged:

> ❌ 1 of 30 repositories did not complete analysis and are missing from the totals, with no
> error of their own. The reported lines of code are therefore an under-count — re-run before
> relying on them.

## 3. Authentication failures read as parse errors

Azure DevOps Server answers an unauthenticated API call with the IIS sign-in page. The Azure
SDK assumes every response is JSON and hands that HTML to a decoder, so what surfaces is:

```
invalid character '<' looking for beginning of value
```

That describes the first byte of `<html>`. It sends the reader looking for a corrupt response
or a parser bug; the actual problem is that the credentials were refused. The SDK can't be
fixed from here, but the error passes through this package — the last point at which what was
being attempted is still known — so it's translated there, naming the URL and the
authentication actually used.

**Deliberately narrow:** only a JSON error *about a `<`* is rewritten. A `*json.SyntaxError`
on its own only says the response wasn't valid JSON, which a truncated reply is too — calling
those authentication failures would swap one misleading message for another. The original
error stays wrapped and reachable via `errors.Is`/`errors.As`.

## 4. Progress bar flooded redirected output

`progressbar` repaints unconditionally. Piped to a file or a CI log, every repaint is kept.
Measured on a 300-file scan:

| stdout | log size | progress-bar lines |
|---|---:|---:|
| before | 117,410 B | many |
| after | 3,011 B | 0 |

**39× smaller**, and the messages someone is actually reading are no longer buried. It now
draws nothing when stdout isn't a character device.

> Note: the original report attributed this to the spinner. The spinner already TTY-guards
> (`spinner.go:317`); the culprit was `progressbar` in `pkg/scanner/scanner.go`.

## Also reported: `GlobalReport.json` / `.txt` missing — not reproducible

Both are written on the internal-run path, verified directly (`--internal-run File` produced
a 186 B `.json` and a 167 B `.txt`). The write lives inside `runGolcInProcess`, which *is*
that path. Left alone rather than guessing at a fix — happy to dig further with the failing
config.

## Verification

- New tests fail when each bug is reinstated — checked, not assumed. Reverting to
  `return total` fails `TestAnalyseReposListCountsAnalysedNotFound` with
  `count = 5, want 4`; restoring the `utils.HTTPClient` bypass fails
  `TestEnableNTLMAlsoWrapsTheSharedClient`.
- The NTLM handshake test drives a real two-message exchange against a server that behaves
  like IIS — it proves the wiring, not domain-controller interoperability.
- Full suite green across all three build tags (default, `golc`, `resultsall`); `go vet`
  clean.
- End-to-end scan: 3/3 repositories, 12.30K LOC, **no false "did not complete" warning** on a
  healthy run.
- SonarQube Agentic Analysis, DEEP, over all 8 files: 6 findings, all confirmed pre-existing
  by re-running against `HEAD` with the changes stashed (`golc.go` `go:S107` + 2× `godre:S8209`,
  `getazure.go` 3× `godre:S8242` on struct fields). None on lines this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)