### PR TITLE
chore: name the launcher golc, not webui

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build Go apps
         run: |
-          go build -trimpath -tags=webui -o webui webui.go golc.go
+          go build -trimpath -tags=webui -o golc webui.go golc.go
           go build -trimpath -tags=resultsall -o ResultsAll ./ResultsAll.go
 
       - name: Generate test coverage reports

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Each archive contains two binaries:
 
 | Binary | Purpose |
 |--------|---------|
-| `webui` / `webui.exe` | Browser-based launcher — start here |
-| `ResultsAll` / `ResultsAll.exe` | Results dashboard (launched automatically by `webui`) |
+| `golc` / `golc.exe` | Browser-based launcher — start here |
+| `ResultsAll` / `ResultsAll.exe` | Results dashboard (launched automatically by `golc`) |
 
-Run `webui` / `webui.exe`. The browser opens automatically to the GoLC UI (default: `http://localhost:8091`).
+Run `golc` / `golc.exe`. The browser opens automatically to the GoLC UI (default: `http://localhost:8091`).
 
 If it doesn't open, copy the URL printed in the terminal. Then:
 
@@ -390,9 +390,9 @@ GoLC writes a detailed log to `Logs/Logs.log` next to the binary. The file is re
 ## Troubleshooting
 
 ### "Apple could not verify" message
-When starting the app on MacOS you may get `Apple could not verify webui is free of malware that may harm your Mac or compromise your privacy."` message. To go around it, run:
+When starting the app on MacOS you may get `Apple could not verify golc is free of malware that may harm your Mac or compromise your privacy."` message. To go around it, run:
 
 ```
-xattr -cr /path/to/webui
+xattr -cr /path/to/golc
 xattr -cr /path/to/ResultsAll
 ```

--- a/ResultsAll.go
+++ b/ResultsAll.go
@@ -1615,7 +1615,7 @@ func handlePortConflict(port int) {
 func main() {
 	utils.ChdirToBinaryDir()
 
-	// Report the build and exit. This binary is shipped and run separately from webui, so
+	// Report the build and exit. This binary is shipped and run separately from golc, so
 	// it needs its own way to answer "which release is this?".
 	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v") {
 		fmt.Printf("GoLC ResultsAll %s\n", assets.Version)

--- a/create_release_sample.sh
+++ b/create_release_sample.sh
@@ -20,10 +20,10 @@ build_platform() {
 
   # -trimpath removes file system paths from binaries for security/privacy
   if [ "${GOOS}" = "windows" ]; then
-      go build -trimpath -tags=webui -ldflags "-X github.com/SonarSource-Demos/sonar-golc/assets.Version=${TAG}" -o "${DEST}/webui.exe" webui.go golc.go
+      go build -trimpath -tags=webui -ldflags "-X github.com/SonarSource-Demos/sonar-golc/assets.Version=${TAG}" -o "${DEST}/golc.exe" webui.go golc.go
       go build -trimpath -tags=resultsall -ldflags "-X github.com/SonarSource-Demos/sonar-golc/assets.Version=${TAG}" -o "${DEST}/ResultsAll.exe" ResultsAll.go
   else
-      go build -trimpath -tags=webui -ldflags "-X github.com/SonarSource-Demos/sonar-golc/assets.Version=${TAG}" -o "${DEST}/webui" webui.go golc.go
+      go build -trimpath -tags=webui -ldflags "-X github.com/SonarSource-Demos/sonar-golc/assets.Version=${TAG}" -o "${DEST}/golc" webui.go golc.go
       go build -trimpath -tags=resultsall -ldflags "-X github.com/SonarSource-Demos/sonar-golc/assets.Version=${TAG}" -o "${DEST}/ResultsAll" ResultsAll.go
   fi
 

--- a/golc.go
+++ b/golc.go
@@ -1544,7 +1544,7 @@ func setupResultsDirectory(platform string) string {
 }
 
 // runGolcInProcess runs the GoLC analysis for the given platform key (e.g. "Github").
-// It is invoked by the webui binary when started with --internal-run <platform>.
+// It is invoked by the golc binary when started with --internal-run <platform>.
 func runGolcInProcess(platform string) {
 	// Sweep any temp clones still registered by failed/partial analyses on the
 	// normal completion path too. Successful repos self-clean via their own

--- a/webui.go
+++ b/webui.go
@@ -1061,7 +1061,7 @@ func main() {
 	// When invoked as an internal analysis subprocess, run the GoLC engine and exit.
 	if len(os.Args) > 1 && os.Args[1] == "--internal-run" {
 		if len(os.Args) < 3 {
-			fmt.Fprintln(os.Stderr, "usage: webui --internal-run <platform>")
+			fmt.Fprintln(os.Stderr, "usage: golc --internal-run <platform>")
 			os.Exit(1)
 		}
 		runGolcInProcess(os.Args[2])


### PR DESCRIPTION
## What

Renames the shipped launcher binary from `webui` / `webui.exe` to `golc` / `golc.exe` on macOS, Linux and Windows.

The release archive was already named `golc_<version>_<os>_<arch>`, so the one thing users were told to double-click was the only thing not called GoLC. This aligns them.

| File | Change |
|---|---|
| `create_release_sample.sh` | Build output → `golc` / `golc.exe` (the script's only OS branch is the `.exe` suffix, so one edit per branch covers all three platforms) |
| `webui.go` | `--internal-run` usage line said `webui` |
| `golc.go`, `ResultsAll.go` | Comments describing "the webui binary" |
| `README.md` | Binary table, Quick Start, and the macOS Gatekeeper `xattr` instructions |
| `.github/workflows/go.yml` | Build smoke test, to match the release |

## Why this is safe

Both places that resolve a binary at runtime go through `os.Executable()`, so they follow the rename with no code change:

- **Self re-exec** (`webui.go:699`) — the launcher spawns itself with `--internal-run <platform>` to run the engine.
- **Sibling lookup** (`findBinary`, `webui.go:565`) — only ever called with `"ResultsAll"`; the launcher never looks itself up by name.

`killPort` finds the process holding a port via `lsof -ti` / `netstat -ano` and kills by **PID**, not by name. There is no process-name matching anywhere in the codebase (no `pkill`/`taskkill`/`killall`/`pgrep`/`/IM`). No test references the binary name.

## Verified

Built and exercised end to end on darwin/arm64:

- Launcher starts and serves (`GET /` and `/api/status` → 200).
- `POST /api/run` re-execs the renamed binary; run reaches `phase: complete`, `error: ""`, full JSON/CSV/PDF report set written.
- `POST /api/open-results` resolves and spawns `ResultsAll` as a child of `golc`; dashboard serves 200.
- `./golc --internal-run File` completes a standalone analysis.
- `go test ./pkg/...`, `go test -tags=golc .`, `go test -tags=resultsall .` all pass; `go vet` clean under both tag sets.

Windows/Linux were not executed. Their only platform-specific paths are `findBinary`'s runtime `.exe` suffix and `pidsByPortWindows`, neither of which reads the launcher's name.

## Deliberately unchanged

- **`webui` build tag** — internal, invisible to users.
- **`webui.go` filename** — renaming it would also mean editing `sonar.coverage.exclusions` and would break SonarQube Cloud's file history for it.
- **`GOLC_WEBUI_PORT`** — renaming it breaks anyone already setting it.

## Release note needed

Worth calling out in the release notes: users who extract over an existing install will keep a stale, still-working `webui` binary alongside the new `golc`, and macOS will re-prompt "Apple could not verify…" on first run of the renamed file. Suggest extracting to a fresh folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)