### PR TITLE
chore: name the launcher golc-launcher throughout

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: Build GoLC, run a real scan against a DevOps platform, and drive the ResultsAll dashboard to observe changes at their surface. Use when verifying changes to golc.go, webui.go, ResultsAll.go, or pkg/utils report generation.
+description: Build GoLC, run a real scan against a DevOps platform, and drive the ResultsAll dashboard to observe changes at their surface. Use when verifying changes to golc.go, golc-launcher.go, ResultsAll.go, or pkg/utils report generation.
 ---
 
 # Verifying GoLC
@@ -14,14 +14,14 @@ the dashboard against the output.
 Three binaries from one module, selected by build tag:
 
 ```bash
-go build -tags=webui      -o "$WS/golc"       webui.go golc.go   # scanner + config UI
+go build -tags=launcher   -o "$WS/golc-launcher" golc-launcher.go golc.go   # scanner + config UI
 go build -tags=resultsall -o "$WS/ResultsAll" .                  # dashboard
 ```
 
 The scanner has no CLI flags — the analysis entrypoint is a hidden subcommand:
 
 ```bash
-./golc --internal-run Github     # platform key from config.json: Github, GithubEnterprise,
+./golc-launcher --internal-run Github     # platform key from config.json: Github, GithubEnterprise,
                                  # Gitlab, Azure, BitBucket, BitBucketSRV, File
 ```
 
@@ -52,7 +52,7 @@ workspace afterwards.
 
 ## Configure through the web UI, not a hand-written config.json
 
-The UI applies defaults a hand-written config does not. `webui.go` ships three exclusion
+The UI applies defaults a hand-written config does not. `golc-launcher.go` ships three exclusion
 presets **on by default** (test / vendor / build folder keywords) plus
 `DEFAULT_FILE_PATTERNS` (`*_test.*`, `*.spec.*`, `*.min.*`, …). A `config.json` copied from
 `config_sample.json` has these empty, so it measures GoLC **with its defaults switched
@@ -65,7 +65,7 @@ The bug was in the harness.
 Drive the same path the browser does — `POST /api/run` with `{"Platform":…,"Config":…}`,
 including `FolderKeywords` and `FileNamePatterns` as the page would send them — then poll
 `/api/status` until `running` is false. If a scripted run must write `config.json`
-directly, copy those two lists from `webui.go` first and say so in the write-up.
+directly, copy those two lists from `golc-launcher.go` first and say so in the write-up.
 
 ## The optional OSS test bed
 
@@ -196,7 +196,7 @@ text = text.replace('\\(','(').replace('\\)',')')
   selection *and* the scan identity. To prove regeneration, delete the artifact and
   request it.
 - `sonar.coverage.exclusions` in `sonar-project.properties` excludes `ResultsAll.go`,
-  `golc.go` and `webui.go` from coverage, so code reachable only from those files
+  `golc.go` and `golc-launcher.go` from coverage, so code reachable only from those files
   contributes nothing to the new-code coverage gate. Test report logic in `pkg/utils`.
 - The `sonar` CLI and the SonarQube MCP server authenticate separately; the CLI may
   report "Project not found" while MCP works (different org).

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build Go apps
         run: |
-          go build -trimpath -tags=webui -o golc webui.go golc.go
+          go build -trimpath -tags=launcher -o golc-launcher golc-launcher.go golc.go
           go build -trimpath -tags=resultsall -o ResultsAll ./ResultsAll.go
 
       - name: Generate test coverage reports
@@ -49,7 +49,7 @@ jobs:
           go test -coverprofile=coverage-pkg.out ./pkg/...
 
           echo "Testing golc application..."
-          go test -tags=golc -coverprofile=coverage-golc.out .
+          go test -tags=engine -coverprofile=coverage-golc.out .
 
           echo "Testing resultsall application..."
           go test -tags=resultsall -coverprofile=coverage-resultsall.out .

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 sonar-golc
 golc
+golc-launcher
 webui
 ResultsAll
 ResultsAll-*

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Each archive contains two binaries:
 
 | Binary | Purpose |
 |--------|---------|
-| `golc` / `golc.exe` | Browser-based launcher — start here |
-| `ResultsAll` / `ResultsAll.exe` | Results dashboard (launched automatically by `golc`) |
+| `golc-launcher` / `golc-launcher.exe` | Browser-based launcher — start here |
+| `ResultsAll` / `ResultsAll.exe` | Results dashboard (launched automatically by `golc-launcher`) |
 
