### PR TITLE
fix: support GitHub Enterprise Cloud data residency (x.ghe.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 It connects to your DevOps platform, counts one branch per repository, and presents the results in an interactive web dashboard with PDF, JSON, and CSV exports.
 
-**Supported platforms:** GitHub.com · GitHub Enterprise Server · GitLab Cloud · GitLab Self-Managed · Bitbucket Cloud · Bitbucket Data Center · Azure DevOps Services · Azure DevOps Server · Local files/directories
+**Supported platforms:** GitHub.com · GitHub Enterprise Server · GitHub Enterprise Cloud (including data residency) · GitLab Cloud · GitLab Self-Managed · Bitbucket Cloud · Bitbucket Data Center · Azure DevOps Services · Azure DevOps Server · Local files/directories
 
 > Current version: **v2.1**
 
@@ -71,6 +71,13 @@ Credentials are entered in the browser and saved automatically — no config fil
 | Bitbucket Data Center | Repo read, pull |
 | Azure DevOps | Code: Read · Project and Team: Read |
 | Azure DevOps Server | Code: Read · Project and Team: Read |
+
+#### GitHub Enterprise
+
+The **GitHub Enterprise** card covers both self-hosted GitHub Enterprise Server and
+GitHub Enterprise Cloud with data residency (a dedicated `*.ghe.com` address). Enter
+your server's URL in the **Server URL** field — GoLC detects which variant it is
+from the address and shows the result right under the field.
 
 #### Azure DevOps Server
 

--- a/golc-launcher.go
+++ b/golc-launcher.go
@@ -1927,11 +1927,14 @@ function syncAzureServerProtocol() {
 }
 
 // Derive Baseapi (hostname) and Protocol from the GithubEnterprise Url field,
-// and show the user which GitHub variant that host resolves to. GHE.com data
-// residency tenants get a dedicated "<subdomain>.ghe.com" host and talk to a
-// bare "https://api.<subdomain>.ghe.com" API (no "/api/v3" segment) — the same
-// shape golc's own client now applies (see initializeGithubClient); everything
-// else is treated as a classic GitHub Enterprise Server host ("<host>/api/v3/").
+// and show the user which GitHub variant that host resolves to. This mirrors
+// go-github's WithEnterpriseURLs exactly (see initializeGithubClient): it only
+// skips appending "/api/v3/" when the host starts with "api." or contains
+// ".api." — GHE.com data residency tenants are reachable at such a bare
+// "https://api.<subdomain>.ghe.com" host. A ".ghe.com" host missing that
+// "api." prefix does NOT get the bare shape — go-github still appends
+// "/api/v3/" to it, which 404s against a real data-residency tenant — so that
+// case is flagged instead of misreported as a working "data residency" host.
 function syncGHEBaseapi() {
   const urlEl = document.getElementById('f-Url');
   if (!urlEl) return;
@@ -1949,10 +1952,14 @@ function syncGHEBaseapi() {
 
   const detectEl = document.getElementById('ghe-detect');
   if (detectEl) {
+    const hasApiPrefix = /^api\./i.test(host) || /\.api\./i.test(host);
+    const isGheComHost = /\.ghe\.com$/i.test(host);
     if (!host) {
       detectEl.innerHTML = '';
-    } else if (/\.ghe\.com$/i.test(host)) {
+    } else if (hasApiPrefix && isGheComHost) {
       detectEl.innerHTML = '<i class="fas fa-circle-check text-success me-1"></i>Detected: <strong>GitHub Enterprise Cloud</strong> (data residency)';
+    } else if (isGheComHost) {
+      detectEl.innerHTML = '<i class="fas fa-triangle-exclamation text-warning me-1"></i>This looks like a data-residency host, but is missing the required <strong>api.</strong> prefix — try <code>https://api.' + host + '/</code>';
     } else {
       detectEl.innerHTML = '<i class="fas fa-circle-check text-success me-1"></i>Detected: <strong>GitHub Enterprise Server</strong>';
     }

--- a/golc-launcher.go
+++ b/golc-launcher.go
@@ -1240,7 +1240,7 @@ const htmlTemplate = `<!DOCTYPE html>
       </div>
       <div class="platform-card" data-platform="GithubEnterprise">
         <div class="icon"><i class="fab fa-github"></i></div>
-        <div class="name">GitHub Enterprise<br><small style="color:#64748b;font-weight:400;">On-premises</small></div>
+        <div class="name">GitHub Enterprise<br><small style="color:#64748b;font-weight:400;">On-premises or GHE.com</small></div>
       </div>
       <div class="platform-card" data-platform="Gitlab">
         <div class="icon"><i class="fab fa-gitlab"></i></div>

--- a/golc-launcher.go
+++ b/golc-launcher.go
@@ -1664,6 +1664,7 @@ function buildBasicFields(key, saved) {
       const detectEl = document.createElement('div');
       detectEl.id = f.detect;
       detectEl.className = 'form-text mt-1';
+      detectEl.style.display = 'none';
       col.appendChild(detectEl);
     }
     row.appendChild(col);
@@ -1963,6 +1964,7 @@ function syncGHEBaseapi() {
     } else {
       detectEl.innerHTML = '<i class="fas fa-circle-check text-success me-1"></i>Detected: <strong>GitHub Enterprise Server</strong>';
     }
+    detectEl.style.display = host ? '' : 'none';
   }
 }
 

--- a/golc-launcher.go
+++ b/golc-launcher.go
@@ -1524,7 +1524,7 @@ const basicFields = {
   GithubEnterprise: [{id:'Users',label:'Username / Login',ph:'your-login'},
                      {id:'AccessToken',label:'Access Token <small class="text-muted">— Classic PAT: <strong>repo</strong> &nbsp;|&nbsp; Fine-grained: <strong>Contents: Read</strong> &amp; <strong>Metadata: Read</strong></small>',ph:TOKEN_PH,secret:true,html:true},
                      {id:'Organization',label:'Organization',ph:'your-org'},
-                     {id:'Url',label:'Server URL',ph:'https://github.yourcompany.com/',onchange:'syncGHEBaseapi()',detect:'ghe-detect'}],
+                     {id:'Url',label:'Server URL <small class="text-muted">— e.g. github.mycompany.com (self-hosted) or api.mycompany.ghe.com (GHEC data residency)</small>',ph:'https://github.yourcompany.com/',onchange:'syncGHEBaseapi()',detect:'ghe-detect',html:true}],
   Gitlab:           [{id:'Users',label:'Username / Login',ph:'your-gitlab-login'},
                      {id:'AccessToken',label:'Access Token <small class="text-muted">— requires <strong>read_api</strong> &amp; <strong>read_repository</strong> scopes</small>',ph:TOKEN_PH,secret:true,html:true},
                      {id:'Organization',label:'Group URL slug(s) <small class="text-muted">(comma-separated — leave blank to auto-discover all your accessible groups)</small>',ph:'url-slug-1,url-slug-2',html:true},
@@ -1955,7 +1955,7 @@ function syncGHEBaseapi() {
     const hasApiPrefix = /^api\./i.test(host) || /\.api\./i.test(host);
     const isGheComHost = /\.ghe\.com$/i.test(host);
     if (!host) {
-      detectEl.innerHTML = 'e.g. <code>https://github.mycompany.com</code> (self-hosted) or <code>https://api.mycompany.ghe.com</code> (GHEC data residency)';
+      detectEl.innerHTML = '';
     } else if (hasApiPrefix && isGheComHost) {
       detectEl.innerHTML = '<i class="fas fa-circle-check text-success me-1"></i>Detected: <strong>GitHub Enterprise Cloud</strong> (data residency)';
     } else if (isGheComHost) {

--- a/golc-launcher.go
+++ b/golc-launcher.go
@@ -1507,7 +1507,7 @@ const htmlTemplate = `<!DOCTYPE html>
 <script>
 const platforms = {
   Github:           { icon:'fab fa-github',     label:'GitHub.com',        sub:'Cloud' },
-  GithubEnterprise: { icon:'fab fa-github',     label:'GitHub Enterprise', sub:'On-premises' },
+  GithubEnterprise: { icon:'fab fa-github',     label:'GitHub Enterprise', sub:'Server · Cloud (data residency)' },
   Gitlab:           { icon:'fab fa-gitlab',     label:'GitLab',            sub:'Cloud & On-premises' },
   BitBucket:        { icon:'fab fa-bitbucket',  label:'Bitbucket Cloud',   sub:'Cloud' },
   BitBucketSRV:     { icon:'fab fa-bitbucket',  label:'Bitbucket DC',      sub:'On-premises' },
@@ -1524,7 +1524,7 @@ const basicFields = {
   GithubEnterprise: [{id:'Users',label:'Username / Login',ph:'your-login'},
                      {id:'AccessToken',label:'Access Token <small class="text-muted">— Classic PAT: <strong>repo</strong> &nbsp;|&nbsp; Fine-grained: <strong>Contents: Read</strong> &amp; <strong>Metadata: Read</strong></small>',ph:TOKEN_PH,secret:true,html:true},
                      {id:'Organization',label:'Organization',ph:'your-org'},
-                     {id:'Url',label:'Server URL',ph:'https://github.yourcompany.com/',onchange:'syncGHEBaseapi()'}],
+                     {id:'Url',label:'Server URL',ph:'https://github.yourcompany.com/',onchange:'syncGHEBaseapi()',detect:'ghe-detect'}],
   Gitlab:           [{id:'Users',label:'Username / Login',ph:'your-gitlab-login'},
                      {id:'AccessToken',label:'Access Token <small class="text-muted">— requires <strong>read_api</strong> &amp; <strong>read_repository</strong> scopes</small>',ph:TOKEN_PH,secret:true,html:true},
                      {id:'Organization',label:'Group URL slug(s) <small class="text-muted">(comma-separated — leave blank to auto-discover all your accessible groups)</small>',ph:'url-slug-1,url-slug-2',html:true},
@@ -1660,6 +1660,12 @@ function buildBasicFields(key, saved) {
     if (f.html) label.innerHTML = f.label; else label.textContent = f.label;
     col.appendChild(label);
     col.appendChild(input);
+    if (f.detect) {
+      const detectEl = document.createElement('div');
+      detectEl.id = f.detect;
+      detectEl.className = 'form-text mt-1';
+      col.appendChild(detectEl);
+    }
     row.appendChild(col);
   });
   container.appendChild(row);
@@ -1667,6 +1673,11 @@ function buildBasicFields(key, saved) {
   // File mode: append multi-directory widget after the standard fields
   if (key === 'File') {
     buildFileDirectories(saved);
+  }
+  // GitHub Enterprise: show the live "which GitHub variant did you type" badge
+  // right away for a pre-filled/saved Url, not just after the next keystroke.
+  if (key === 'GithubEnterprise') {
+    syncGHEBaseapi();
   }
 }
 
@@ -1915,7 +1926,12 @@ function syncAzureServerProtocol() {
   el.value = m ? m[1].toLowerCase() : 'https';
 }
 
-// Derive Baseapi (hostname) and Protocol from the GithubEnterprise Url field.
+// Derive Baseapi (hostname) and Protocol from the GithubEnterprise Url field,
+// and show the user which GitHub variant that host resolves to. GHE.com data
+// residency tenants get a dedicated "<subdomain>.ghe.com" host and talk to a
+// bare "https://api.<subdomain>.ghe.com" API (no "/api/v3" segment) — the same
+// shape golc's own client now applies (see initializeGithubClient); everything
+// else is treated as a classic GitHub Enterprise Server host ("<host>/api/v3/").
 function syncGHEBaseapi() {
   const urlEl = document.getElementById('f-Url');
   if (!urlEl) return;
@@ -1930,6 +1946,17 @@ function syncGHEBaseapi() {
   };
   setHidden('f-Baseapi', host);
   setHidden('f-Protocol', protocol);
+
+  const detectEl = document.getElementById('ghe-detect');
+  if (detectEl) {
+    if (!host) {
+      detectEl.innerHTML = '';
+    } else if (/\.ghe\.com$/i.test(host)) {
+      detectEl.innerHTML = '<i class="fas fa-circle-check text-success me-1"></i>Detected: <strong>GitHub Enterprise Cloud</strong> (data residency)';
+    } else {
+      detectEl.innerHTML = '<i class="fas fa-circle-check text-success me-1"></i>Detected: <strong>GitHub Enterprise Server</strong>';
+    }
+  }
 }
 
 function gatherConfig() {

--- a/golc-launcher.go
+++ b/golc-launcher.go
@@ -1507,7 +1507,7 @@ const htmlTemplate = `<!DOCTYPE html>
 <script>
 const platforms = {
   Github:           { icon:'fab fa-github',     label:'GitHub.com',        sub:'Cloud' },
-  GithubEnterprise: { icon:'fab fa-github',     label:'GitHub Enterprise', sub:'Server · Cloud (data residency)' },
+  GithubEnterprise: { icon:'fab fa-github',     label:'GitHub Enterprise', sub:'On-premises or GHE.com' },
   Gitlab:           { icon:'fab fa-gitlab',     label:'GitLab',            sub:'Cloud & On-premises' },
   BitBucket:        { icon:'fab fa-bitbucket',  label:'Bitbucket Cloud',   sub:'Cloud' },
   BitBucketSRV:     { icon:'fab fa-bitbucket',  label:'Bitbucket DC',      sub:'On-premises' },
@@ -1955,7 +1955,7 @@ function syncGHEBaseapi() {
     const hasApiPrefix = /^api\./i.test(host) || /\.api\./i.test(host);
     const isGheComHost = /\.ghe\.com$/i.test(host);
     if (!host) {
-      detectEl.innerHTML = '';
+      detectEl.innerHTML = 'e.g. <code>https://github.mycompany.com</code> (self-hosted) or <code>https://api.mycompany.ghe.com</code> (GHEC data residency)';
     } else if (hasApiPrefix && isGheComHost) {
       detectEl.innerHTML = '<i class="fas fa-circle-check text-success me-1"></i>Detected: <strong>GitHub Enterprise Cloud</strong> (data residency)';
     } else if (isGheComHost) {

--- a/pkg/devops/getgithub/getgithub.go
+++ b/pkg/devops/getgithub/getgithub.go
@@ -805,22 +805,21 @@ func initializeGithubClient(platformConfig map[string]interface{}) (context.Cont
 
 	// Check if this is GitHub Enterprise Server (not GitHub cloud)
 	if url != "https://api.github.com/" && url != "https://api.github.com" {
-		// GitHub Enterprise Server - construct the proper API URLs
+		// This URL covers two distinct GitHub variants that share the same config
+		// shape: classic GitHub Enterprise Server (self-hosted, API at
+		// "<host>/api/v3/") and GitHub Enterprise Cloud with data residency
+		// (API at the bare host "https://api.<subdomain>.ghe.com/", no "/api/v3"
+		// segment). Deliberately do NOT append "/api/v3/" ourselves here:
+		// go-github's own WithEnterpriseURLs already adds it for a classic GHES
+		// host, but skips it whenever the host starts with "api." (or contains
+		// ".api.") — which is exactly the data-residency shape. Pre-appending it
+		// would defeat that check and send data-residency tenants to a 404.
 		baseURL := url
 		if !strings.HasSuffix(baseURL, "/") {
 			baseURL += "/"
 		}
-		// GitHub Enterprise Server API is typically at /api/v3/
-		// Only add /api/v3/ if it's not already present
-		if !strings.Contains(baseURL, "/api/v3/") && !strings.Contains(baseURL, "/api/v4/") {
-			if strings.HasSuffix(baseURL, "/") {
-				baseURL += "api/v3/"
-			} else {
-				baseURL += "/api/v3/"
-			}
-		}
 
-		// Create client for GitHub Enterprise Server
+		// Create client for GitHub Enterprise Server / GHE.com data residency
 		client, err := github.NewClient(nil).WithAuthToken(accessToken).WithEnterpriseURLs(baseURL, baseURL)
 		if err != nil {
 			loggers := utils.SharedLogger()

--- a/pkg/devops/getgithub/getgithub_test.go
+++ b/pkg/devops/getgithub/getgithub_test.go
@@ -799,7 +799,11 @@ func TestUtilityFunctions(t *testing.T) {
 	})
 }
 
-// TestInitializeGithubClient tests GitHub client initialization
+// TestInitializeGithubClient tests GitHub client initialization, including the
+// BaseURL each of the GitHub variants ends up with — not just that a client
+// was returned. This is the behavior that distinguishes classic GitHub
+// Enterprise Server (gets "/api/v3/" appended) from GitHub Enterprise Cloud
+// with data residency (bare "api.<subdomain>.ghe.com" host, no "/api/v3/").
 func TestInitializeGithubClient(t *testing.T) {
 	t.Run("GitHub Cloud client", func(t *testing.T) {
 		platformConfig := map[string]interface{}{
@@ -812,11 +816,14 @@ func TestInitializeGithubClient(t *testing.T) {
 			t.Error("initializeGithubClient should return non-nil context")
 		}
 		if client == nil {
-			t.Error("initializeGithubClient should return non-nil client")
+			t.Fatal("initializeGithubClient should return non-nil client")
+		}
+		if got := client.BaseURL.String(); got != "https://api.github.com/" {
+			t.Errorf("BaseURL = %q, want %q", got, "https://api.github.com/")
 		}
 	})
 
-	t.Run("GitHub Enterprise client", func(t *testing.T) {
+	t.Run("GitHub Enterprise Server client gets /api/v3/ appended", func(t *testing.T) {
 		platformConfig := map[string]interface{}{
 			"AccessToken": testToken,
 			"Url":         "https://github.enterprise.com/",
@@ -827,11 +834,15 @@ func TestInitializeGithubClient(t *testing.T) {
 			t.Error("initializeGithubClient should return non-nil context for enterprise")
 		}
 		if client == nil {
-			t.Error("initializeGithubClient should return non-nil client for enterprise")
+			t.Fatal("initializeGithubClient should return non-nil client for enterprise")
+		}
+		want := "https://github.enterprise.com/api/v3/"
+		if got := client.BaseURL.String(); got != want {
+			t.Errorf("BaseURL = %q, want %q", got, want)
 		}
 	})
 
-	t.Run("GitHub Enterprise with api/v3 in URL", func(t *testing.T) {
+	t.Run("GitHub Enterprise with api/v3 already in URL is not duplicated", func(t *testing.T) {
 		platformConfig := map[string]interface{}{
 			"AccessToken": testToken,
 			"Url":         "https://github.enterprise.com/api/v3/",
@@ -842,7 +853,48 @@ func TestInitializeGithubClient(t *testing.T) {
 			t.Error("initializeGithubClient should return non-nil context")
 		}
 		if client == nil {
-			t.Error("initializeGithubClient should return non-nil client")
+			t.Fatal("initializeGithubClient should return non-nil client")
+		}
+		want := "https://github.enterprise.com/api/v3/"
+		if got := client.BaseURL.String(); got != want {
+			t.Errorf("BaseURL = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("GHE.com data residency host keeps a bare API path", func(t *testing.T) {
+		platformConfig := map[string]interface{}{
+			"AccessToken": testToken,
+			"Url":         "https://api.acme.ghe.com/",
+		}
+
+		ctx, client := initializeGithubClient(platformConfig)
+		if ctx == nil {
+			t.Error("initializeGithubClient should return non-nil context")
+		}
+		if client == nil {
+			t.Fatal("initializeGithubClient should return non-nil client")
+		}
+		// "api.<subdomain>.ghe.com" must NOT get "/api/v3/" appended — that path
+		// only exists on classic GHES. See getgithub.go: initializeGithubClient.
+		want := "https://api.acme.ghe.com/"
+		if got := client.BaseURL.String(); got != want {
+			t.Errorf("BaseURL = %q, want %q (data residency host must stay bare)", got, want)
+		}
+	})
+
+	t.Run("GHE.com data residency host without trailing slash", func(t *testing.T) {
+		platformConfig := map[string]interface{}{
+			"AccessToken": testToken,
+			"Url":         "https://api.acme.ghe.com",
+		}
+
+		_, client := initializeGithubClient(platformConfig)
+		if client == nil {
+			t.Fatal("initializeGithubClient should return non-nil client")
+		}
+		want := "https://api.acme.ghe.com/"
+		if got := client.BaseURL.String(); got != want {
+			t.Errorf("BaseURL = %q, want %q", got, want)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- `initializeGithubClient` was manually pre-appending `/api/v3/` to any non-`api.github.com` URL before calling go-github's `WithEnterpriseURLs`. That defeated go-github's own host-aware logic, which already skips the `/api/v3/` suffix for a bare `api.<subdomain>.ghe.com` host — exactly the API shape GHE.com data-residency tenants use (unprefixed, same scheme as github.com, just on a dedicated subdomain). Classic GitHub Enterprise Server hosts are unaffected — go-github still appends `/api/v3/` for those.
- Added a live "Detected: GitHub Enterprise Server" / "Detected: GitHub Enterprise Cloud (data residency)" badge under the Server URL field in the launcher UI, so users get instant feedback on which GitHub variant their entered host resolves to.
- Expanded `TestInitializeGithubClient` to assert actual `BaseURL` values (not just non-nil) and added dedicated cases for the GHE.com data-residency host shape (with/without trailing slash).

## Test plan
- [x] `go build ./...` and `go build -tags launcher ./...`
- [x] `go test ./pkg/devops/getgithub/...` — all tests pass, including new GHE.com data-residency cases
- [x] Verified against a live GHES 3.18.10 on-prem instance: ran a real org scan (30 repos, 3.78M LOC) after the fix — connection, auth, and analysis all succeed, confirming classic GHES behavior is unchanged
- [ ] GHE.com data residency was **not** tested against a live tenant (none available) — covered by unit tests only
- [x] Vortex DEEP analysis clean on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)