### PR TITLE
fix: strip a UTF-8 BOM before testing for comment tokens

### DIFF
--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -193,6 +193,7 @@ func (sc *Scanner) scanFile(file analyzer.FileMetadata) (scanResult, error) {
 	defer f.Close()
 
 	reader := bufio.NewReader(f)
+	firstLine := true
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil && err != io.EOF {
@@ -206,6 +207,17 @@ func (sc *Scanner) scanFile(file analyzer.FileMetadata) (scanResult, error) {
 		lastLine := err == io.EOF
 		if lastLine && line == "" {
 			break
+		}
+
+		// A UTF-8 BOM is not Unicode whitespace, so TrimSpace leaves it in place and every
+		// prefix test below misses: a file opening with a BOM and then a block comment had
+		// its whole licence header counted as code. Visual Studio writes a BOM by default,
+		// so this hit 92% of the C# files in a real .NET repository and inflated its count
+		// by 50%. Strip it only on the first line - U+FEFF anywhere else is a zero-width
+		// no-break space, which is content.
+		if firstLine {
+			line = strings.TrimPrefix(line, "\ufeff")
+			firstLine = false
 		}
 
 		line = strings.TrimSpace(line)

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -324,3 +324,105 @@ func TestScanCountsFinalLineInsideBlockComment(t *testing.T) {
 			got.CodeLines, got.Comments)
 	}
 }
+
+// A UTF-8 BOM must not hide the comment tokens on the first line. TrimSpace does not
+// remove U+FEFF - it is not Unicode whitespace - so before the fix a BOM left the line
+// as U+FEFF followed by "/*", every HasPrefix test missed, and the block comment was never entered:
+// the whole licence header was counted as code. Visual Studio writes a BOM by default,
+// which made this the dominant error on .NET repositories.
+func TestScanCountsCommentsOnBOMPrefixedFirstLine(t *testing.T) {
+	const bom = "\ufeff"
+
+	sc := NewScanner(language.Languages{
+		"C#": {
+			LineComments:      []string{"//"},
+			MultiLineComments: [][]string{{"/*", "*/"}},
+			Extensions:        []string{".cs"},
+		},
+	})
+
+	cases := []struct {
+		name                         string
+		content                      string
+		code, comments, blank, lines int
+	}{
+		{
+			name:     "BOM then a multi-line licence header",
+			content:  bom + "/*\n * Copyright\n */\nvar a = 1;\n",
+			code:     1,
+			comments: 3,
+			lines:    4,
+		},
+		{
+			name:     "same header without a BOM counts identically",
+			content:  "/*\n * Copyright\n */\nvar a = 1;\n",
+			code:     1,
+			comments: 3,
+			lines:    4,
+		},
+		{
+			name:     "BOM then a single-line comment",
+			content:  bom + "// note\nvar a = 1;\n",
+			code:     1,
+			comments: 1,
+			lines:    2,
+		},
+		{
+			name:     "BOM then a self-closing block comment",
+			content:  bom + "/* note */\nvar a = 1;\n",
+			code:     1,
+			comments: 1,
+			lines:    2,
+		},
+		{
+			name:    "BOM then code is still code",
+			content: bom + "var a = 1;\n",
+			code:    1,
+			lines:   1,
+		},
+		{
+			name:    "BOM alone is a blank line, not code",
+			content: bom + "\nvar a = 1;\n",
+			code:    1,
+			blank:   1,
+			lines:   2,
+		},
+		{
+			// Only the first line is stripped: U+FEFF later in a file is a zero-width
+			// no-break space, which is content and must not silently vanish.
+			name:     "a BOM-like rune on a later line does not open a comment",
+			content:  "var a = 1;\n" + bom + "/* note */\n",
+			code:     2,
+			comments: 0,
+			lines:    2,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "f.cs")
+			if err := os.WriteFile(path, []byte(c.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := sc.scanFile(analyzer.FileMetadata{
+				FilePath: path, Extension: ".cs", Language: "C#",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.CodeLines != c.code {
+				t.Errorf("CodeLines = %d, want %d", got.CodeLines, c.code)
+			}
+			if got.Comments != c.comments {
+				t.Errorf("Comments = %d, want %d", got.Comments, c.comments)
+			}
+			if got.BlankLines != c.blank {
+				t.Errorf("BlankLines = %d, want %d", got.BlankLines, c.blank)
+			}
+			if got.Lines != c.lines {
+				t.Errorf("Lines = %d, want %d", got.Lines, c.lines)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The defect

`strings.TrimSpace` does not remove U+FEFF — the BOM is not Unicode whitespace. So the first line of a BOM-prefixed file reads as U+FEFF followed by its real content, every `strings.HasPrefix` test in `scanFile` misses, block-comment state is never entered, and the entire leading licence header is counted as code.

Visual Studio writes a BOM by default, which makes this the dominant counting error on .NET repositories — and it is invisible on most benchmark corpora, because no other language in the five repositories I swept is affected.

## Measured effect

On SonarSource's `sonarlint-visualstudio`, over the **exact 1,157 files SonarQube analyses** (file list read from `api/measures/component_tree`, hard-linked into a tree containing nothing else, GoLC exclusions off — so scope is identical on both sides and only the counting engine is under test):

| | ncloc |
|---|---:|
| SonarQube | 41,578 |
| GoLC before | 62,565 — **+50.5%** |
| GoLC after | 41,871 — **+0.7%** |

1,785 of its 1,950 C# files carry a BOM followed by a 19-line header: **33,917 lines** across the repository attributed to code. GoLC reported 7,691 comment lines where the true figure is 28,377.

Across a five-repository corpus (sonar-enterprise, sonarqube-webapp, llvm-project, sonar-skunk, sonarlint-visualstudio) scanned at SonarQube's own file-level scope, the total moves from **+2.5% to +1.5%** of ncloc — 2,049,118 → 2,028,422 against 1,998,879 over 14,821 files. The other four projects are unaffected and already sat within 2%.

## The change

Four lines: strip the BOM from the first line before the prefix tests. Only the first line — U+FEFF elsewhere in a file is a zero-width no-break space and is content, so stripping it globally would silently drop real characters. A test case covers that boundary.

## Tests

`TestScanCountsCommentsOnBOMPrefixedFirstLine` covers seven cases: BOM + multi-line header, the same header without a BOM (must count identically), BOM + line comment, BOM + self-closing block comment, BOM + code, BOM alone as a blank line, and a BOM-like rune on a later line that must **not** open a comment.

- `go test ./...` — pass
- `go test -tags=engine .` — pass
- `GOLC_RESULTS_PORT=<free> go test -tags=resultsall .` — pass (the default 8090 is held by Docker locally; that failure is pre-existing and reproduces on an unmodified tree)
- `go vet`, `gofmt` — clean
- `sonar analyze` on both files — no issues

Server-side Vortex analysis could not run: the `sonar` CLI and MCP server authenticate to `sonarcloud-demos`, while this project's key lives in `sonar-solutions`, so both report "Project not found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