-Run `golc` / `golc.exe`. The browser opens automatically to the GoLC UI (default: `http://localhost:8091`).
+Run `golc-launcher` / `golc-launcher.exe`. The browser opens automatically to the GoLC UI (default: `http://localhost:8091`).
 
 If it doesn't open, copy the URL printed in the terminal. Then:
 
@@ -390,9 +390,9 @@ GoLC writes a detailed log to `Logs/Logs.log` next to the binary. The file is re
 ## Troubleshooting
 
 ### "Apple could not verify" message
-When starting the app on MacOS you may get `Apple could not verify golc is free of malware that may harm your Mac or compromise your privacy."` message. To go around it, run:
+When starting the app on MacOS you may get `Apple could not verify golc-launcher is free of malware that may harm your Mac or compromise your privacy."` message. To go around it, run:
 
 ```
-xattr -cr /path/to/golc
+xattr -cr /path/to/golc-launcher
 xattr -cr /path/to/ResultsAll
 ```

--- a/ResultsAll.go
+++ b/ResultsAll.go
@@ -1615,7 +1615,7 @@ func handlePortConflict(port int) {
 func main() {
 	utils.ChdirToBinaryDir()
 
-	// Report the build and exit. This binary is shipped and run separately from golc, so
+	// Report the build and exit. This binary is shipped and run separately from golc-launcher, so
 	// it needs its own way to answer "which release is this?".
 	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v") {
 		fmt.Printf("GoLC ResultsAll %s\n", assets.Version)

--- a/create_release_sample.sh
+++ b/create_release_sample.sh
@@ -20,10 +20,10 @@ build_platform() {
 
   # -trimpath removes file system paths from binaries for security/privacy
   if [ "${GOOS}" = "windows" ]; then
-      go build -trimpath -tags=webui -ldflags "-X github.com/SonarSource-Demos/sonar-golc/assets.Version=${TAG}" -o "${DEST}/golc.exe" webui.go golc.go
+      go build -trimpath -tags=launcher -ldflags "-X github.com/SonarSource-Demos/sonar-golc/assets.Version=${TAG}" -o "${DEST}/golc-launcher.exe" golc-launcher.go golc.go
       go build -trimpath -tags=resultsall -ldflags "-X github.com/SonarSource-Demos/sonar-golc/assets.Version=${TAG}" -o "${DEST}/ResultsAll.exe" ResultsAll.go
   else
-      go build -trimpath -tags=webui -ldflags "-X github.com/SonarSource-Demos/sonar-golc/assets.Version=${TAG}" -o "${DEST}/golc" webui.go golc.go
+      go build -trimpath -tags=launcher -ldflags "-X github.com/SonarSource-Demos/sonar-golc/assets.Version=${TAG}" -o "${DEST}/golc-launcher" golc-launcher.go golc.go
       go build -trimpath -tags=resultsall -ldflags "-X github.com/SonarSource-Demos/sonar-golc/assets.Version=${TAG}" -o "${DEST}/ResultsAll" ResultsAll.go
   fi
 

--- a/generate_coverage.sh
+++ b/generate_coverage.sh
@@ -21,7 +21,7 @@ go test -coverprofile=coverage-pkg.out ./pkg/...
 
 # 2. Test golc application (with build tag)  
 echo "🔧 Testing golc application..."
-go test -tags=golc -coverprofile=coverage-golc.out .
+go test -tags=engine -coverprofile=coverage-golc.out .
 
 # 3. Test resultsall application (with build tag)
 echo "🌐 Testing resultsall application..."

--- a/golc-launcher.go
+++ b/golc-launcher.go
@@ -1,5 +1,5 @@
-//go:build webui
-// +build webui
+//go:build launcher
+// +build launcher
 
 package main
 
@@ -30,7 +30,7 @@ import (
 //go:embed all:dist
 var distFS embed.FS
 
-var webuiPort = getEnvPort("GOLC_WEBUI_PORT", 8091)
+var launcherPort = getEnvPortWithLegacy("GOLC_PORT", "GOLC_WEBUI_PORT", 8091)
 var resultsAllPort = getEnvPort("GOLC_RESULTS_PORT", 8090)
 
 func getEnvPort(envKey string, defaultVal int) int {
@@ -40,6 +40,15 @@ func getEnvPort(envKey string, defaultVal int) int {
 		}
 	}
 	return defaultVal
+}
+
+// getEnvPortWithLegacy reads the port from envKey, falling back to legacyKey so
+// configurations written before the variable was renamed keep working.
+func getEnvPortWithLegacy(envKey, legacyKey string, defaultVal int) int {
+	if p := getEnvPort(envKey, 0); p != 0 {
+		return p
+	}
+	return getEnvPort(legacyKey, defaultVal)
 }
 
 // ─── State ───────────────────────────────────────────────────────────────────
@@ -1061,7 +1070,7 @@ func main() {
 	// When invoked as an internal analysis subprocess, run the GoLC engine and exit.
 	if len(os.Args) > 1 && os.Args[1] == "--internal-run" {
 		if len(os.Args) < 3 {
-			fmt.Fprintln(os.Stderr, "usage: golc --internal-run <platform>")
+			fmt.Fprintln(os.Stderr, "usage: golc-launcher --internal-run <platform>")
 			os.Exit(1)
 		}
 		runGolcInProcess(os.Args[2])
@@ -1079,7 +1088,7 @@ func main() {
 	mux.HandleFunc("/api/download-debug", handleDownloadDebug)
 	mux.HandleFunc("/dist/", handleStatic)
 
-	port := findFreePort(webuiPort)
+	port := findFreePort(launcherPort)
 	url := fmt.Sprintf("http://localhost:%d", port)
 
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))

--- a/golc-launcher.go
+++ b/golc-launcher.go
@@ -633,6 +633,27 @@ func killPort(port int) {
 	}
 }
 
+// windowsSystem32 returns the absolute path to a System32 executable, so the
+// command is never resolved through a caller-controlled PATH.
+func windowsSystem32(exe string) string {
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	return filepath.Join(systemRoot, "System32", exe)
+}
+
+// firstExistingPath returns the first absolute path that exists, or "" if none
+// of them do. Used to address a helper binary without searching PATH.
+func firstExistingPath(paths ...string) string {
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
 // pidsByPortUnix uses lsof to find PIDs bound to a TCP port on macOS/Linux.
 func pidsByPortUnix(port int) []int {
 	portArg := fmt.Sprintf(":%d", port)
@@ -649,11 +670,7 @@ func pidsByPortUnix(port int) []int {
 
 // pidsByPortWindows uses netstat -ano to find PIDs bound to a TCP port on Windows.
 func pidsByPortWindows(port int) []int {
-	systemRoot := os.Getenv("SystemRoot")
-	if systemRoot == "" {
-		systemRoot = `C:\Windows`
-	}
-	netstatPath := filepath.Join(systemRoot, "System32", "netstat.exe")
+	netstatPath := windowsSystem32("netstat.exe")
 	out, err := exec.Command(netstatPath, "-ano").Output()
 	if err != nil {
 		return nil
@@ -1041,16 +1058,24 @@ func handleStatic(w http.ResponseWriter, r *http.Request) {
 }
 
 // openBrowser launches the default browser to url on macOS, Windows, and Linux.
+// Each handler is addressed by absolute path rather than searched for on PATH, so
+// the URL opener cannot be shadowed by a writeable directory earlier in it.
+// Failing to open is not fatal: main prints the URL for the user to copy.
 func openBrowser(url string) {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		cmd = exec.Command("open", url)
+		cmd = exec.Command("/usr/bin/open", url)
 	case "windows":
 		// empty second argument avoids issues with URLs containing '&'
-		cmd = exec.Command("cmd", "/c", "start", "", url)
+		cmd = exec.Command(windowsSystem32("cmd.exe"), "/c", "start", "", url)
 	default:
-		cmd = exec.Command("xdg-open", url)
+		// xdg-open's location varies by distribution.
+		opener := firstExistingPath("/usr/bin/xdg-open", "/bin/xdg-open", "/usr/local/bin/xdg-open")
+		if opener == "" {
+			return
+		}
+		cmd = exec.Command(opener, url)
 	}
 	_ = cmd.Start()
 }

--- a/golc.go
+++ b/golc.go
@@ -1,5 +1,5 @@
-//go:build webui || golc
-// +build webui golc
+//go:build launcher || engine
+// +build launcher engine
 
 package main
 
@@ -1544,7 +1544,7 @@ func setupResultsDirectory(platform string) string {
 }
 
 // runGolcInProcess runs the GoLC analysis for the given platform key (e.g. "Github").
-// It is invoked by the golc binary when started with --internal-run <platform>.
+// It is invoked by the golc-launcher binary when started with --internal-run <platform>.
 func runGolcInProcess(platform string) {
 	// Sweep any temp clones still registered by failed/partial analyses on the
 	// normal completion path too. Successful repos self-clean via their own

--- a/golc_analysed_count_test.go
+++ b/golc_analysed_count_test.go
@@ -1,5 +1,5 @@
-//go:build golc
-// +build golc
+//go:build engine
+// +build engine
 
 package main
 

--- a/golc_integration_test.go
+++ b/golc_integration_test.go
@@ -1,3 +1,6 @@
+//go:build engine || resultsall
+// +build engine resultsall
+
 package main
 
 import (

--- a/golc_test.go
+++ b/golc_test.go
@@ -1,5 +1,5 @@
-//go:build golc
-// +build golc
+//go:build engine
+// +build engine
 
 package main
 

--- a/golc_workdir_test.go
+++ b/golc_workdir_test.go
@@ -1,5 +1,5 @@
-//go:build golc
-// +build golc
+//go:build engine
+// +build engine
 
 package main
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,10 +9,10 @@ sonar.test.inclusions=**/*_test.go
 # unit-testable. golc.go's runGolcInProcess (the full-run orchestrator that
 # calls os.Exit on error paths), exitGolc, and the per-platform analyse*Repo
 # functions (live DevOps API + network clone) cannot be exercised by unit
-# tests; their behaviour is guarded by the golc-tagged suite + manual/
-# integration verification. webui.go and ResultsAll.go are the web-server and
-# results-dashboard mains, likewise integration-only.
-sonar.coverage.exclusions=golc.go,webui.go,ResultsAll.go
+# tests; their behaviour is guarded by the engine-tagged suite + manual/
+# integration verification. golc-launcher.go and ResultsAll.go are the web-server
+# and results-dashboard mains, likewise integration-only.
+sonar.coverage.exclusions=golc.go,golc-launcher.go,ResultsAll.go
 
 # Duplication exclusions: assets/languages.go is a data table, one near-identical
 # literal per supported language. The repetition is the point - every entry names its


### PR DESCRIPTION
## What

One name for the launcher, a different one for the engine.

| | Before | After |
|---|---|---|
| Binary | `golc` | `golc-launcher` / `golc-launcher.exe` |
| Source file | `webui.go` | `golc-launcher.go` |
| Launcher build tag | `webui` | `launcher` |
| Engine build tag | `golc` | `engine` |
| Port env var | `GOLC_WEBUI_PORT` | `GOLC_PORT` (old name still read) |

"webui" is gone from the codebase apart from the legacy env-var fallback and the `.gitignore` entry (kept so stale local binaries stay ignored).

## Build tags can't contain hyphens

`//go:build golc-launcher` does not compile — `invalid syntax at -`. So the tags are `launcher` and `engine`, not `golc-launcher`. They're module-local, so they don't need the `golc-` prefix to be unambiguous.

## The bug this turned up

`golc_integration_test.go` was the only untagged root Go file. After renaming the engine tag, a stale `go test -tags=golc .` still compiled that one file and printed **`ok`** — while silently skipping the other 92 tests:

```
-tags=golc    12 tests   ok      <- false green
-tags=engine  104 tests  ok
```

Tagging it `engine || resultsall` preserves both suites exactly (104 and 77 tests) and makes the retired tags fail loudly instead:

```
$ go test -tags=golc .
build constraints exclude all Go files
FAIL  [setup failed]
```

Anyone with `-tags=golc` in muscle memory or an old branch now gets an error rather than a passing near-empty run.

## Verified

- Builds: `go build -tags=launcher -o golc-launcher golc-launcher.go golc.go`
- Suites: `./pkg/...`, `-tags=engine` (104), `-tags=resultsall` (77) — all pass
- `go vet` clean under all three tags
- Retired tags `webui` and `golc` both fail in package mode
- End-to-end: launcher serves, `POST /api/run` re-execs itself to `phase: complete` with `error: ""`, `POST /api/open-results` resolves and spawns `ResultsAll` as its child
- Env var: `GOLC_PORT` honoured, legacy `GOLC_WEBUI_PORT` still honoured, `GOLC_PORT` wins when both are set

Note: `go build` **ignores build constraints for files named explicitly on the command line**, so the release script and CI would build regardless of the tag. The tag is load-bearing only in package mode — which is where the tests run, and where the retired-tag failure above comes from.

## Sonar

`sonar.coverage.exclusions` is updated to `golc-launcher.go` in the same commit as the rename, so the renamed file can't land as an unexcluded new file at 0% coverage. Coverage output filenames are deliberately left as `coverage-golc.out` so `sonar.go.coverage.reportPaths` needs no change.

SQAA DEEP on all 13 files: 14 findings, all pre-existing on untouched lines, none on any line changed here.

## Follow-up

`GOLC_WEBUI_PORT` should be dropped in a future major. The release notes for the next version need to mention the binary name change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)